### PR TITLE
Redux router

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-router-redux": "^4.0.5",
     "react-simpletabs": "^0.7.0",
     "redux": "^3.5.2",
+    "redux-thunk": "^2.1.0",
     "seamless-immutable": "^6.1.0",
     "socket.io-client": "^1.4.6",
     "uuid": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-overlays": "^0.6.3",
     "react-redux": "^4.4.5",
     "react-router": "^2.4.0",
+    "react-router-redux": "^4.0.5",
     "react-simpletabs": "^0.7.0",
     "redux": "^3.5.2",
     "seamless-immutable": "^6.1.0",

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -1,6 +1,7 @@
 export const actionTypes = {
   SESSION_STARTED: "Session started",
   LOADED_CHALLENGE_FROM_AUTHORING: "Loaded challenge from authoring",
+  NAVIGATED: "Navigated",
   BRED: "Bred",
   ALLELE_CHANGED: "Allele changed",
   SEX_CHANGED: "Sex changed",
@@ -27,6 +28,15 @@ export function loadAuthoredChallenge(challenge=0) {
     type: actionTypes.LOADED_CHALLENGE_FROM_AUTHORING,
     authoring,
     challenge
+  };
+}
+
+export function navigateToChallenge(_case, challenge) {
+  return {
+    type: actionTypes.NAVIGATED,
+    case: _case,
+    challenge,
+    route: `/${_case+1}/${challenge+1}`
   };
 }
 

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -38,6 +38,21 @@ export function navigateToNextChallenge() {
   };
 }
 
