### PR TITLE
Mitigate case 3 browser drag/drop inconsistencies

### DIFF
--- a/examples/case-3/case-3.js
+++ b/examples/case-3/case-3.js
@@ -85,6 +85,7 @@ const DragOrganismGlowView = ReactDnD.DragSource(
                           function(connect, monitor) {
                             return {
                               connectDragSource: connect.dragSource(),
+                              wrapper: connect.dragPreview(),
                               isDragging: monitor.isDragging()
                             };
                           }

--- a/src/code/components/glow-background.js
+++ b/src/code/components/glow-background.js
@@ -8,8 +8,8 @@ const GlowBackgroundView = ({id, color, size, containerStyle={}, glowStyle={}, C
 
   return (
     <div className="geniblocks glow-background" style={tContainerStyle}>
-      <CircularGlowView id={id+'-glow'} color={color} size={size} style={tGlowStyle}/>
-      <ChildComponent id={id+'-child'} style={tChildStyle} width={size} {...others} />
+      <CircularGlowView id={'glow-'+id} color={color} size={size} style={tGlowStyle}/>
+      <ChildComponent id={'child-'+id} style={tChildStyle} width={size} {...others} />
     </div>
   );
 };

--- a/src/code/components/organism.js
+++ b/src/code/components/organism.js
@@ -1,11 +1,28 @@
 import {PropTypes} from 'react';
 
-const OrganismView = ({org, id, width=200, style={}, onClick }) => {
+const OrganismView = ({org, id, width=200, style={}, handleClick, wrapper }) => {
   const baseUrl = "https://geniverse-resources.concord.org/resources/drakes/images/",
-        url     = baseUrl + org.getImageName();
+        url     = baseUrl + org.getImageName(),
+        // The goal here was to have the onMouseDown handler select the organism,
+        // so that mousedown-drag will both select the organism and begin the
+        // drag. This works on Chrome and Safari, but on Firefox it disables
+        // dragging. Disabling the onMouseDown handler means that Firefox users
+        // must click to select and then click to drag, but at least they can
+        // drag. The right solution is probably to allow organisms to be dragged
+        // whether or not they're selected and then hopefully the onMouseDown
+        // handler will work as expected. Otherwise, it may be necessary to
+        // select the organism (if it isn't already selected) in beginDrag.
+        isFirefox = (navigator.userAgent.toLowerCase().indexOf('firefox') >= 0),
+        handleMouseDown = isFirefox ? undefined : localhandleClick,
+        divWrapper = wrapper || function(elt) { return elt; };
 
-  return (
-    <div className="geniblocks organism" id={id} style={style} onMouseDown={onClick} onClick={onClick}>
+  function localhandleClick() {
+    if (handleClick) handleClick(id, org);
+  }
+
+  return divWrapper(
+    <div className="geniblocks organism" id={id} style={style} 
+          onMouseDown={handleMouseDown} onClick={localhandleClick}>
       <img src={url} width={width} />
     </div>
   );
@@ -14,10 +31,10 @@ const OrganismView = ({org, id, width=200, style={}, onClick }) => {
 OrganismView.propTypes = {
   org: PropTypes.object.isRequired,
   id: PropTypes.string,
-  index: PropTypes.number,
   width: PropTypes.number,
   style: PropTypes.object,
-  onClick: PropTypes.func
+  handleClick: PropTypes.func,
+  wrapper: PropTypes.func
 };
 
 export default OrganismView;

--- a/src/code/components/pen-stats.js
+++ b/src/code/components/pen-stats.js
@@ -21,7 +21,7 @@ class PenStatsView extends React.Component {
         <Tabs.Panel title="Breeding Pen" key="Breeding Pen">
           <PenView orgs={lastClutch} {...others}
                   selectedIndex={selectedIndex}
-                  onClick={(evt, iSelectedIndex) => {
+                  handleClick={(iSelectedIndex) => {
                     if (onSelectionChange)
                       onSelectionChange(iSelectedIndex);
                   }} />

--- a/src/code/components/pen.js
+++ b/src/code/components/pen.js
@@ -1,21 +1,23 @@
 import {PropTypes} from 'react';
 import OrganismView from './organism';
 
-const PenView = ({orgs, idPrefix='organism-', width=400, columns=5, SelectedOrganismView=OrganismView, selectedIndex, onClick}) => {
+const PenView = ({orgs, idPrefix='organism-', width=400, columns=5, SelectedOrganismView=OrganismView, selectedIndex, handleClick}) => {
 
-  function handleClick(evt) {
-    const index = Number(evt.currentTarget.id.substr(idPrefix.length));
-    if (onClick)
-      onClick(evt, index);
+  function localHandleClick(id, org) {
+    // That this conversion would be better done by the OrganismView
+    // and then propagated up to here.
+    const prefixIndex = id.indexOf(idPrefix),
+          index = Number(id.substr(prefixIndex + idPrefix.length));
+    if (handleClick) handleClick(index, id, org);
   }
 
   let orgWidth = width/columns,
       orgViews = orgs.map((org, index) => {
         return index === selectedIndex
                 ? <SelectedOrganismView org={org} id={idPrefix + index} index={index} key={index}
-                                    color="#FFFFAA" size={orgWidth} onClick={handleClick}/>
+                                    color="#FFFFAA" size={orgWidth} handleClick={localHandleClick}/>
                 : <OrganismView org={org} id={idPrefix + index} index={index} key={index}
-                                width={orgWidth} onClick={handleClick}/>;
+                                width={orgWidth} handleClick={localHandleClick}/>;
       });
 
   return (
@@ -32,7 +34,7 @@ PenView.propTypes = {
   columns: PropTypes.number,
   SelectedOrganismView: PropTypes.func,
   selectedIndex: PropTypes.number,
-  onClick: PropTypes.func
+  handleClick: PropTypes.func
 };
 
 export default PenView;

--- a/test/components/organism.js
+++ b/test/components/organism.js
@@ -1,17 +1,31 @@
 import OrganismView from '../../src/code/components/organism';
 
 describe("<OrganismView />", function(){
-  const drake = new BioLogica.Organism(BioLogica.Species.Drake, '');
+  const drake = new BioLogica.Organism(BioLogica.Species.Drake, ''),
+        orgID = 'organism-0';
 
   it("should create a <div> tag with appropriate classes", function() {
-    const wrapper = shallow(<OrganismView org={drake}/>);
+    const wrapper = shallow(<OrganismView org={drake} id={orgID} />);
     assert(wrapper.find('div').hasClass('geniblocks'), "Should create a <div> with 'geniblocks' class");
     assert(wrapper.find('div').hasClass('organism'), "Should create a <div> with 'organism' class");
   });
 
   it("should create an <img> tag", function() {
-    const wrapper = shallow(<OrganismView org={drake}/>);
+    const wrapper = shallow(<OrganismView org={drake} id={orgID} />);
     assert.equal(wrapper.find('img').length, 1, "Should create a single <img> tag");
+  });
+
+  it("clicking an <OrganismView> should trigger the handleClick handler", function() {
+    let clickedID, clickedOrg;
+    function testHandleClick(id, org) {
+      clickedID = id;
+      clickedOrg = org;
+    }
+    const wrapper = shallow(<OrganismView org={drake}  id={orgID}
+                                          handleClick={testHandleClick} />);
+    wrapper.simulate('click');
+    assert.equal(clickedID, orgID, "Clicking an <OrganismView> should trigger click handler");
+    assert.equal(clickedOrg, drake, "Clicking an <OrganismView> should trigger click handler");
   });
 
 });

--- a/test/components/pen.js
+++ b/test/components/pen.js
@@ -16,14 +16,23 @@ describe("<PenView />", function(){
     assert.lengthOf(wrapper.find('OrganismView'), 20, "Should create 20 <OrganismView> components");
   });
 
-  it("clicking an <OrganismView> should trigger the onClick handler", function() {
-    let clickedIndex;
-    function handleClick(evt, index) { clickedIndex = index; }
-    const wrapper = shallow(<PenView orgs={drakes} onClick={handleClick}/>),
-          firstOrg = wrapper.find('OrganismView').first(),
-          firstOrgID = firstOrg.prop('id');
-    wrapper.find('OrganismView').first().simulate('click', { currentTarget: { id: firstOrgID }});
+  it("clicking an <OrganismView> should trigger the handleClick handler", function() {
+    let clickedIndex, clickedID;
+    function testHandleClick(index, id) {
+      clickedIndex = index;
+      clickedID = id;
+    }
+    const wrapper = mount(<PenView orgs={drakes} handleClick={testHandleClick}/>),
+          firstOrgView = wrapper.find('OrganismView').first(),
+          firstOrgID = firstOrgView.prop('id'),
+          lastOrgView = wrapper.find('OrganismView').last(),
+          lastOrgID = lastOrgView.prop('id');
+    firstOrgView.simulate('click');
     assert.equal(clickedIndex, 0, "Clicking an <OrganismView> should select it");
+    assert.equal(clickedID, firstOrgID, "Clicking an <OrganismView> should select it");
+    lastOrgView.simulate('click');
+    assert.equal(clickedIndex, drakes.length-1, "Clicking an <OrganismView> should select it");
+    assert.equal(clickedID, lastOrgID, "Clicking an <OrganismView> should select it");
   });
 
   it("can specify another class for the selected item", function() {


### PR DESCRIPTION
- Dragging works on Firefox (but must select first)
- DragImage is the drake on all tested browsers
- Click selection/deselection works as expected
- Mitigates [#117663369]
- Fixes [#117663015]