### PR TITLE
Authored linked genes

### DIFF
--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -12,6 +12,23 @@ function processAuthoredBaskets(authoredChallenge, state) {
   return baskets || state.baskets;
 }
 
+function processAuthoredDrakes(authoredChallenge, trial, template) {
+  // takes authored list of named drakes ("mother", etc) and returns an
+  // array specific for this template
+  const authoredDrakesArray = template.authoredDrakesToDrakeArray(authoredChallenge, trial);
+
+  // turn authored alleles into completely-specified alleleStrings
+  let drakes = authoredDrakesArray.map(function(drakeDef) {
+    if (!drakeDef) return null;
+    let drake = new BioLogica.Organism(BioLogica.Species.Drake, drakeDef.alleles, drakeDef.sex);
+    return {
+      alleleString: drake.getAlleleString(),
+      sex: drake.sex
+    };
+  });
+  return drakes;
+}
+
 export function loadStateFromAuthoring(state, authoring, progress={}) {
   let trial = state.trial ? state.trial : 0;
 
@@ -31,18 +48,7 @@ export function loadStateFromAuthoring(state, authoring, progress={}) {
         baskets = processAuthoredBaskets(authoredChallenge, state),
         showUserDrake = (authoredChallenge.showUserDrake != null) ? authoredChallenge.showUserDrake : false,
         trials = authoredChallenge.targetDrakes,
-        authoredDrakesArray = template.authoredDrakesToDrakeArray(authoredChallenge, trial),
-
-        // turn authored alleles into completely-specified alleleStrings
-        // (once we have nested arrays this will need to be tweaked)
-        drakes = authoredDrakesArray.map(function(drakeDef) {
-          if (!drakeDef) return null;
-          let drake = new BioLogica.Organism(BioLogica.Species.Drake, drakeDef.alleles, drakeDef.sex);
-          return {
-            alleleString: drake.getAlleleString(),
-            sex: drake.sex
-          };
-        });
+        drakes = processAuthoredDrakes(authoredChallenge, trial, template);
 
   let goalMoves = null;
   if (template.calculateGoalMoves) {
@@ -89,18 +95,7 @@ export function loadNextTrial(state, authoring, progress) {
       template = templates[templateName],
       hiddenAlleles = extractHiddenAlleles(state, authoredChallenge),
       baskets = authoredChallenge.baskets || state.baskets,
-      authoredDrakesArray = template.authoredDrakesToDrakeArray(authoredChallenge, trial),
-
-      // turn authored alleles into completely-specified alleleStrings
-      // (once we have nested arrays this will need to be tweaked)
-      drakes = authoredDrakesArray.map(function(drakeDef) {
-        if (!drakeDef) return null;
-        let drake = new BioLogica.Organism(BioLogica.Species.Drake, drakeDef.alleles, drakeDef.sex);
-        return {
-          alleleString: drake.getAlleleString(),
-          sex: drake.sex
-        };
-      });
+      drakes = processAuthoredDrakes(authoredChallenge, trial, template);
 
   let goalMoves = null;
   if (template.calculateGoalMoves) {

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -15,14 +15,18 @@
       "instructions": "Match the target drake!",
       "showUserDrake": true,
       "initialDrake": {
-        "alleles": "T-T, h-h, A1-A1, C-C, B-B, D-D, rh-rh, Bog-Bog",
+        "alleles": "Bog-, D-, rh-",
         "sex": 1
       },
       "targetDrakes": [{
-        "alleles": "w-, m-m, fl-, hl-, T-T, h-h, C-C, A1-A1, B-B, D-D, rh-rh, Bog-Bog",
+        "alleles": "w-, m-m, fl-, hl-",
         "sex": 1
       }],
-      "hiddenAlleles": "t,tk,h,c,a,b,d,bog,rh"
+      "hiddenAlleles": "t,tk,h,c,a,b,d,bog,rh",
+      "linkedGenes": {
+        "drakes": [0, 1],
+        "genes": "tail, horns, color, black, dilute, armor, nose, bogbreath"
+      }
     },
     {
       "comment": "*** Case 1: Challenge 3 - Single Drake (User Drake Hidden) ***",

--- a/test/templates/egg-game.js
+++ b/test/templates/egg-game.js
@@ -1,6 +1,21 @@
 import EggGame from '../../src/code/templates/egg-game';
 import GeneticsUtils from '../../src/code/utilities/genetics-utils';
+import reducer from '../../src/code/reducers/';
+import { navigateToChallenge } from '../../src/code/actions';
 import expect from 'expect';
+
+const basicUnderdefinedInitialState = (template, _case, challenge, challenges) => ({
+  template,
+  case: _case,
+  challenge,
+  challenges,
+  challengeType: undefined,
+  interactionType: undefined,
+  goalMoves: null,
+  instructions: undefined,
+  showUserDrake: false,
+  trialSuccess: false
+});
 
 describe('authoredDrakesToDrakeArray()', () => {
   it('Egg Game I should create valid parent drakes', () => {
@@ -50,3 +65,87 @@ describe('authoredDrakesToDrakeArray()', () => {
     }
   });
 });
+
+
+describe('loading authored state into template', () => {
+  describe('in the EggGame II template', () => {
+    let authoring = GeneticsUtils.convertDashAllelesObjectToABAlleles([
+          [
+            {},
+            {
+              "template": "EggGame",
+              "challengeType": "match-target",
+              "mother":{
+                "alleles": "W-W, T-T",
+                "sex": 1
+              },
+              "father": {
+                "alleles": "w-w, T-T",
+                "sex": 0
+              },
+              "targetDrakes": [{},{},{}]
+            }
+          ]
+        ], ["alleles"]);
+
+    let defaultState = reducer(undefined, {});
+    let initialState = defaultState.merge({
+      case: 0,
+      challenge: 0,
+      authoring: authoring
+    });
+
+    let nextState = reducer(initialState, navigateToChallenge(0, 1));
+
+    it('should create the correct drake and trial state on initial load', () => {
+
+      expect(nextState).toEqual(initialState
+        .merge(basicUnderdefinedInitialState("EggGame", 0,1,2))
+        .merge({
+          "challengeType": "match-target",
+          "drakes": [
+            {
+              "alleleString": nextState.drakes[0].alleleString, // we check valid alleles below
+              "sex": 1
+            },
+            {
+              "alleleString": nextState.drakes[1].alleleString,
+              "sex": 0
+            },
+            null,
+            {
+              "alleleString": nextState.drakes[3].alleleString,
+              "sex": nextState.drakes[3].sex
+            },
+            {
+              "alleleString": nextState.drakes[4].alleleString,
+              "sex": nextState.drakes[4].sex
+            },
+            {
+              "alleleString": nextState.drakes[5].alleleString,
+              "sex": nextState.drakes[5].sex
+            }
+          ],
+          "gametes": [ {}, {} ],
+          "goalMoves": nextState.goalMoves,
+          "trials": [ {}, {}, {} ]
+        }));
+    });
+
+    it('should create drakes of the authored genotype', () => {
+
+      expect(GeneticsUtils.isValidAlleleString(nextState.drakes[0].alleleString)).toBe(true);
+      expect(nextState.drakes[0].alleleString.indexOf("a:W,b:W") > -1).toBe(true);
+
+      expect(GeneticsUtils.isValidAlleleString(nextState.drakes[1].alleleString)).toBe(true);
+      expect(nextState.drakes[1].alleleString.indexOf("a:w,b:w") > -1).toBe(true);
+
+      // all trial drakes must be T-T
+      expect(GeneticsUtils.isValidAlleleString(nextState.drakes[3].alleleString)).toBe(true);
+      expect(nextState.drakes[3].alleleString.indexOf("a:T,b:T") > -1).toBe(true);
+      expect(nextState.drakes[4].alleleString.indexOf("a:T,b:T") > -1).toBe(true);
+      expect(nextState.drakes[5].alleleString.indexOf("a:T,b:T") > -1).toBe(true);
+    });
+  });
+});
+

--- a/test/templates/genome-challenge.js
+++ b/test/templates/genome-challenge.js
@@ -106,4 +106,58 @@ describe('loading authored state into template', () => {
       expect(nextState.drakes[1].alleleString.indexOf("a:W,b:W") > -1).toBe(true);
     });
   });
+
+  describe('with linked genes', () => {
+    describe('in the GenomeChallenge template', () => {
+      let authoring = GeneticsUtils.convertDashAllelesObjectToABAlleles([
+            [
+              {},
+              {
+                "template": "GenomeChallenge",
+                "initialDrake": {
+                  "alleles": "W-w",
+                  "sex": 1
+                },
+                "targetDrakes": [{
+                  "alleles": "W-W",
+                  "sex": 1
+                },
+                {
+                  "alleles": "w-w",
+                  "sex": 1
+                }],
+                "linkedGenes": {
+                  "drakes": [0, 1],
+                  "genes": "tail, horns"
+                }
+              }
+            ]
+          ], ["alleles"]);
+
+      let defaultState = reducer(undefined, {});
+      let initialState = defaultState.merge({
+        case: 0,
+        challenge: 0,
+        authoring: authoring
+      });
+
+      let nextState = reducer(initialState, navigateToChallenge(0, 1));
+
+      it('should create drakes with linked genes', () => {
+        expect(GeneticsUtils.isValidAlleleString(nextState.drakes[0].alleleString)).toBe(true);
+        expect(nextState.drakes[0].alleleString.indexOf("a:W,b:w") > -1).toBe(true);
+
+        expect(GeneticsUtils.isValidAlleleString(nextState.drakes[1].alleleString)).toBe(true);
+        expect(nextState.drakes[1].alleleString.indexOf("a:W,b:W") > -1).toBe(true);
+
+        let drake0Def = nextState.drakes[0],
+            drake0 = new BioLogica.Organism(BioLogica.Species.Drake, drake0Def.alleleString, drake0Def.sex),
+            tailGenotype = drake0.genetics.genotype.getAlleleString(["tail"], drake0.genetics),
+            hornsGenotype = drake0.genetics.genotype.getAlleleString(["horns"], drake0.genetics);
+
+        expect(nextState.drakes[1].alleleString.indexOf(tailGenotype) > -1).toBe(true);
+        expect(nextState.drakes[1].alleleString.indexOf(hornsGenotype) > -1).toBe(true);
+      });
+    });
+  });
 });

--- a/test/templates/genome-challenge.js
+++ b/test/templates/genome-challenge.js
@@ -1,0 +1,109 @@
+import expect from 'expect';
+import GenomeChallenge from '../../src/code/templates/genome-challenge';
+import GeneticsUtils from '../../src/code/utilities/genetics-utils';
+import reducer from '../../src/code/reducers/';
+import { navigateToChallenge } from '../../src/code/actions';
+
+const basicUnderdefinedInitialState = (template, _case, challenge, challenges) => ({
+  template,
+  case: _case,
+  challenge,
+  challenges,
+  challengeType: undefined,
+  interactionType: undefined,
+  goalMoves: null,
+  instructions: undefined,
+  showUserDrake: false,
+  trialSuccess: false
+});
+
+describe('authoredDrakesToDrakeArray()', () => {
+  it('Genome Challenge should create valid drakes', () => {
+    expect(GenomeChallenge.authoredDrakesToDrakeArray).toExist("must implement authoredDrakesToDrakeArray()");
+
+    const challenge = GeneticsUtils.convertDashAllelesObjectToABAlleles({
+            "initialDrake":{
+              "alleles": "w-w",
+              "sex": 1
+            },
+            "targetDrakes": [{
+              "alleles": "W-W",
+              "sex": 1
+            }]
+          }, ["alleles"]),
+          drakes = GenomeChallenge.authoredDrakesToDrakeArray(challenge, 0);
+    expect(drakes.length).toBe(2);
+    expect(GeneticsUtils.isValidAlleleString(drakes[0].alleles)).toBe(true);
+    expect(GeneticsUtils.isValidAlleleString(drakes[1].alleles)).toBe(true);
+  });
+});
+
+describe('loading authored state into template', () => {
+  describe('in the GenomeChallenge template', () => {
+    let authoring = GeneticsUtils.convertDashAllelesObjectToABAlleles([
+          [
+            {},
+            {
+              "template": "GenomeChallenge",
+              "initialDrake":{
+                "alleles": "W-w",
+                "sex": 1
+              },
+              "targetDrakes": [{
+                "alleles": "W-W",
+                "sex": 1
+              },
+              {
+                "alleles": "w-w",
+                "sex": 1
+              }]
+            }
+          ]
+        ], ["alleles"]);
+
+    let defaultState = reducer(undefined, {});
+    let initialState = defaultState.merge({
+      case: 0,
+      challenge: 0,
+      authoring: authoring
+    });
+
+    let nextState = reducer(initialState, navigateToChallenge(0, 1));
+
+    it('should create the correct drake and trial state on initial load', () => {
+      expect(nextState).toEqual(initialState
+        .merge(basicUnderdefinedInitialState("GenomeChallenge", 0,1,2))
+        .merge({
+          "drakes": [
+            {
+              "alleleString": nextState.drakes[0].alleleString, // we check valid alleles below
+              "sex": 1
+            },
+            {
+              "alleleString": nextState.drakes[1].alleleString,
+              "sex": 1
+            }
+          ],
+          "goalMoves": nextState.goalMoves,
+          "trials": [
+            {
+              "alleles": "a:W,b:W",
+              "sex": 1
+            },
+            {
+              "alleles": "a:w,b:w",
+              "sex": 1
+            }
+          ]
+        }));
+    });
+
+    it('should create drakes of the authored genotype', () => {
+      expect(GeneticsUtils.isValidAlleleString(nextState.drakes[0].alleleString)).toBe(true);
+      expect(nextState.drakes[0].alleleString.indexOf("a:W,b:w") > -1).toBe(true);
+
+      expect(GeneticsUtils.isValidAlleleString(nextState.drakes[1].alleleString)).toBe(true);
+      expect(nextState.drakes[1].alleleString.indexOf("a:W,b:W") > -1).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
This adds the ability to include

```
    "linkedGenes": {
        "drakes": [0, 1],
        "genes": "tail, horns, color, black, dilute, armor, nose, bogbreath"
      }
```

in the authoring, to define genes may not be explicitly authored, but must remain identical between two (or more) drakes.

https://www.pivotaltracker.com/story/show/136137281