### PR TITLE
Fix GUIDE socket.io connection; show ITS messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "axios": "^0.15.3",
     "babel-polyfill": "^6.20.0",
     "lodash": "^4.17.3",
+    "mustache": "^2.3.0",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "react-motion": "^0.4.7",

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -24,9 +24,10 @@ export const actionTypes = {
   MODAL_DIALOG_DISMISSED: "Modal dialog dismissed",
   ADVANCED_TRIAL: "Advanced to next trial",
   ADVANCED_CHALLENGE: "Advanced to next challenge",
-  SOCKET_CONNECTED: "Socket connected",
-  SOCKET_RECEIVED: "Socket received",
-  SOCKET_ERRORED: "Socket errored"
+  GUIDE_CONNECTED: "Guide connected",
+  GUIDE_MESSAGE_RECEIVED: "Guide message received",
+  GUIDE_ALERT_RECEIVED: "Guide alert received",
+  GUIDE_ERRORED: "Guide errored"
 };
 
 const ITS_ACTORS = {
@@ -512,7 +513,7 @@ export function showCompleteChallengeDialog() {
         showAward: true
       };
     }
-    
+
     dispatch(showModalDialog(dialog));
   };
 }

--- a/src/code/app.js
+++ b/src/code/app.js
@@ -39,16 +39,17 @@ const loggingMetadata = {
   applicationName: "GeniStarDev"
 };
 
-const socketEndpoint = "wss://guide.intellimedia.ncsu.edu";
+const guideServer = "wss://guide.intellimedia.ncsu.edu",
+      guideProtocol  = "guide-protocol-v2";
 
