### PR TITLE
Egg Game II

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -8,7 +8,8 @@
       <ul>
         <!-- "gv2" is a sibling of "examples" -->
         <li><a href="../gv2/#/1/1"/">Case 1: Match Drake</a></li>
-        <li><a href="../gv2/#/2/1"/">Case 2: Egg Game</a></li>
+        <li><a href="../gv2/#/2/1"/">Case 2: Egg Game I</a></li>
+        <li><a href="../gv2/#/2/2"/">Case 2: Egg Game II</a></li>
       </ul>
     </div>
     <h3>Geniverse 2.0 Prototype</h3>

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -76,13 +76,26 @@ export function navigateToChallenge(_case, challenge) {
   };
 }
 
+export function retryCurrentChallenge() {
+  return (dispatch, getState) => {
+    const { case: currentCase, challenge: currentChallenge } = getState();
+    dispatch(navigateToChallenge(currentCase, currentChallenge));
+  };
+}
+
 export function navigateToNextChallenge() {
   return (dispatch, getState) => {
     const { case: currentCase, challenge: currentChallenge, authoring} = getState();
     let nextCase = currentCase,
-        nextChallenge = currentChallenge+1;
-    if (authoring[currentCase].length <= nextChallenge) {
-      if (authoring[currentCase+1]) nextCase++;
+        nextChallenge = currentChallenge+1,
+        challengeCountInCase = authoring[currentCase].length;
+    if (challengeCountInCase <= nextChallenge) {
+      // if the next case exists, navigate to it
+      if (authoring[currentCase+1])
+        nextCase++;
+      // otherwise, circle back to the beginning
+      else
+        nextCase = 0;
       nextChallenge = 0;
     }
     dispatch(navigateToChallenge(nextCase, nextChallenge));
@@ -202,6 +215,10 @@ export function submitDrake(correctPhenotype, submittedPhenotype, correct, incor
         dialog = {
           message: "~ALERT.TITLE.GOOD_WORK",
           explanation: "~ALERT.COMPLETE_COIN",
+          leftButton: {
+            label: "~BUTTON.TRY_AGAIN",
+            action: "retryCurrentChallenge"
+          },
           rightButton: {
             label: "~BUTTON.NEXT_CASE",
             action: "navigateToNextChallenge"
@@ -212,6 +229,10 @@ export function submitDrake(correctPhenotype, submittedPhenotype, correct, incor
         dialog = {
           message: "~ALERT.TITLE.GOOD_WORK",
           explanation: "~ALERT.NEW_PIECE_OF_COIN",
+          leftButton: {
+            label: "~BUTTON.TRY_AGAIN",
+            action: "retryCurrentChallenge"
+          },
           rightButton: {
             label: "~BUTTON.NEXT_CHALLENGE",
             action: "navigateToNextChallenge"
@@ -306,6 +327,10 @@ export function completeChallenge() {
     dispatch(showModalDialog({
       message: "~ALERT.TITLE.GOOD_WORK",
       explanation: "~ALERT.NEW_PIECE_OF_COIN",
+      leftButton:{
+        label: "~BUTTON.TRY_AGAIN",
+        action: "retryCurrentChallenge"
+      },
       rightButton:{
         label: "~BUTTON.NEXT_CHALLENGE",
         action: "navigateToNextChallenge"

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -180,7 +180,7 @@ function _submitDrake(correctPhenotype, submittedPhenotype, correct) {
   };
 }
 
-export function submitDrake(correctPhenotype, submittedPhenotype, correct) {
+export function submitDrake(correctPhenotype, submittedPhenotype, correct, incorrectAction) {
   return (dispatch, getState) => {
     dispatch(_submitDrake(correctPhenotype, submittedPhenotype, correct));
 
@@ -235,7 +235,7 @@ export function submitDrake(correctPhenotype, submittedPhenotype, correct) {
         explanation: "~ALERT.INCORRECT_DRAKE",
         rightButton: {
           label: "~BUTTON.TRY_AGAIN",
-          action: "dismissModalDialog"
+          action: incorrectAction || "dismissModalDialog"
         },
         top: "475px"
       };

--- a/src/code/components/challenge-award.js
+++ b/src/code/components/challenge-award.js
@@ -57,13 +57,11 @@ class ChallengeAwardView extends React.Component {
     for (let i = 0; i < challengeCount; i++){
       for (var key in progress){
         if (key.startsWith(pieceKey + i)){
-          let score = progress[key];
-          let currentScore = challengeScore[i];
-          if (!currentScore) {
+          const score = progress[key];
+          if (challengeScore[i] == null) {
              challengeScore[i] = score;
           } else {
-            currentScore = currentScore + score;
-            challengeScore[i] = score;
+            challengeScore[i] += score;
           }
         }
       }

--- a/src/code/components/genome.js
+++ b/src/code/components/genome.js
@@ -7,7 +7,7 @@ import ChromosomeView from './chromosome';
  * Usually defined by passing in a Biologica Organism, but may also be defined by
  * passing in a map of Biologica Chromosomes and a Biologica Species.
  */
-const GenomeView = ({org, chromosomes, species, hiddenAlleles = [], editable=true, showLabels=true, showAlleles=false, selectedChromosomes={}, small=false, orgName, displayStyle, onAlleleChange, onChromosomeSelected}) => {
+const GenomeView = ({org, className="", chromosomes, species, hiddenAlleles = [], editable=true, showLabels=true, showAlleles=false, selectedChromosomes={}, small=false, orgName, displayStyle, onAlleleChange, onChromosomeSelected}) => {
   let pairWrappers = [];
   if (org) {
     chromosomes = org.genetics.genotype.chromosomes;
@@ -46,8 +46,9 @@ const GenomeView = ({org, chromosomes, species, hiddenAlleles = [], editable=tru
       </div>
     );
   }
+  const classes = "geniblocks genome" + (className ? " " + className : "");
   return (
-    <div className="geniblocks genome">
+    <div className={classes}>
       { pairWrappers }
     </div>
   );
@@ -55,6 +56,7 @@ const GenomeView = ({org, chromosomes, species, hiddenAlleles = [], editable=tru
 
 GenomeView.propTypes = {
   org: PropTypes.object,
+  className: PropTypes.string,
   chromosomes: PropTypes.object,
   species: PropTypes.object,
   hiddenAlleles: PropTypes.array,

--- a/src/code/components/modal-alert.js
+++ b/src/code/components/modal-alert.js
@@ -21,7 +21,7 @@ const backdropStyle = {
 };
 
 const dialogStyle = function(top="50%") {
-  // we use some psuedo random coords so nested modals
+  // we use some pseudo random coords so nested modals
   // don't sit right on top of each other.
   let left = 50;
   return {

--- a/src/code/components/ordinal-organism.js
+++ b/src/code/components/ordinal-organism.js
@@ -1,0 +1,38 @@
+import React, {PropTypes} from 'react';
+import OrganismView from './organism';
+
+/**
+ * Presents either a BioLogica organism or a simple number within a square border.
+ * Designed to be used as trial feedback indicating the number of trials successfully
+ * completed, for instance.
+ *
+ * @param {string} id - a unique id for CSS purposes
+ * @param {string} className - CSS class to be applied
+ * @param {number} ordinal - the numeric value to be represented if no organism specified
+ * @param {BioLogica.Organism} organism - the organism to be represented
+ * @param {number} size - the width and height of the view
+ */
+const OrdinalOrganismView = ({id, className, ordinal, organism, size=32, ...other}) => {
+  const containerStyle = { width: size, height: size },
+        orgView = organism != null
+                    ? <OrganismView id={`${id}-organism`} org={organism} width={size} {...other} />
+                    : <div className='ordinal'>
+                        {ordinal}
+                      </div>;
+
+  return (
+    <div id={id} className={`geniblocks ordinal-organism ${className}`} style={containerStyle}>
+      { orgView }
+    </div>
+  );
+};
+
+OrdinalOrganismView.propTypes = {
+  id: PropTypes.string,
+  className: PropTypes.string,
+  ordinal: PropTypes.number,
+  organism: PropTypes.object,
+  size: PropTypes.number
+};
+
+export default OrdinalOrganismView;

--- a/src/code/components/organism.js
+++ b/src/code/components/organism.js
@@ -1,6 +1,6 @@
 import React, {PropTypes} from 'react';
 
-const OrganismView = ({org, id, width=200, flipped=false, style={}, onClick, wrapper }) => {
+const OrganismView = ({org, id, className="", width=200, flipped=false, style={}, onClick, wrapper }) => {
   const baseUrl = "https://geniverse-resources.concord.org/resources/drakes/images/",
         url     = baseUrl + org.getImageName(),
         // The goal here was to have the onMouseDown handler select the organism,
@@ -16,9 +16,9 @@ const OrganismView = ({org, id, width=200, flipped=false, style={}, onClick, wra
         handleMouseDown = isFirefox ? undefined : handleClick,
         divWrapper = wrapper || function(elt) { return elt; };
 
-  let className = "geniblocks organism";
+  let classes = "geniblocks organism" + (className ? " " + className : "");
   if (flipped) {
-    className += " flipped";
+    classes += " flipped";
   }
 
   function handleClick() {
@@ -26,7 +26,7 @@ const OrganismView = ({org, id, width=200, flipped=false, style={}, onClick, wra
   }
 
   return divWrapper(
-    <div className={className} id={id} style={style}
+    <div className={classes} id={id} style={style}
           onMouseDown={handleMouseDown} onClick={handleClick}>
       <img src={url} width={width} />
     </div>
@@ -36,6 +36,7 @@ const OrganismView = ({org, id, width=200, flipped=false, style={}, onClick, wra
 OrganismView.propTypes = {
   org: PropTypes.object.isRequired,
   id: PropTypes.string,
+  className: PropTypes.string,
   width: PropTypes.number,
   style: PropTypes.object,
   onClick: PropTypes.func,

--- a/src/code/containers/challenge-container.js
+++ b/src/code/containers/challenge-container.js
@@ -1,7 +1,10 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import templates from '../templates';
-import { changeAllele, changeSex, submitDrake, resetGametes, navigateToCurrentRoute, navigateToChallenge, navigateToNextChallenge, addGameteChromosome, keepOffspring, fertilize, hatch, completeChallenge } from '../actions';
+import { changeAllele, changeSex, submitDrake, resetGametes,
+        navigateToCurrentRoute, navigateToChallenge, navigateToNextChallenge,
+        addGameteChromosome, keepOffspring, fertilize, hatch,
+        completeChallenge } from '../actions';
 
 class ChallengeContainer extends Component {
   componentWillMount() {
@@ -47,6 +50,8 @@ class ChallengeContainer extends Component {
 function mapStateToProps (state) {
     return {
       template: state.template,
+      challengeType: state.challengeType,
+      showUserDrake: state.showUserDrake,
       drakes: state.drakes,
       gametes: state.gametes,
       hiddenAlleles: state.hiddenAlleles.asMutable(),
@@ -64,7 +69,8 @@ function mapDispatchToProps(dispatch) {
   return {
     onChromosomeAlleleChange: (index, chrom, side, prevAllele, newAllele) => dispatch(changeAllele(index, chrom, side, prevAllele, newAllele, true)),
     onSexChange: (index, newSex) => dispatch(changeSex(index, newSex, true)),
-    onDrakeSubmission: (targetPhenotype, userPhenotype, correct) => dispatch(submitDrake(targetPhenotype, userPhenotype, correct)),
+    onDrakeSubmission: (targetPhenotype, userPhenotype, correct, incorrectAction) => 
+      dispatch(submitDrake(targetPhenotype, userPhenotype, correct, incorrectAction)),
     onNavigateNextChallenge: () => dispatch(navigateToNextChallenge()),
     onCompleteChallenge: () => dispatch(completeChallenge()),
     navigateToChallenge: (_case, challenge) => dispatch(navigateToChallenge(_case, challenge)),

--- a/src/code/geniblocks.js
+++ b/src/code/geniblocks.js
@@ -23,6 +23,7 @@ export { default as GenomeTestView } from './components/genome-test';
 export { default as GenomeView } from './components/genome';
 export { default as GlowBackgroundView } from './components/glow-background';
 export { default as ModalAlert } from './components/modal-alert';
+export { default as OrdinalOrganismView } from './components/ordinal-organism';
 export { default as OrganismView } from './components/organism';
 export { default as OrganismGlowView } from './components/organism-glow';
 export { default as PenView } from './components/pen';

--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -7,12 +7,15 @@ export function loadStateFromAuthoring(state, authoring, progress={}) {
   let authoredChallenge = authoring[state.case][state.challenge],
       templateName = authoredChallenge.template,
       template = templates[templateName],
+      challengeType = authoredChallenge.challengeType,
+      showUserDrake = authoredChallenge.showUserDrake != null ? authoredChallenge.showUserDrake : false,
       trials = authoredChallenge.targetDrakes,
       authoredDrakesArray = template.authoredDrakesToDrakeArray(authoredChallenge, trial),
 
       // turn authored alleles into completely-specified alleleStrings
       // (once we have nested arrays this will need to be tweaked)
       drakes = authoredDrakesArray.map(function(drakeDef) {
+        if (!drakeDef) return null;
         let drake = new BioLogica.Organism(BioLogica.Species.Drake, drakeDef.alleles, drakeDef.sex);
         return {
           alleleString: drake.getAlleleString(),
@@ -32,6 +35,8 @@ export function loadStateFromAuthoring(state, authoring, progress={}) {
 
   return state.merge({
     template: templateName,
+    challengeType,
+    showUserDrake,
     drakes,
     gametes,
     trial,
@@ -55,12 +60,12 @@ export function loadNextTrial(state, authoring, progress) {
   let authoredChallenge = authoring[state.case][state.challenge],
       templateName = state.template,
       template = templates[templateName],
-      //trials = authoredChallenge.targetDrakes,
       authoredDrakesArray = template.authoredDrakesToDrakeArray(authoredChallenge, trial),
 
       // turn authored alleles into completely-specified alleleStrings
       // (once we have nested arrays this will need to be tweaked)
       drakes = authoredDrakesArray.map(function(drakeDef) {
+        if (!drakeDef) return null;
         let drake = new BioLogica.Organism(BioLogica.Species.Drake, drakeDef.alleles, drakeDef.sex);
         return {
           alleleString: drake.getAlleleString(),
@@ -69,7 +74,6 @@ export function loadNextTrial(state, authoring, progress) {
       });
 
   let goalMoves = null;
-  // let template = templates[state.template];
   if (template.calculateGoalMoves) {
     goalMoves = template.calculateGoalMoves(drakes);
   }

--- a/src/code/reducers/index.js
+++ b/src/code/reducers/index.js
@@ -87,7 +87,8 @@ export default function reducer(state, action) {
     case actionTypes.NAVIGATED: {
       state = state.merge({
         case: action.case,
-        challenge: action.challenge
+        challenge: action.challenge,
+        trial: 0
       });
       return loadStateFromAuthoring(state, state.authoring, state.challengeProgress);
     }

--- a/src/code/reducers/routing.js
+++ b/src/code/reducers/routing.js
@@ -3,7 +3,7 @@ import { LOCATION_CHANGE } from 'react-router-redux';
 
 const initialState = Immutable({});
 
-export default function modalDialog(state = initialState, action) {
+export default function routing(state = initialState, action) {
   switch (action.type) {
     case LOCATION_CHANGE: {
       return state.set("locationBeforeTransitions", action.payload);

--- a/src/code/reducers/user-drake-hidden.js
+++ b/src/code/reducers/user-drake-hidden.js
@@ -2,8 +2,9 @@ import { actionTypes } from '../actions';
 
 const initialState = true;
 
-export default function modalDialog(state = initialState, action) {
+export default function userDrakeHidden(state = initialState, action) {
   switch (action.type) {
+    // Right now the drake is always hidden unless we are displaying a message
     case actionTypes.MODAL_DIALOG_SHOWN:
       return false;
     default:

--- a/src/code/templates/egg-game.js
+++ b/src/code/templates/egg-game.js
@@ -325,7 +325,6 @@ export default class EggGame extends Component {
             break;
           }
         }
-        resetAnimationEvents(false, showUserDrake);
         onKeepOffspring(2, success, 8);
       }
       else if (challengeType === 'match-target') {

--- a/src/code/templates/egg-game.js
+++ b/src/code/templates/egg-game.js
@@ -6,7 +6,6 @@ import PenView from '../components/pen';
 import GameteImageView from '../components/gamete-image';
 import AnimatedComponentView from '../components/animated-component';
 import ChromosomeImageView from '../components/chromosome-image';
-import { actionTypes } from '../actions';
 import t from '../utilities/translate';
 
 // a "reasonable" lookup function for the two gametes

--- a/src/code/templates/egg-game.js
+++ b/src/code/templates/egg-game.js
@@ -340,6 +340,15 @@ export default class EggGame extends Component {
       "XY": { b: getGameteChromosome(0, "XY") }
     };
 
+    // map all chromosomes in a gamete to a single side for selection purposes
+    function mapChromosomesToSide(gamete, side) {
+      let chromName, mappedGamete = {};
+      for (chromName in gamete) {
+        mappedGamete[chromName] = side;
+      }
+      return mappedGamete;
+    }
+
     let gametesClass = "gametes";
     if (!drakes[2]) {
       gametesClass += " unfertilized";
@@ -394,6 +403,8 @@ export default class EggGame extends Component {
         sChroms = maleGameteChromosomeMap,
         ovumChromosomes  = [oChroms[1] && oChroms[1].a, oChroms[2] && oChroms[2].a, oChroms.XY && oChroms.XY.a],
         spermChromosomes = [sChroms[1] && sChroms[1].b, sChroms[2] && sChroms[2].b, sChroms.XY && sChroms.XY.b],
+        ovumSelected = mapChromosomesToSide(gametes[1], 'a'),
+        spermSelected = mapChromosomesToSide(gametes[0], 'b'),
         ovumClasses = "ovum" + (isMatchingChallenge ? " matching" : ""),
         spermClasses = "sperm" + (isMatchingChallenge ? " matching" : "");
 
@@ -427,11 +438,17 @@ export default class EggGame extends Component {
             <div className={ gametesClass }>
               <div className='half-genome half-genome-left' id="mother-gamete-genome">
                 { ovumView }
-                <GenomeView className={childGenomeClass} orgName="targetmother" chromosomes={ femaleGameteChromosomeMap } species={ mother.species } editable={false} hiddenAlleles= { hiddenAlleles } small={ true } displayStyle={chromosomeDisplayStyle} />
+                <GenomeView className={childGenomeClass} orgName="targetmother" species={ mother.species }
+                            chromosomes={ femaleGameteChromosomeMap } selectedChromosomes={ ovumSelected }
+                            editable={false} hiddenAlleles={ hiddenAlleles }
+                            small={ true } displayStyle={chromosomeDisplayStyle} />
               </div>
               <div className='half-genome half-genome-right' id="father-gamete-genome">
                 { spermView }
-                <GenomeView className={childGenomeClass} orgName="targetfather" chromosomes={ maleGameteChromosomeMap }   species={ mother.species } editable={false} hiddenAlleles= { hiddenAlleles } small={ true } displayStyle={chromosomeDisplayStyle} />
+                <GenomeView className={childGenomeClass} orgName="targetfather" species={ mother.species } 
+                            chromosomes={ maleGameteChromosomeMap } selectedChromosomes={ spermSelected }
+                            editable={false} hiddenAlleles={ hiddenAlleles }
+                            small={ true } displayStyle={chromosomeDisplayStyle} />
               </div>
             </div>
           </div>

--- a/src/code/utilities/lang/en-us.js
+++ b/src/code/utilities/lang/en-us.js
@@ -19,6 +19,8 @@ export default {
   "~BUTTON.PLAYGROUND_MOVE_FORWARD": "Bring It On!",
   "~BUTTON.CHECK_DRAKE": "Check Drake",
   "~BUTTON.SAVE_DRAKE": "Save this",
+  "~BUTTON.SUBMIT": "Submit",
+  "~BUTTON.RESET": "Reset",
   "~BUTTON.FERTILIZE_DISABLED": "Fertilize",
   "~BUTTON.FERTILIZE": "Fertilize ❤️",
 

--- a/src/resources/authoring/gv2.js
+++ b/src/resources/authoring/gv2.js
@@ -86,7 +86,9 @@ window.GV2Authoring = [
       },
       "targetDrakes": [{},{},{}],
       "hiddenAlleles": "t,tk,h,c,a,b,d,bog,rh"
-    },
+    }
+  ],
+  [
     {
       "template": "GenomePlayground",
       "initialDrake": {
@@ -94,6 +96,6 @@ window.GV2Authoring = [
         "sex": 1
       },
       "hiddenAlleles": "t,tk,h,c,a,b,d,bog,rh"
-    }
+    },
   ]
 ];

--- a/src/resources/authoring/gv2.js
+++ b/src/resources/authoring/gv2.js
@@ -45,6 +45,8 @@ window.GV2Authoring = [
   [
     {
       "template": "EggGame",
+      "challengeType": "create-unique",
+      "showUserDrake": false,
       "mother":{
         "alleles": "a:w,b:W,a:M,b:m,a:fl,a:hl,a:T,b:T,a:h,b:h,a:C,b:C,a:A1,b:A1,a:B,b:B,a:D,b:D,a:rh,b:rh,a:Bog,b:Bog",
         "sex": 1
@@ -53,6 +55,36 @@ window.GV2Authoring = [
         "alleles": "a:w,b:W,a:m,b:m,a:T,b:T,a:h,b:h,a:A1,b:A1,a:C,b:C,a:B,b:B,a:D,b:D,a:rh,b:rh,a:Bog,b:Bog",
         "sex": 0
       },
+      "hiddenAlleles": "t,tk,h,c,a,b,d,bog,rh"
+    },
+    {
+      "template": "EggGame",
+      "challengeType": "match-target",
+      "showUserDrake": true,
+      "mother":{
+        "alleles": "a:w,b:W,a:M,b:m,a:fl,a:hl,a:T,b:T,a:h,b:h,a:C,b:C,a:A1,b:A1,a:B,b:B,a:D,b:D,a:rh,b:rh,a:Bog,b:Bog",
+        "sex": 1
+      },
+      "father": {
+        "alleles": "a:w,b:W,a:m,b:m,a:T,b:T,a:h,b:h,a:A1,b:A1,a:C,b:C,a:B,b:B,a:D,b:D,a:rh,b:rh,a:Bog,b:Bog",
+        "sex": 0
+      },
+      "targetDrakes": [{},{},{}],
+      "hiddenAlleles": "t,tk,h,c,a,b,d,bog,rh"
+    },
+    {
+      "template": "EggGame",
+      "challengeType": "match-target",
+      "showUserDrake": false,
+      "mother":{
+        "alleles": "a:w,b:W,a:M,b:m,a:fl,a:hl,a:T,b:T,a:h,b:h,a:C,b:C,a:A1,b:A1,a:B,b:B,a:D,b:D,a:rh,b:rh,a:Bog,b:Bog",
+        "sex": 1
+      },
+      "father": {
+        "alleles": "a:w,b:W,a:m,b:m,a:T,b:T,a:h,b:h,a:A1,b:A1,a:C,b:C,a:B,b:B,a:D,b:D,a:rh,b:rh,a:Bog,b:Bog",
+        "sex": 0
+      },
+      "targetDrakes": [{},{},{}],
       "hiddenAlleles": "t,tk,h,c,a,b,d,bog,rh"
     },
     {

--- a/src/resources/authoring/gv2.js
+++ b/src/resources/authoring/gv2.js
@@ -46,7 +46,7 @@ window.GV2Authoring = [
     {
       "template": "EggGame",
       "challengeType": "create-unique",
-      "showUserDrake": false,
+      "showUserDrake": true,
       "mother":{
         "alleles": "a:w,b:W,a:M,b:m,a:fl,a:hl,a:T,b:T,a:h,b:h,a:C,b:C,a:A1,b:A1,a:B,b:B,a:D,b:D,a:rh,b:rh,a:Bog,b:Bog",
         "sex": 1

--- a/src/stylus/challenges.styl
+++ b/src/stylus/challenges.styl
@@ -197,22 +197,34 @@
   .geniblocks.genome
     position: relative
     top: -33px
+    &.matching
+      top: -60px
+    &.matching.parent
+      top: 50px
   .geniblocks.organism
     height: 202px
+    &.target
+      height: 102px
 
 .egg
   position: relative
   display: flex
   width: 420px
 
-  .top
+  .fertilization
     display: flex
     align-items: flex-start
     height: 218px
 
     .organism
       padding-left: 25px
+      padding-right: 10px
       height: 170px
+      &.matching
+        margin-top: 10px
+        padding-left: 10px
+        padding-right: 20px
+        height: 140px
 
     .offspring-buttons
       display: flex
@@ -248,12 +260,15 @@
       transition: left 2s
       top: -135px
       left: 110px
+      &.matching
+        top: -160px
     .sperm
       position: absolute
       transition: left 2s
       top: -117px
       left: -12px
-
+      &.matching
+        top: -142px
 
     &.unfertilized
       .ovum
@@ -263,15 +278,24 @@
 
   .fertilize-button
     margin-top: 45px
+    &.matching
+      margin-top: 25px
     &.disabled
       color: gray
 
   .egg-image
     width: 103px
     padding: 34px
+    &.matching
+      margin-top: 0px
+      width: 70px
 
   .organism
     padding-top: 40px
+    &.target
+      padding-top: 10px
+    &.matching
+      padding-top: 10px
 
 #egg-game .bottom
   justify-content center

--- a/src/stylus/challenges.styl
+++ b/src/stylus/challenges.styl
@@ -210,6 +210,22 @@
   position: relative
   display: flex
   width: 420px
+  
+  .target-section
+    display: flex
+    flex-direction: row
+    justify-content: center
+    margin-left: -40px;
+  
+  .target-drake
+    margin-top: -20px;
+  
+  .target-counters
+    display: flex
+    flex-direction: column
+    justify-content: center
+    margin-top: 10px;
+    margin-left: 30px;
 
   .fertilization
     display: flex

--- a/src/stylus/ordinal-organism.styl
+++ b/src/stylus/ordinal-organism.styl
@@ -1,0 +1,16 @@
+.geniblocks.ordinal-organism
+  border: 1px solid #444444
+  
+  .ordinal
+    font: bold 24px sans-serif
+    text-align: center
+    color: #555555
+    margin-top: 3px
+  
+  .organism
+    padding-top: 0
+    margin-left: -2px
+    margin-top: -1px
+    
+.geniblocks.ordinal-organism.complete
+  background-color: #AAAAAA

--- a/test/actions/navigate-to-challenge.js
+++ b/test/actions/navigate-to-challenge.js
@@ -31,6 +31,8 @@ describe('navigateToChallenge action', () => {
       let initialState = defaultState.merge({
         case: 0,
         challenge: 0,
+        challengeType: undefined,
+        showUserDrake: false,
         authoring: [
           [],
           [{}, {}, {
@@ -50,6 +52,7 @@ describe('navigateToChallenge action', () => {
         challenge: 2,
         template: "GenomePlayground",
         challenges: 3,
+        showUserDrake: false,
         trialSuccess: false,
 
         // punt on these, as they're not part of the test

--- a/test/actions/submit-drake.js
+++ b/test/actions/submit-drake.js
@@ -37,11 +37,14 @@ describe('submitDrake action', () => {
         type: types.MODAL_DIALOG_SHOWN,
         message: "~ALERT.TITLE.GOOD_WORK",
         explanation: "~ALERT.COMPLETE_COIN",
+        leftButton: {
+          label: "~BUTTON.TRY_AGAIN",
+          action: "retryCurrentChallenge"
+        },
         rightButton: {
           label: "~BUTTON.NEXT_CASE",
           action: "navigateToNextChallenge"
         },
-        leftButton: undefined,
         showAward: true,
         top: undefined
       });


### PR DESCRIPTION
- author can specify challenge type ("create-unique" or "match-target")
- author can specify whether user drake is hatched/shown automatically
- target drake is shown (and pen view is hidden) in target matching challenges [#129879003]
- user can fertilize once gametes are complete [#129879183][#129879515]
- egg hatches (Egg Game 2a) or not (Egg Game 2b) [#129879183][#129879515]
- after fertilization user can submit drake or reset gametes [#129879109]
- dialog gives feedback on whether submitted drake matches [#129879109]
- drake is visible while feedback dialog is displayed
- Egg Game 2a (hatched drake) and 2b (unhatched egg) each contain three trials
- gold, silver, or bronze coin piece provided upon completion of challenges [#120794161]

With 20/20 hindsight, it might have made sense to split this up over a couple of PRs, but I kept thinking that just one more story wouldn't make that much difference.