### PR TITLE
Link to gv2 from examples

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -3,10 +3,18 @@
   </head>
   <body>
     <h1>GeniBlocks Examples</h1>
+    <h3>Geniverse 2.0 Interactives</h3>
+    <div>
+      <ul>
+        <!-- "gv2" is a sibling of "examples" -->
+        <li><a href="../gv2/#/1/1"/">Case 1: Match Drake</a></li>
+        <li><a href="../gv2/#/2/1"/">Case 2: Egg Game</a></li>
+      </ul>
+    </div>
     <h3>Geniverse 2.0 Prototype</h3>
     <div>
       <ul>
-        <li><a href="gv2-prototype/">Case Log</a></li>
+        <li><a href="gv2-prototype/">Case Log Prototype</a></li>
       </ul>
     </div>
     <h3>Basic Examples</h3>

--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
     "deploy": "gulp deploy",
     "env": "env",
     "lint": "eslint examples gv2 src test",
-    "examples": "live-server public/examples",
-    "gv2": "live-server public/gv2",
+    "examples": "live-server public --open=examples",
+    "gv2": "live-server public --open=gv2",
     "pretest": "npm run lint",
     "test": "mocha --compilers js:babel-core/register --recursive --require ./test/setup.js",
     "test:watch": "npm run test -- --watch"

--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ Now you can see a list of actions and state changes, a history slider, have the 
 
 ## Resources
 
-* [GeniBlocks Examples](http://concord-consortium.github.io/geniblocks/)
+* [GeniBlocks Examples](http://concord-consortium.github.io/geniblocks/examples)
 * [GV2 Prototype](http://concord-consortium.github.io/geniblocks/gv2/)
 * [Geniverse Demo](http://demo.geniverse.concord.org)
 * [Geniverse Lab](https://geniverse-lab.concord.org)


### PR DESCRIPTION
Request from Frieda [9:31 AM]  
It would be great to have the new challenges that are available by URL (e.g., http://concord-consortium.github.io/geniblocks/gv2/#/2/1) added to the geniblocks examples page (http://concord-consortium.github.io/geniblocks/examples/) under a new category; how about "GV 2.0 Interactives"? 