-const socket = io(socketEndpoint, {reconnection: false});
-socket.on('connection', state =>
+const socket = io(`${guideServer}/${guideProtocol}`, {reconnection: false});
+socket.on('connect', state =>
   store.dispatch({type: actionTypes.SOCKET_CONNECTED, state})
 );
 socket.on('message', state =>
   store.dispatch({type: actionTypes.SOCKET_RECEIVED, state})
 );
-socket.on('error', state=>
+socket.on('connect_error', state =>
   store.dispatch({type: actionTypes.SOCKET_ERRORED, state})
 );
 

--- a/src/code/app.js
+++ b/src/code/app.js
@@ -13,6 +13,7 @@ import { actionTypes, startSession, changeAuthoring } from './actions';
 import AuthoringUpload from './containers/authoring-upload';
 import ChallengeContainer from "./containers/challenge-container";
 import ModalMessageContainer from "./containers/modal-message-container";
+import NotificationContainer from "./containers/notification-container";
 
 import loggerMiddleware from './middleware/gv-log';
 import itsMiddleware from './middleware/its-log';
@@ -103,6 +104,7 @@ function renderApp() {
                           <Route path="/(:case/:challenge)" component={ChallengeContainer} />
                         </Router>
                         <ModalMessageContainer />
+                        <NotificationContainer />
                       </div>;
   render(
     <Provider store={store}>

--- a/src/code/app.js
+++ b/src/code/app.js
@@ -23,6 +23,7 @@ import thunk from 'redux-thunk';
 import io from 'socket.io-client';
 import GeneticsUtils from './utilities/genetics-utils';
 import urlParams from './utilities/url-params';
+import GuideProtocol from './utilities/guide-protocol';
 import uuid from 'uuid';
 
 function convertAuthoring(authoring) {
@@ -43,14 +44,17 @@ const guideServer = "wss://guide.intellimedia.ncsu.edu",
       guideProtocol  = "guide-protocol-v2";
 
 const socket = io(`${guideServer}/${guideProtocol}`, {reconnection: false});
-socket.on('connect', state =>
-  store.dispatch({type: actionTypes.SOCKET_CONNECTED, state})
+socket.on('connect', data =>
+  store.dispatch({type: actionTypes.GUIDE_CONNECTED, data})
 );
-socket.on('message', state =>
-  store.dispatch({type: actionTypes.SOCKET_RECEIVED, state})
+socket.on(GuideProtocol.TutorDialog.Channel, data =>
+  store.dispatch({type: actionTypes.GUIDE_MESSAGE_RECEIVED, data: GuideProtocol.TutorDialog.fromJson(data)})
 );
-socket.on('connect_error', state =>
-  store.dispatch({type: actionTypes.SOCKET_ERRORED, state})
+socket.on(GuideProtocol.Alert.Channel, (data) =>
+  store.dispatch({type: actionTypes.GUIDE_ALERT_RECEIVED, data: GuideProtocol.Alert.fromJson(data)})
+);
+socket.on('connect_error', data =>
+  store.dispatch({type: actionTypes.GUIDE_ERRORED, data})
 );
 
 const hashHistory = useRouterHistory(createHashHistory)({ queryKey: false });

--- a/src/code/components/notifications.js
+++ b/src/code/components/notifications.js
@@ -1,0 +1,31 @@
+/*
+ * Based on ReactOverlays demo at http://react-bootstrap.github.io/react-overlays/examples/#modals
+ */
+import React, { PropTypes } from 'react';
+import t from '../utilities/translate';
+
+class Notifications extends React.Component {
+
+  static propTypes = {
+    notifications: PropTypes.array
+  }
+
+  static defaultProps = {
+    notifications: []
+  }
+
+  render() {
+    const messages = this.props.notifications.map((message, i) =>
+        <div key={i} className="notification">{ t(message) }</div>
+      );
+
+    return (
+      <div className="geniblocks notification-container">
+        { messages }
+      </div>
+    );
+  }
+}
+
+export default Notifications;
+

--- a/src/code/containers/notification-container.js
+++ b/src/code/containers/notification-container.js
@@ -1,0 +1,12 @@
+import { connect } from 'react-redux';
+import Notifications from '../components/notifications';
+
+function mapStateToProps (state) {
+    return {
+      notifications: state.notifications
+    };
+  }
+
+const NotificationContainer = connect(mapStateToProps)(Notifications);
+
+export default NotificationContainer;

--- a/src/code/middleware/its-log.js
+++ b/src/code/middleware/its-log.js
@@ -15,17 +15,18 @@ export default (socket) => store => next => action => {
   }
 
   switch(action.type) {
-    case actionTypes.SOCKET_ERRORED: {
+    case actionTypes.GUIDE_ERRORED: {
       console.log("Error connecting to ITS");
       socket.close();
       break;
     }
-    case actionTypes.SOCKET_CONNECTED: {
+    case actionTypes.GUIDE_CONNECTED: {
       console.log("Connection Success!");
       break;
     }
-    case actionTypes.SOCKET_RECEIVED: {
-      console.log("Message received!", action.state.data);
+    case actionTypes.GUIDE_MESSAGE_RECEIVED:
+    case actionTypes.GUIDE_ALERT_RECEIVED: {
+      console.log("Message received!", action.data);
       break;
     }
     default: {

--- a/src/code/reducers/index.js
+++ b/src/code/reducers/index.js
@@ -12,6 +12,7 @@ import userDrakeHidden from './user-drake-hidden';
 import gametes from './gametes';
 import drakes from './drakes';
 import baskets from './baskets';
+import notifications from './notifications';
 
 function initialState() {
   return Immutable({
@@ -39,7 +40,8 @@ export default function reducer(state, action) {
     userDrakeHidden: userDrakeHidden(state.userDrakeHidden, action),
     gametes: gametes(state.gametes, action),
     drakes: drakes(state.drakes, action),
-    baskets: baskets(state.baskets, action)
+    baskets: baskets(state.baskets, action),
+    notifications: notifications(state.notifications, action)
   });
 
   switch(action.type) {

--- a/src/code/reducers/modal-dialog.js
+++ b/src/code/reducers/modal-dialog.js
@@ -1,6 +1,5 @@
 import Immutable from 'seamless-immutable';
 import { actionTypes } from '../actions';
-import urlParams from '../utilities/url-params';
 
 const initialState = Immutable({
   show: false,
@@ -27,23 +26,13 @@ export default function modalDialog(state = initialState, action) {
         showAward: action.showAward,
         top: action.top
       });
-    case actionTypes.GUIDE_MESSAGE_RECEIVED:
-      if (action.data && urlParams.showITS === "true") {
-        return state.merge({
-          show: true,
-          message: "Message from ITS",
-          explanation: action.data.message.asString(),
-          rightButton: defaultRightButton
-        });
-      }
-      else
-        return state;
     case actionTypes.MODAL_DIALOG_DISMISSED:
       return initialState;
     // actions which don't close the dialog, i.e. that can occur
     // while a dialog is being shown
     case actionTypes.BASKET_SELECTION_CHANGED:
     case actionTypes.DRAKE_SELECTION_CHANGED:
+    case actionTypes.GUIDE_MESSAGE_RECEIVED:
       return state;
     // Assume for now that all other actions also close dialog
     default:

--- a/src/code/reducers/modal-dialog.js
+++ b/src/code/reducers/modal-dialog.js
@@ -1,5 +1,6 @@
 import Immutable from 'seamless-immutable';
 import { actionTypes } from '../actions';
+import urlParams from '../utilities/url-params';
 
 const initialState = Immutable({
   show: false,
@@ -27,7 +28,7 @@ export default function modalDialog(state = initialState, action) {
         top: action.top
       });
     case actionTypes.GUIDE_MESSAGE_RECEIVED:
-      if (action.data) {
+      if (action.data && urlParams.showITS === "true") {
         return state.merge({
           show: true,
           message: "Message from ITS",

--- a/src/code/reducers/modal-dialog.js
+++ b/src/code/reducers/modal-dialog.js
@@ -26,12 +26,12 @@ export default function modalDialog(state = initialState, action) {
         showAward: action.showAward,
         top: action.top
       });
-    case actionTypes.SOCKET_RECEIVED:
-      if (action.state.data) {
+    case actionTypes.GUIDE_MESSAGE_RECEIVED:
+      if (action.data) {
         return state.merge({
           show: true,
           message: "Message from ITS",
-          explanation: JSON.parse(action.state.data).text,
+          explanation: action.data.message.asString(),
           rightButton: defaultRightButton
         });
       }

--- a/src/code/reducers/notifications.js
+++ b/src/code/reducers/notifications.js
@@ -1,0 +1,19 @@
+import Immutable from 'seamless-immutable';
+import { actionTypes } from '../actions';
+import urlParams from '../utilities/url-params';
+
+const initialState = Immutable([]);
+
+export default function notifications(state = initialState, action) {
+  switch (action.type) {
+    case actionTypes.GUIDE_MESSAGE_RECEIVED:
+      if (action.data && urlParams.showITS === "true") {
+        return state.concat(action.data.message.asString());
+      }
+      else
+        return state;
+    // For now, clear all messages every time the user does anything else
+    default:
+      return initialState;
+  }
+}

--- a/src/code/reducers/user-drake-hidden.js
+++ b/src/code/reducers/user-drake-hidden.js
@@ -7,6 +7,13 @@ export default function userDrakeHidden(state = initialState, action) {
     // Right now the drake is always hidden unless we are displaying a message
     case actionTypes.MODAL_DIALOG_SHOWN:
       return false;
+    // The following actions don't change the state:
+    case actionTypes.GUIDE_CONNECTED:
+    case actionTypes.GUIDE_ERRORED:
+    case actionTypes.GUIDE_MESSAGE_RECEIVED:
+    case actionTypes.GUIDE_ALERT_RECEIVED:
+      return state;
+    // All other actions re-hide the drake
     default:
       return true;
   }

--- a/src/code/utilities/guide-protocol.js
+++ b/src/code/utilities/guide-protocol.js
@@ -1,0 +1,134 @@
+/**
+* This files defines data structures and functions used to
+* send messages (serialized as JSON) to and from the GUIDE ITS
+* server.
+*
+* Edited from https://github.com/IntelliMedia/guide-server/blob/master/shared/guide-protocol.js
+*/
+
+import Mustache from 'mustache';
+
+var GuideProtocol = {};
+
+/**
+ * Message - string object with named substitution variables.
+ * NOTE: Requires mustache.js (https://github.com/janl/mustache.js/)
+ */
+GuideProtocol.Text = function(id, text, args) {
+    this.id = id;
+    this.text = text;
+    this.args = (args ? args : {});
+};
+
+GuideProtocol.Text.prototype.asString = function() {
+    return this.text ? Mustache.render(this.text, this.args) : "";
+};
+
+/**
+ * Event - information sent by the client (Geniverse) to the GUIDE ITS
+ */
+GuideProtocol.Event = function(username, session, sequence, actor, action, target, context, time) {
+    this.username = username;
+    this.session = session;
+    this.sequence = sequence;
+    this.actor = actor;
+    this.action = action;
+    this.target = target;
+    this.context = context;
+    this.time = (time == null ? Date.now() : time);
+};
+
+GuideProtocol.Event.Channel = 'Event';
+
+GuideProtocol.Event.prototype.toJson = function() {
+    return JSON.stringify(this);
+};
+
+GuideProtocol.Event.fromJson = function(json) {
+    var obj = JSON.parse(json);
+    return new GuideProtocol.Event(
+        obj.username,
+        obj.session,
+        obj.sequence,
+        obj.actor,
+        obj.action,
+        obj.target,
+        obj.context,
+        obj.time);
+};
+
+GuideProtocol.Event.fromJsonAsync = function(json) {
+    return new Promise((resolve) => {
+        resolve(GuideProtocol.Event.fromJson(json));
+    });
+};
+
+/**
+ * TutorDialog - used by the ITS to send a message to the student
+ */
+GuideProtocol.TutorDialog = function(message, time) {
+
+    if (message instanceof GuideProtocol.Text) {
+       this.message = message;
+    } else if (message instanceof String) {
+        this.message = new GuideProtocol.Text(null, message);
+    } else if (message.hasOwnProperty('id') && message.hasOwnProperty('text') && message.hasOwnProperty('args')) {
+        this.message = new GuideProtocol.Text(message.id, message.text, message.args);
+    }
+
+    this.time = (time == null ? Date.now() : time);
+};
+
+GuideProtocol.TutorDialog.Channel = 'TutorDialog';
+
+GuideProtocol.TutorDialog.prototype.toJson = function() {
+    return JSON.stringify(this);
+};
+
+GuideProtocol.TutorDialog.fromJson = function(json) {
+    var obj = JSON.parse(json);
+    return new GuideProtocol.TutorDialog(
+        obj.message,
+        obj.time);
+};
+
+GuideProtocol.TutorDialog.fromJsonAsync = function(json) {
+    return new Promise((resolve) => {
+        resolve(GuideProtocol.TutorDialog.fromJson(json));
+    });
+};
+
+/**
+ * Alert - used for system-level information, warning, and error messages
+ */
+GuideProtocol.Alert = function(type, message, time) {
+    this.type = type;
+    this.message = message;
+    this.time = (time == null ? Date.now() : time);
+};
+
+GuideProtocol.Alert.Channel = 'Alert';
+
+GuideProtocol.Alert.Error = 'Error';
+GuideProtocol.Alert.Warning = 'Warning';
+GuideProtocol.Alert.Info = 'Info';
+
+GuideProtocol.Alert.prototype.toJson = function() {
+    return JSON.stringify(this);
+};
+
+GuideProtocol.Alert.fromJson = function(json) {
+    var obj = JSON.parse(json);
+    return new GuideProtocol.Alert(
+        obj.type,
+        obj.message,
+        obj.time);
+};
+
+GuideProtocol.Alert.fromJsonAsync = function(json) {
+    return new Promise((resolve) => {
+        resolve(GuideProtocol.Alert.fromJson(json));
+    });
+};
+
+export default GuideProtocol;

--- a/src/stylus/notifications.styl
+++ b/src/stylus/notifications.styl
@@ -1,0 +1,16 @@
+.geniblocks.notification-container
+  position: fixed
+  top: 0
+  right: 0
+
+  .notification
+    width: 200px
+    margin: 17px
+    padding: 12px
+    color: #2d1c06
+    border-radius: 5px
+    border: 1px solid #2d1c06
+    background: rgba(250, 235, 215, 0.8)
+    box-shadow: inset 0px 0px 18px #ffffff, 0px 0px 8px #ffdfb5
+
+

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -8,7 +8,8 @@
   },
   "globals": { "GeniBlocks": false, "BioLogica": false, "React": false,
                 "describe": false, "it": false, "assert": false,
-                "mount": false, "shallow": false },
+                "mount": false, "shallow": false, "before": false, "after": false,
+                "beforeEach": false, "afterEach": false },
   "extends": [ "eslint:recommended", "plugin:react/recommended" ],
   "rules": {
     "semi": [2, "always"],

--- a/test/actions/notifications.js
+++ b/test/actions/notifications.js
@@ -1,0 +1,88 @@
+import expect from 'expect';
+import reducer from '../../src/code/reducers/';
+import * as actions from '../../src/code/actions';
+import urlParams from '../../src/code/utilities/url-params';
+import GuideProtocol from '../../src/code/utilities/guide-protocol';
+
+const types = actions.actionTypes;
+
+describe('Notification actions', () => {
+
+  before( () => urlParams.showITS = "true" );
+
+  after( () => delete urlParams.showITS );
+
+  describe('the reducer', () => {
+
+    let defaultState = reducer(undefined, {});
+    let nextState;
+
+      let messageData = JSON.stringify(
+        {
+          message: {
+            id: 'ITS.CHALLENGE.INTRO.2',
+            text: 'Ok! Let\'s get to work on Case {{case}} Challenge {{challenge}}.',
+            args: {
+              'case': 0,
+              challenge: 2
+            }
+          },
+          time: 1484069330265
+        }
+      );
+
+    describe('on receiving GUIDE message', () => {
+
+      it('should add to the notifications', () => {
+
+        nextState = reducer(defaultState, {
+          type: types.GUIDE_MESSAGE_RECEIVED,
+          data: GuideProtocol.TutorDialog.fromJson(messageData)
+        });
+
+        expect(nextState).toEqual(defaultState.merge({
+          notifications: ["Ok! Let's get to work on Case 0 Challenge 2."]
+        }));
+      });
+
+      it('should keep adding to the notifications', () => {
+
+        let secondMessageData = JSON.stringify(
+          {
+            message: {
+              id: 'ITS.CHALLENGE.INTRO.3',
+              text: 'Second message.',
+              args: {}
+            },
+            time: 1484069330265
+          }
+        );
+
+        let lastState = reducer(nextState, {
+          type: types.GUIDE_MESSAGE_RECEIVED,
+          data: GuideProtocol.TutorDialog.fromJson(secondMessageData)
+        });
+
+        expect(lastState).toEqual(defaultState.merge({
+          notifications: ["Ok! Let's get to work on Case 0 Challenge 2.", "Second message."]
+        }));
+      });
+    });
+
+    describe('on receiving other actions', () => {
+
+      nextState = reducer(defaultState, {
+        type: types.GUIDE_MESSAGE_RECEIVED,
+        data: GuideProtocol.TutorDialog.fromJson(messageData)
+      });
+
+      it('should clear the notifications', () => {
+        let lastState = reducer(nextState, actions.startSession("123"));
+
+        expect(lastState).toEqual(defaultState.merge({
+          notifications: []
+        }));
+      });
+    });
+  });
+});

--- a/test/actions/show-modal-dialog.js
+++ b/test/actions/show-modal-dialog.js
@@ -95,28 +95,23 @@ describe('showModalDialog action', () => {
       }));
     });
 
-    it('should update the modalDialog correctly for an ITS message', () => {
+    it('should leave the current modalDialog alone after an ITS message', () => {
       let defaultState = reducer(undefined, {});
 
-      let nextState = reducer(defaultState, {
-        type: types.SOCKET_RECEIVED,
+      let messageState = reducer(defaultState, {
+        type: types.MODAL_DIALOG_SHOWN,
+        message: "Message",
+        showAward: false
+      });
+
+      let nextState = reducer(messageState, {
+        type: types.GUIDE_MESSAGE_RECEIVED,
         state: {
           data: '{"text": "Hi from ITS"}'
         }
       });
 
-      expect(nextState).toEqual(defaultState.merge({
-        modalDialog: {
-          show: true,
-          message: "Message from ITS",
-          explanation: "Hi from ITS",
-          rightButton: {
-            "action": "dismissModalDialog",
-            "label": "~BUTTON.OK"
-          },
-          leftButton: null
-        }
-      }));
+      expect(nextState).toEqual(messageState);
     });
 
     it('should dismiss the modalDialog on a dismiss event', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3524,6 +3524,10 @@ multipipe@^0.1.2:
   dependencies:
     duplexer2 "0.0.2"
 
+mustache@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.0.tgz#4028f7778b17708a489930a6e52ac3bca0da41d0"
+
 mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"


### PR DESCRIPTION
This fixes our communication to the ITS GUIDE Server, listens for ITS messages in their new format, and appends new messages to a new lightweight notification component.

Because the ITS messages are mostly demo strings for now, we don't show the messages by default. We can view the messages by including `?showITS=true` in the url. Eventually, we'll want to switch it so that the default is to view them.

https://www.pivotaltracker.com/story/show/137109565
https://www.pivotaltracker.com/story/show/137371291