+/*
+ * Called when route params are different from current case and challenge,
+ * so user must have changed them in the address bar.
+ * Skips the route change, so just updates current case and challenge and
+ * triggers `loadStateFromAuthoring` in router
+ */
+export function navigateToCurrentRoute(_case, challenge) {
+  return {
+    type: actionTypes.NAVIGATED,
+    case: _case,
+    challenge,
+    skipRouteChange: true
+  };
+}
+
 export function breed(mother, father, offspringBin, quantity=1, incrementMoves=false) {
   return {
     type: actionTypes.BRED,

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -40,6 +40,13 @@ export function navigateToChallenge(_case, challenge) {
   };
 }
 
+export function navigateToNextChallenge() {
+  return (dispatch, getState) => {
+    const { case: currentCase, challenge: currentChallenge} = getState();
+    dispatch(navigateToChallenge(currentCase, currentChallenge+1));
+  };
+}
+
 export function breed(mother, father, offspringBin, quantity=1, incrementMoves=false) {
   return {
     type: actionTypes.BRED,

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -22,15 +22,6 @@ export function startSession(uuid) {
   };
 }
 
-export function loadAuthoredChallenge(challenge=0) {
-  let authoring = window.GV2Authoring;
-  return {
-    type: actionTypes.LOADED_CHALLENGE_FROM_AUTHORING,
-    authoring,
-    challenge
-  };
-}
-
 export function navigateToChallenge(_case, challenge) {
   return {
     type: actionTypes.NAVIGATED,

--- a/src/code/app.js
+++ b/src/code/app.js
@@ -16,6 +16,7 @@ import ModalMessageContainer from "./containers/modal-message-container";
 import loggerMiddleware from './middleware/gv-log';
 import itsMiddleware from './middleware/its-log';
 import routerMiddleware from './middleware/router-history';
+import thunk from 'redux-thunk';
 
 import uuid from 'uuid';
 
@@ -43,6 +44,7 @@ const hashHistory = useRouterHistory(createHashHistory)({ queryKey: false });
 
 const createStoreWithMiddleware =
   applyMiddleware(
+    thunk,
     loggerMiddleware(loggingMetadata),
     itsMiddleware(socket, loggingMetadata),
     routerMiddleware(hashHistory)

--- a/src/code/app.js
+++ b/src/code/app.js
@@ -5,16 +5,17 @@ import { createStore, applyMiddleware } from 'redux';
 
 import { Router, Route, useRouterHistory } from 'react-router';
 import { createHashHistory } from 'history';
-import { syncHistoryWithStore, routerMiddleware, push as pushHistory } from 'react-router-redux';
+import { syncHistoryWithStore } from 'react-router-redux';
 
 import reducer from './reducers/reducer';
-import { actionTypes, startSession, loadAuthoredChallenge } from './actions';
+import { actionTypes, startSession, loadAuthoredChallenge, navigateToChallenge } from './actions';
 
 import ChallengeContainer from "./containers/challenge-container";
 import ModalMessageContainer from "./containers/modal-message-container";
 
 import loggerMiddleware from './middleware/gv-log';
 import itsMiddleware from './middleware/its-log';
+import routerMiddleware from './middleware/router-history';
 
 import uuid from 'uuid';
 
@@ -58,7 +59,7 @@ const history = syncHistoryWithStore(hashHistory, store);
 store.dispatch(startSession(uuid.v4()));
 store.dispatch(loadAuthoredChallenge());
 
-store.dispatch(pushHistory("/1/1"));
+store.dispatch(navigateToChallenge(0, 0));
 
 render(
   <Provider store={store}>

--- a/src/code/app.js
+++ b/src/code/app.js
@@ -60,13 +60,11 @@ const history = syncHistoryWithStore(hashHistory, store);
 
 store.dispatch(startSession(uuid.v4()));
 
-store.dispatch(navigateToChallenge(0, 0));
-
 render(
   <Provider store={store}>
     <div>
       <Router history={history}>
-        <Route path="/:case/:challenge" component={ChallengeContainer} />
+        <Route path="/(:case/:challenge)" component={ChallengeContainer} />
       </Router>
       <ModalMessageContainer />
     </div>

--- a/src/code/app.js
+++ b/src/code/app.js
@@ -8,7 +8,7 @@ import { createHashHistory } from 'history';
 import { syncHistoryWithStore } from 'react-router-redux';
 
 import reducer from './reducers/reducer';
-import { actionTypes, startSession, loadAuthoredChallenge, navigateToChallenge } from './actions';
+import { actionTypes, startSession, navigateToChallenge } from './actions';
 
 import ChallengeContainer from "./containers/challenge-container";
 import ModalMessageContainer from "./containers/modal-message-container";
@@ -59,7 +59,6 @@ const store = configureStore();
 const history = syncHistoryWithStore(hashHistory, store);
 
 store.dispatch(startSession(uuid.v4()));
-store.dispatch(loadAuthoredChallenge());
 
 store.dispatch(navigateToChallenge(0, 0));
 

--- a/src/code/containers/challenge-container.js
+++ b/src/code/containers/challenge-container.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import templates from '../templates';
-import { changeAllele, changeSex, submitDrake, loadAuthoredChallenge, navigateToChallenge } from '../actions';
+import { changeAllele, changeSex, submitDrake, loadAuthoredChallenge, navigateToNextChallenge } from '../actions';
 
 class ChallengeContainer extends Component {
   componentWillMount() {
@@ -48,7 +48,7 @@ function mapDispatchToProps(dispatch) {
     onChromosomeAlleleChange: (index, chrom, side, prevAllele, newAllele) => dispatch(changeAllele(index, chrom, side, prevAllele, newAllele, true)),
     onSexChange: (index, newSex) => dispatch(changeSex(index, newSex, true)),
     onDrakeSubmission: (targetPhenotype, userPhenotype, correct) => dispatch(submitDrake(targetPhenotype, userPhenotype, correct)),
-    onNavigateNextChallenge: () => dispatch(navigateToChallenge(0,1)), // still hard-coded
+    onNavigateNextChallenge: () => dispatch(navigateToNextChallenge()),
     loadAuthoredChallenge: (nextChallenge) => dispatch(loadAuthoredChallenge(nextChallenge)) // hard-coded for the moment
   };
 }

--- a/src/code/containers/challenge-container.js
+++ b/src/code/containers/challenge-container.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import templates from '../templates';
-import { changeAllele, changeSex, submitDrake, loadAuthoredChallenge } from '../actions';
+import { changeAllele, changeSex, submitDrake, loadAuthoredChallenge, navigateToChallenge } from '../actions';
 
 class ChallengeContainer extends Component {
   componentWillMount() {
@@ -48,7 +48,7 @@ function mapDispatchToProps(dispatch) {
     onChromosomeAlleleChange: (index, chrom, side, prevAllele, newAllele) => dispatch(changeAllele(index, chrom, side, prevAllele, newAllele, true)),
     onSexChange: (index, newSex) => dispatch(changeSex(index, newSex, true)),
     onDrakeSubmission: (targetPhenotype, userPhenotype, correct) => dispatch(submitDrake(targetPhenotype, userPhenotype, correct)),
-    onNavigateNextChallenge: () => {},
+    onNavigateNextChallenge: () => dispatch(navigateToChallenge(0,1)), // still hard-coded
     loadAuthoredChallenge: (nextChallenge) => dispatch(loadAuthoredChallenge(nextChallenge)) // hard-coded for the moment
   };
 }

--- a/src/code/containers/challenge-container.js
+++ b/src/code/containers/challenge-container.js
@@ -1,24 +1,26 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import templates from '../templates';
-import { changeAllele, changeSex, submitDrake, navigateToCurrentRoute, navigateToNextChallenge } from '../actions';
+import { changeAllele, changeSex, submitDrake, navigateToCurrentRoute, navigateToChallenge, navigateToNextChallenge } from '../actions';
 
 class ChallengeContainer extends Component {
   componentWillMount() {
-    if (this.props.case !== this.props.routeParams.case-1 ||
-      this.props.challenge !== this.props.routeParams.challenge-1) {
+    if (this.props.routeParams.case && this.props.routeParams.challenge) {
       this.props.navigateToCurrentRoute(this.props.routeParams.case-1, this.props.routeParams.challenge-1);
+    } else {
+      this.props.navigateToChallenge(0, 0);
     }
   }
   componentWillReceiveProps(newProps) {
     if (newProps.case !== newProps.routeParams.case-1 ||
       newProps.challenge !== newProps.routeParams.challenge-1) {
-      console.log("Will do!!! Going to ", (newProps.routeParams.challenge-1));
       this.props.navigateToCurrentRoute(newProps.routeParams.case-1, newProps.routeParams.challenge-1);
     }
   }
 
   render() {
+    if (!this.props.template) return null;
+
     const Template = templates[this.props.template];
     return (
       <div id="challenges" className="case-backdrop">
@@ -55,6 +57,7 @@ function mapDispatchToProps(dispatch) {
     onSexChange: (index, newSex) => dispatch(changeSex(index, newSex, true)),
     onDrakeSubmission: (targetPhenotype, userPhenotype, correct) => dispatch(submitDrake(targetPhenotype, userPhenotype, correct)),
     onNavigateNextChallenge: () => dispatch(navigateToNextChallenge()),
+    navigateToChallenge: (_case, challenge) => dispatch(navigateToChallenge(_case, challenge)),
     navigateToCurrentRoute: (_case, challenge) => dispatch(navigateToCurrentRoute(_case, challenge))
   };
 }

--- a/src/code/containers/challenge-container.js
+++ b/src/code/containers/challenge-container.js
@@ -4,6 +4,15 @@ import templates from '../templates';
 import { changeAllele, changeSex, submitDrake, loadAuthoredChallenge } from '../actions';
 
 class ChallengeContainer extends Component {
+  componentWillMount() {
+    this.props.loadAuthoredChallenge(this.props.routeParams.challenge-1);
+  }
+  componentWillReceiveProps(newProps) {
+    if (this.props.routeParams.challenge !== newProps.routeParams.challenge) {
+      this.props.loadAuthoredChallenge(newProps.routeParams.challenge-1);
+    }
+  }
+
   render() {
     const Template = templates[this.props.template];
     return (
@@ -39,7 +48,8 @@ function mapDispatchToProps(dispatch) {
     onChromosomeAlleleChange: (index, chrom, side, prevAllele, newAllele) => dispatch(changeAllele(index, chrom, side, prevAllele, newAllele, true)),
     onSexChange: (index, newSex) => dispatch(changeSex(index, newSex, true)),
     onDrakeSubmission: (targetPhenotype, userPhenotype, correct) => dispatch(submitDrake(targetPhenotype, userPhenotype, correct)),
-    onNavigateNextChallenge: (nextChallenge) => dispatch(loadAuthoredChallenge(nextChallenge)) // hard-coded for the moment
+    onNavigateNextChallenge: () => {},
+    loadAuthoredChallenge: (nextChallenge) => dispatch(loadAuthoredChallenge(nextChallenge)) // hard-coded for the moment
   };
 }
 

--- a/src/code/containers/challenge-container.js
+++ b/src/code/containers/challenge-container.js
@@ -1,9 +1,23 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import templates from '../templates';
-import { changeAllele, changeSex, submitDrake, navigateToNextChallenge } from '../actions';
+import { changeAllele, changeSex, submitDrake, navigateToCurrentRoute, navigateToNextChallenge } from '../actions';
 
 class ChallengeContainer extends Component {
+  componentWillMount() {
+    if (this.props.case !== this.props.routeParams.case-1 ||
+      this.props.challenge !== this.props.routeParams.challenge-1) {
+      this.props.navigateToCurrentRoute(this.props.routeParams.case-1, this.props.routeParams.challenge-1);
+    }
+  }
+  componentWillReceiveProps(newProps) {
+    if (newProps.case !== newProps.routeParams.case-1 ||
+      newProps.challenge !== newProps.routeParams.challenge-1) {
+      console.log("Will do!!! Going to ", (newProps.routeParams.challenge-1));
+      this.props.navigateToCurrentRoute(newProps.routeParams.case-1, newProps.routeParams.challenge-1);
+    }
+  }
+
   render() {
     const Template = templates[this.props.template];
     return (
@@ -27,6 +41,7 @@ function mapStateToProps (state) {
       hiddenAlleles: state.hiddenAlleles.asMutable(),
       trial: state.trial,
       trials: state.trials,
+      case: state.case,
       challenge: state.challenge,
       moves: state.moves,
       goalMoves: state.goalMoves,
@@ -39,7 +54,8 @@ function mapDispatchToProps(dispatch) {
     onChromosomeAlleleChange: (index, chrom, side, prevAllele, newAllele) => dispatch(changeAllele(index, chrom, side, prevAllele, newAllele, true)),
     onSexChange: (index, newSex) => dispatch(changeSex(index, newSex, true)),
     onDrakeSubmission: (targetPhenotype, userPhenotype, correct) => dispatch(submitDrake(targetPhenotype, userPhenotype, correct)),
-    onNavigateNextChallenge: () => dispatch(navigateToNextChallenge())
+    onNavigateNextChallenge: () => dispatch(navigateToNextChallenge()),
+    navigateToCurrentRoute: (_case, challenge) => dispatch(navigateToCurrentRoute(_case, challenge))
   };
 }
 

--- a/src/code/containers/challenge-container.js
+++ b/src/code/containers/challenge-container.js
@@ -1,18 +1,9 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import templates from '../templates';
-import { changeAllele, changeSex, submitDrake, loadAuthoredChallenge, navigateToNextChallenge } from '../actions';
+import { changeAllele, changeSex, submitDrake, navigateToNextChallenge } from '../actions';
 
 class ChallengeContainer extends Component {
-  componentWillMount() {
-    this.props.loadAuthoredChallenge(this.props.routeParams.challenge-1);
-  }
-  componentWillReceiveProps(newProps) {
-    if (this.props.routeParams.challenge !== newProps.routeParams.challenge) {
-      this.props.loadAuthoredChallenge(newProps.routeParams.challenge-1);
-    }
-  }
-
   render() {
     const Template = templates[this.props.template];
     return (
@@ -48,8 +39,7 @@ function mapDispatchToProps(dispatch) {
     onChromosomeAlleleChange: (index, chrom, side, prevAllele, newAllele) => dispatch(changeAllele(index, chrom, side, prevAllele, newAllele, true)),
     onSexChange: (index, newSex) => dispatch(changeSex(index, newSex, true)),
     onDrakeSubmission: (targetPhenotype, userPhenotype, correct) => dispatch(submitDrake(targetPhenotype, userPhenotype, correct)),
-    onNavigateNextChallenge: () => dispatch(navigateToNextChallenge()),
-    loadAuthoredChallenge: (nextChallenge) => dispatch(loadAuthoredChallenge(nextChallenge)) // hard-coded for the moment
+    onNavigateNextChallenge: () => dispatch(navigateToNextChallenge())
   };
 }
 

--- a/src/code/containers/modal-message-container.js
+++ b/src/code/containers/modal-message-container.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import ModalAlert from '../components/modal-alert';
-import { dismissModalDialog, advanceTrial, advanceChallenge } from '../actions';
+import { dismissModalDialog, advanceTrial, navigateToNextChallenge } from '../actions';
 
 const messageProps = {
   MatchDrakeFailure: {
@@ -24,7 +24,7 @@ const messageProps = {
     explanation: "You have completed all trials in this challenge.",
     rightButton: {
       label: "Next challenge",
-      clickFunc: "onAdvanceChallenge"
+      clickFunc: "onNavigateToNextChallenge"
     },
     challengeAwards: {id: 0, progress: -1}
   }
@@ -64,7 +64,7 @@ function mapDispatchToProps (dispatch) {
   return {
     onDismiss: () => dispatch(dismissModalDialog()),
     onAdvanceTrial: () => dispatch(advanceTrial()),
-    onAdvanceChallenge: () => dispatch(advanceChallenge())
+    onNavigateToNextChallenge: () => dispatch(navigateToNextChallenge())
   };
 }
 

--- a/src/code/middleware/router-history.js
+++ b/src/code/middleware/router-history.js
@@ -10,7 +10,7 @@ import { actionTypes } from '../actions';
 
 export default function routerMiddleware(history) {
   return () => next => action => {
-    if (action.type === actionTypes.NAVIGATED) {
+    if (action.type === actionTypes.NAVIGATED && action.route) {
       history.push(action.route);
     }
 

--- a/src/code/middleware/router-history.js
+++ b/src/code/middleware/router-history.js
@@ -1,0 +1,19 @@
+/**
+ * This is based off the middleware provided by react-router-redux.
+ *
+ * This is extracted to our own middleware to allow us to use our own
+ * semantically-meaningful actions, and to pass the actions forward so
+ * that they may be logged.
+ */
+
+import { actionTypes } from '../actions';
+
+export default function routerMiddleware(history) {
+  return () => next => action => {
+    if (action.type === actionTypes.NAVIGATED) {
+      history.push(action.route);
+    }
+
+    return next(action);
+  };
+}

--- a/src/code/reducers/loadStateFromAuthoring.js
+++ b/src/code/reducers/loadStateFromAuthoring.js
@@ -1,10 +1,10 @@
 import templates from '../templates';
 
-export function loadStateFromAuthoring(state, authoring, challenge, progress={}) {
+export function loadStateFromAuthoring(state, authoring, progress={}) {
   let trial = state.trial ? state.trial : 0;
 
   let challenges = authoring[state.case].length;
-  let authoredChallenge = authoring[state.case][challenge],
+  let authoredChallenge = authoring[state.case][state.challenge],
       templateName = authoredChallenge.template,
       template = templates[templateName],
       trials = authoredChallenge.targetDrakes,
@@ -30,7 +30,6 @@ export function loadStateFromAuthoring(state, authoring, challenge, progress={})
     drakes: drakes,
     trial,
     trials,
-    challenge,
     challenges,
     moves: 0,
     goalMoves: goalMoves,

--- a/src/code/reducers/reducer.js
+++ b/src/code/reducers/reducer.js
@@ -3,6 +3,8 @@ import { actionTypes } from '../actions';
 import { loadStateFromAuthoring, loadNextTrial } from './loadStateFromAuthoring';
 import { updateProgress, getChallengeScore } from './challengeProgress';
 
+import { LOCATION_CHANGE } from 'react-router-redux';
+
 const initialState = Immutable({
   template: "GenomePlayground",
   drakes: [],
@@ -16,7 +18,8 @@ const initialState = Immutable({
   currentScore: -1,
   showingInfoMessage: false,
   shouldShowITSMessages: true,
-  userDrakeHidden: true
+  userDrakeHidden: true,
+  routing: {}
 });
 
 export default function reducer(state, action) {
@@ -27,6 +30,9 @@ export default function reducer(state, action) {
   }
 
   switch(action.type) {
+    case LOCATION_CHANGE: {
+      return state.set("routing", {locationBeforeTransitions: action.payload});
+    }
     case actionTypes.LOADED_CHALLENGE_FROM_AUTHORING: {
       state.merge({
         userDrakeHidden: true,

--- a/src/code/reducers/reducer.js
+++ b/src/code/reducers/reducer.js
@@ -19,7 +19,8 @@ const initialState = Immutable({
   showingInfoMessage: false,
   shouldShowITSMessages: true,
   userDrakeHidden: true,
-  routing: {}
+  routing: {},
+  authoring: window.GV2Authoring
 });
 
 export default function reducer(state, action) {
@@ -32,15 +33,6 @@ export default function reducer(state, action) {
   switch(action.type) {
     case LOCATION_CHANGE: {
       return state.set("routing", {locationBeforeTransitions: action.payload});
-    }
-    case actionTypes.LOADED_CHALLENGE_FROM_AUTHORING: {
-      state.merge({
-        userDrakeHidden: true,
-        showingInfoMessage: false,
-        trialSuccess: false
-      });
-
-      return loadStateFromAuthoring(state, action.authoring, action.challenge);
     }
     case actionTypes.BRED: {
       let mother = new BioLogica.Organism(BioLogica.Species.Drake, action.mother, 1),
@@ -103,10 +95,13 @@ export default function reducer(state, action) {
       } else return state;
     }
 
-    case actionTypes.ADVANCED_CHALLENGE: {
-      let nextChallenge = state.challenge + 1;
+    case actionTypes.NAVIGATED: {
       let progress = updateProgress(state);
-      return loadStateFromAuthoring(state, action.authoring, nextChallenge, progress);
+      state = state.merge({
+        case: action.case,
+        challenge: action.challenge
+      });
+      return loadStateFromAuthoring(state, state.authoring, progress);
     }
 
     case actionTypes.SOCKET_RECEIVED: {

--- a/src/code/reducers/reducer.js
+++ b/src/code/reducers/reducer.js
@@ -6,7 +6,7 @@ import { updateProgress, getChallengeScore } from './challengeProgress';
 import { LOCATION_CHANGE } from 'react-router-redux';
 
 const initialState = Immutable({
-  template: "GenomePlayground",
+  template: null,
   drakes: [],
   hiddenAlleles: ['t','tk','h','c','a','b','d','bog','rh'],
   trial: 0,

--- a/test/actions/navigate-to-challenge.js
+++ b/test/actions/navigate-to-challenge.js
@@ -1,0 +1,56 @@
+import expect from 'expect';
+import reducer from '../../src/code/reducers/reducer';
+import { navigateToChallenge, actionTypes as types } from '../../src/code/actions';
+
+describe('navigateToChallenge action', () => {
+  it('should create the correct action when we navigate to a challenge', () => {
+    const _case = 2,
+          challenge = 3;
+
+    let actionObject = navigateToChallenge(_case, challenge);
+
+    expect(actionObject).toEqual({
+      type: types.NAVIGATED,
+      case: _case,
+      challenge,
+      route: "/3/4"
+    });
+  });
+
+  describe('the reducer', () => {
+    it('should update the state to match the authored state when we navigate', () => {
+      let defaultState = reducer(undefined, {});
+      let initialState = defaultState.merge({
+        case: 0,
+        challenge: 0,
+        authoring: [
+          [],
+          [{}, {}, {
+            template: "GenomePlayground",
+            "initialDrake": {
+              "alleles": "a:T,b:T",
+              "sex": 1
+            }
+          }]
+        ]
+      });
+
+      let nextState = reducer(initialState, navigateToChallenge(1, 2));
+
+      expect(nextState).toEqual(initialState.merge({
+        case: 1,
+        challenge: 2,
+        template: "GenomePlayground",
+        challengeComplete: false,
+        challenges: 3,
+        trialSuccess: false,
+
+        // punt on these, as they're not part of the test
+        challengeProgress: nextState.challengeProgress,
+        drakes: nextState.drakes,
+        trials: nextState.trials,
+        goalMoves: nextState.goalMoves
+      }));
+    });
+  });
+});


### PR DESCRIPTION
This adds hash-based url routing for challenges.

* Case and challenge are visible in the url, starting at 1 to match expectations, as {geniblocks-url}/#/1/2 for case 1 challenge 2
* When the game is loaded, if no route is in the url, it will go to case 1 challenge 1 automatically
* If a url such as http://localhost:8080/#/1/3 is loaded directly, it will go directly to that challenge
* While in game, navigation button actions update the url
* While in game, you can change url route and it will be as if a navigation event happened in-game (i.e. an action is sent, and state changes as expected)

The loading of authored state was also simplified a tiny bit, it's now only called within a navigation action, so buttons or templates shouldn't need to call `loadAuthoredChallenge` anymore. A bit more work is needed on this, but it doesn't need to be part of this PR, I think.

One test is added (action-reducer), but we should work out middleware tests soon.

@dstrawberrygirl Can you test this out? There's a number of possible point of failure between navigating around and using urls, so I may be introducing bugs without realizing. (Note, trying to go to a non-existent challenge, either by url or by hitting "Next challenge" after challenge 3, is still not handled.)