### PR TITLE
Changeable visible genes

### DIFF
--- a/examples/basic-examples/chromosomes.html
+++ b/examples/basic-examples/chromosomes.html
@@ -15,6 +15,7 @@
         <th>Chromosome with labels</th>
         <th>Chromosome with alleles</th>
         <th>Chromosome with both</th>
+        <th>Chromosome selectively editable, visible alleles</th>
         <th>Chromosome with no organism</th>
       </tr>
       <tr>
@@ -22,6 +23,7 @@
         <td id="chromosome-labels"></td>
         <td id="chromosome-alleles"></td>
         <td id="chromosome-both"></td>
+        <td id="chromosome-selective"></td>
         <td id="chromosome-orgless"></td>
       </tr>
     </table>
@@ -74,6 +76,18 @@
             onAlleleChange
           }),
           document.getElementById('chromosome-both')
+        );
+
+        ReactDOM.render(
+          React.createElement(GeniBlocks.ChromosomeView, {
+            chromosome: dragon.getGenotype().chromosomes[1]["a"],
+            showLabels: true,
+            showAlleles: true,
+            userChangeableGenes: ["tail", "metallic"],
+            visibleGenes: ["wings"],
+            onAlleleChange
+          }),
+          document.getElementById('chromosome-selective')
         );
 
         ReactDOM.render(

--- a/examples/basic-examples/genome-test.html
+++ b/examples/basic-examples/genome-test.html
@@ -22,6 +22,7 @@
           React.createElement(GeniBlocks.GenomeTestView, {
             org: dragon,
             selection: selection,
+            userChangeableGenes: ['tail', 'wings', 'color', 'forelimbs', 'hindlimbs'],
             onSelectionChange: function(gene, newValue) {
               selection[gene.name] = newValue;
               render();

--- a/examples/basic-examples/genome.html
+++ b/examples/basic-examples/genome.html
@@ -20,6 +20,8 @@
         ReactDOM.render(
           React.createElement(GeniBlocks.GenomeView, {
             org: dragon,
+            userChangeableGenes: ['forelimbs', 'hindlimbs', 'color', 'black', 'dilute'],
+            visibleGenes: ['wings', 'tail', 'bogbreath'],
             onAlleleChange: function(chrom, side, prevAllele, newAllele) {
               dragon.genetics.genotype.replaceAlleleChromName(chrom, side, prevAllele, newAllele);
               dragon = new BioLogica.Organism(BioLogica.Species.Drake, dragon.getAlleleString(), 1);

--- a/examples/experiments/meiosis/meiosis.js
+++ b/examples/experiments/meiosis/meiosis.js
@@ -1,6 +1,6 @@
 var mother = new BioLogica.Organism(BioLogica.Species.Drake, "a:m,b:M,a:h,b:h,a:C,b:C,a:a,b:a,a:B,b:B,a:D,b:D,a:w,b:W,a:Fl,b:Fl,a:Hl,b:hl,a:T,b:t,a:rh,b:rh,a:Bog,b:Bog", 1),
     father = new BioLogica.Organism(BioLogica.Species.Drake, "a:M,a:h,b:h,a:C,b:C,a:a,b:a,a:B,a:D,a:W,a:fl,b:fl,a:Hl,a:t,b:T,a:rh,a:Bog,b:Bog", 0),
-    hiddenAlleles = ['h','c','a','b','d','bog','rh'],
+    visibleGenes = ['tail', 'wings', 'forelimbs', 'hindlimbs'],
     motherDisabledAlleles = [],
     fatherDisabledAlleles = [],
     showFilters = false,
@@ -92,7 +92,7 @@ function render() {
     ReactDOM.render(
       React.createElement(GeniBlocks.AlleleFiltersView, {
         species: mother.species,
-        hiddenAlleles: hiddenAlleles,
+        visibleGenes: visibleGenes,
         disabledAlleles: motherDisabledAlleles,
         onFilterChange: function(evt, allele, isChecked) {
           evt;
@@ -125,7 +125,7 @@ function render() {
     ReactDOM.render(
       React.createElement(GeniBlocks.AlleleFiltersView, {
         species: father.species,
-        hiddenAlleles: hiddenAlleles,
+        visibleGenes: visibleGenes,
         disabledAlleles: fatherDisabledAlleles,
         onFilterChange: function(evt, allele, isChecked) {
           evt;
@@ -157,7 +157,7 @@ function render() {
   ReactDOM.render(
     React.createElement(GeniBlocks.GametePoolView, {
       gametes: motherGametes,
-      hiddenAlleles: hiddenAlleles,
+      visibleGenes: visibleGenes,
       width: gametePoolWidth,
       height: gametePoolHeight,
       animStiffness: animStiffness,
@@ -181,7 +181,7 @@ function render() {
   ReactDOM.render(
     React.createElement(GeniBlocks.GametePoolView, {
       gametes: fatherGametes,
-      hiddenAlleles: hiddenAlleles,
+      visibleGenes: visibleGenes,
       width: gametePoolWidth,
       height: gametePoolHeight,
       animStiffness: animStiffness,
@@ -207,7 +207,7 @@ function render() {
     if (offspring) {
       ReactDOM.render(
         React.createElement(GeniBlocks.AnimatedOrganismView, {
-            org: offspring, 
+            org: offspring,
             initialOpacity: 0.0,
             opacity: offspringOpacity,
             onRest: function() {
@@ -238,8 +238,8 @@ function render() {
         React.createElement(GeniBlocks.FertilizingGameteView, {
           type: 'mother',
           gamete: selectedMotherGamete, id: selectedMotherGameteId,
-          fertilizationState: fertilizationState, 
-          hiddenAlleles: hiddenAlleles,
+          fertilizationState: fertilizationState,
+          visibleGenes: visibleGenes,
           srcRect: selectedMotherGameteSrcRect,
           dstRect: motherSelectedGameteViewportRect,
           animStiffness: animStiffness,
@@ -274,8 +274,8 @@ function render() {
         React.createElement(GeniBlocks.FertilizingGameteView, {
           type: 'father',
           gamete: selectedFatherGamete, id: selectedFatherGameteId,
-          fertilizationState: fertilizationState, 
-          hiddenAlleles: hiddenAlleles,
+          fertilizationState: fertilizationState,
+          visibleGenes: visibleGenes,
           srcRect: selectedFatherGameteSrcRect,
           dstRect: fatherSelectedGameteViewportRect,
           animStiffness: animStiffness

--- a/src/code/components/allele-filters.js
+++ b/src/code/components/allele-filters.js
@@ -1,17 +1,11 @@
 import React, {PropTypes} from 'react';
 
-const AlleleFiltersView = ({species, hiddenAlleles=[], disabledAlleles = [], onFilterChange}) => {
-  let hiddenGenes = new Set,
-      geneInputs = [];
-
-  for (const allele of hiddenAlleles) {
-    const gene = BioLogica.Genetics.getGeneOfAllele(species, allele);
-    if (gene)
-      hiddenGenes.add(gene.name);
-  }
+const AlleleFiltersView = ({species, visibleGenes=[], disabledAlleles=[], onFilterChange}) => {
+  let geneInputs = [],
+      allVisible = visibleGenes.length === 0;
 
   for (const gene in species.geneList) {
-    if (!hiddenGenes.has(gene)) {
+    if (allVisible || visibleGenes.indexOf(gene) > -1) {
       const alleles = species.geneList[gene].alleles,
             alleleItems = alleles.map(allele => {
               const name = species.alleleLabelMap[allele],
@@ -49,7 +43,7 @@ const AlleleFiltersView = ({species, hiddenAlleles=[], disabledAlleles = [], onF
 
 AlleleFiltersView.propTypes = {
   species: PropTypes.object.isRequired,
-  hiddenAlleles: PropTypes.arrayOf(PropTypes.string),
+  visibleGenes: PropTypes.arrayOf(PropTypes.string),
   disabledAlleles: PropTypes.arrayOf(PropTypes.string),
   onFilterChange: PropTypes.func.isRequired
 };

--- a/src/code/components/animated-gamete.js
+++ b/src/code/components/animated-gamete.js
@@ -7,7 +7,7 @@ import GameteView from './gamete';
  *
  * @param {Object} gamete - Biologica gamete (map of chromosome names to chromosomes)
  * @param {number} id - the unique id of this gamete
- * @param {string[]} hiddenAlleles - individual alleles of genes for which all alleles should be hidden
+ * @param {string[]} visibleGenes - genes which should be visible
  * @param {Object} [initialDisplay] - initial display parameters used to represent the gamete
  * @param {number} [initialDisplay.x] - initial location (left) of the gamete
  * @param {number} [initialDisplay.y] - initial location (top) of the gamete
@@ -67,7 +67,7 @@ const AnimatedGameteView = ({id, initialDisplay, display, animStiffness=100, onR
 AnimatedGameteView.propTypes = {
   gamete: PropTypes.object.isRequired,
   id: PropTypes.number.isRequired,
-  hiddenAlleles: PropTypes.arrayOf(PropTypes.string),
+  visibleGenes: PropTypes.arrayOf(PropTypes.string),
   initialDisplay: PropTypes.shape({ // initial display properties
     x: PropTypes.number.isRequired, // location (left) of gamete image
     y: PropTypes.number.isRequired, // location (top) of gamete image

--- a/src/code/components/chromosome.js
+++ b/src/code/components/chromosome.js
@@ -10,7 +10,7 @@ import GeneticsUtils from '../utilities/genetics-utils';
  * chromosome name and side.
  */
 
-const ChromosomeView = ({chromosome, org, chromosomeName, side, hiddenAlleles = [], small = false, editable = true, selected = false, onAlleleChange, onChromosomeSelected, showLabels = true, showAlleles = false, labelsOnRight = true, orgName, displayStyle = {}}) => {
+const ChromosomeView = ({chromosome, org, chromosomeName, side, userChangeableGenes = [], visibleGenes = [], small = false, editable = true, selected = false, onAlleleChange, onChromosomeSelected, showLabels = true, showAlleles = false, labelsOnRight = true, orgName, displayStyle = {}}) => {
   var containerClass = "items",
       empty = false,
       yChromosome = false,
@@ -22,14 +22,14 @@ const ChromosomeView = ({chromosome, org, chromosomeName, side, hiddenAlleles = 
 
   if (chromosome) {
     let alleles = chromosome.alleles,
-        visibleAlleles = GeneticsUtils.filterAlleles(alleles, hiddenAlleles, chromosome.species);
+        visibleAlleles = GeneticsUtils.filterVisibleAlleles(alleles, userChangeableGenes, visibleGenes, chromosome.species);
 
     if (showLabels) {
       let labels = visibleAlleles.map(a => {
         return (
-          <GeneLabelView key={a} species={chromosome.species} allele={a} editable={editable}
+          <GeneLabelView key={a.allele} species={chromosome.species} allele={a.allele} editable={editable && a.editable}
           onAlleleChange={function(event) {
-            onAlleleChange(a, event.target.value);
+            onAlleleChange(a.allele, event.target.value);
           }}/>
         );
       });
@@ -48,7 +48,7 @@ const ChromosomeView = ({chromosome, org, chromosomeName, side, hiddenAlleles = 
     if (showAlleles) {
       let alleleSymbols = visibleAlleles.map(a => {
         return (
-          <AlleleView key={a} allele={a} />
+          <AlleleView key={a.allele} allele={a.allele} />
         );
       });
 
@@ -92,7 +92,8 @@ ChromosomeView.propTypes = {
   chromosomeName: PropTypes.string,
   side: PropTypes.string,
   chromosome: PropTypes.object,
-  hiddenAlleles: PropTypes.array,
+  userChangeableGenes: PropTypes.array,
+  visibleGenes: PropTypes.array,
   small: PropTypes.bool,
   editable: PropTypes.bool,
   selected: PropTypes.bool,

--- a/src/code/components/fertilizing-gamete.js
+++ b/src/code/components/fertilizing-gamete.js
@@ -18,7 +18,7 @@ export default class FertilizingGameteView extends React.Component {
     gamete: PropTypes.object.isRequired,
     id: PropTypes.number.isRequired,
     fertilizationState: PropTypes.oneOf(['none', 'fertilizing', 'fertilized', 'complete']).isRequired,
-    hiddenAlleles: PropTypes.arrayOf(PropTypes.string),
+    visibleGenes: PropTypes.arrayOf(PropTypes.string),
     srcRect: PropTypes.shape({
       left: PropTypes.number.isRequired,
       top: PropTypes.number.isRequired,
@@ -36,7 +36,7 @@ export default class FertilizingGameteView extends React.Component {
   }
 
   static defaultProps = {
-    hiddenAlleles: [],
+    visibleGenes: [],
     animStiffness: 100
   }
 
@@ -45,7 +45,7 @@ export default class FertilizingGameteView extends React.Component {
   }
 
   render = () => {
-    let {gamete, id, hiddenAlleles, animStiffness, onRest} = this.props,
+    let {gamete, id, visibleGenes, animStiffness, onRest} = this.props,
         xOffset = this.props.srcRect ? this.props.srcRect.left - this.props.dstRect.left : 0,
         yOffset = this.props.srcRect ? this.props.srcRect.top - this.props.dstRect.top : 0,
         xResting = this.props.type === GAMETE_TYPE.FATHER ? RESTING_FATHER_GAMETE_X
@@ -72,7 +72,7 @@ export default class FertilizingGameteView extends React.Component {
     }
 
     return (
-      <AnimatedGameteView gamete={gamete} id={id} hiddenAlleles={hiddenAlleles}
+      <AnimatedGameteView gamete={gamete} id={id} visibleGenes={visibleGenes}
                           initialDisplay={initial} display={tFinal}
                           animStiffness={animStiffness} onRest={onRest} />
     );

--- a/src/code/components/gamete-pool.js
+++ b/src/code/components/gamete-pool.js
@@ -1,7 +1,7 @@
 import React, {PropTypes} from 'react';
 import AnimatedGameteView from './animated-gamete';
 
-const GametePoolView = ({gametes, hiddenAlleles=[], width=300, height=200, animStiffness=60, selectedId, isGameteDisabled, onGameteSelected}) => {
+const GametePoolView = ({gametes, visibleGenes=[], width=300, height=200, animStiffness=60, selectedId, isGameteDisabled, onGameteSelected}) => {
   let gameteCount = gametes.length,
       gameteSize = 30,
       margin = 5,
@@ -44,7 +44,7 @@ const GametePoolView = ({gametes, hiddenAlleles=[], width=300, height=200, animS
           x = isDisabled ? col * xDisabledSpacing : col * xSpacing;
     return (
       <AnimatedGameteView gamete={gamete} id={index + 1} key={index}
-                          hiddenAlleles={hiddenAlleles}
+                          visibleGenes={visibleGenes}
                           initialDisplay={{ x: Math.round(width/2), y: -Math.round(ySpacing) }}
                           display={{ x: Math.round(x), y: Math.round(y) }}
                           animStiffness={animStiffness}
@@ -63,7 +63,7 @@ const GametePoolView = ({gametes, hiddenAlleles=[], width=300, height=200, animS
 
 GametePoolView.propTypes = {
   gametes: PropTypes.arrayOf(PropTypes.object).isRequired,
-  hiddenAlleles: PropTypes.arrayOf(PropTypes.string),
+  visibleGenes: PropTypes.arrayOf(PropTypes.string),
   width: PropTypes.number,
   height: PropTypes.number,
   animStiffness: PropTypes.number,

--- a/src/code/components/genome-test.js
+++ b/src/code/components/genome-test.js
@@ -1,6 +1,5 @@
 import React, {PropTypes} from 'react';
 import ChromosomeImageView from './chromosome-image';
-import GeneticsUtils from '../utilities/genetics-utils';
 
 let TestPulldownView = ({species, gene, selection, onSelectionChange}) => {
       let alleles = gene.alleles,
@@ -29,13 +28,14 @@ let TestPulldownView = ({species, gene, selection, onSelectionChange}) => {
       );
     };
 
-const GenomeTestView = ({org, hiddenAlleles=[], selection={}, onSelectionChange}) => {
-  let pairWrappers = [];
+const GenomeTestView = ({org, userChangeableGenes=[], selection={}, onSelectionChange}) => {
+  let pairWrappers = [],
+      allVisible = userChangeableGenes.length === 0;
   for (let chromosomeName of org.species.chromosomeNames) {
     let chrom = org.genetics.genotype.chromosomes[chromosomeName],
         alleles = chrom[Object.keys(chrom)[0]].alleles,
-        visibleAlleles = GeneticsUtils.filterAlleles(alleles, hiddenAlleles, org.species),
-        genes = visibleAlleles.map(a => BioLogica.Genetics.getGeneOfAllele(org.species, a)),
+        genes = alleles.map(a => BioLogica.Genetics.getGeneOfAllele(org.species, a))
+                        .filter(g => allVisible || userChangeableGenes.indexOf(g.name) > -1),
         pulldowns = genes.map(g => {
           return (
             <TestPulldownView
@@ -76,7 +76,7 @@ TestPulldownView.propTypes = {
 
 GenomeTestView.propTypes = {
   org: PropTypes.object.isRequired,
-  hiddenAlleles: PropTypes.array,
+  userChangeableGenes: PropTypes.array,
   selection: PropTypes.object,
   onSelectionChange: PropTypes.func.isRequired
 };

--- a/src/code/components/genome.js
+++ b/src/code/components/genome.js
@@ -7,7 +7,7 @@ import ChromosomeView from './chromosome';
  * Usually defined by passing in a Biologica Organism, but may also be defined by
  * passing in a map of Biologica Chromosomes and a Biologica Species.
  */
-const GenomeView = ({org, className="", chromosomes, species, hiddenAlleles = [], editable=true, showLabels=true, showAlleles=false, selectedChromosomes={}, small=false, orgName, displayStyle, onAlleleChange, onChromosomeSelected}) => {
+const GenomeView = ({org, className="", chromosomes, species, userChangeableGenes=[], visibleGenes=[], editable=true, showLabels=true, showAlleles=false, selectedChromosomes={}, small=false, orgName, displayStyle, onAlleleChange, onChromosomeSelected}) => {
   let pairWrappers = [];
   if (org) {
     chromosomes = org.genetics.genotype.chromosomes;
@@ -22,7 +22,8 @@ const GenomeView = ({org, className="", chromosomes, species, hiddenAlleles = []
         <ChromosomeView
           chromosome={chromosome}
           key={pairs.length + 1}
-          hiddenAlleles={hiddenAlleles}
+          userChangeableGenes={userChangeableGenes}
+          visibleGenes={visibleGenes}
           labelsOnRight={pairs.length>0 || side==="b"}
           editable={editable}
           selected={selectedChromosomes[chromosomeName] === side}
@@ -59,7 +60,8 @@ GenomeView.propTypes = {
   className: PropTypes.string,
   chromosomes: PropTypes.object,
   species: PropTypes.object,
-  hiddenAlleles: PropTypes.array,
+  userChangeableGenes: PropTypes.array,
+  visibleGenes: PropTypes.array,
   onAlleleChange: PropTypes.func,
   editable: PropTypes.bool,
   showLabels: PropTypes.bool,

--- a/src/code/containers/challenge-container.js
+++ b/src/code/containers/challenge-container.js
@@ -68,7 +68,8 @@ function mapStateToProps (state) {
       drakes: state.drakes,
       gametes: state.gametes,
       gametePools: state.gametePools,
-      hiddenAlleles: state.hiddenAlleles.asMutable(),
+      userChangeableGenes: state.userChangeableGenes,
+      visibleGenes: state.visibleGenes,
       baskets: state.baskets,
       trial: state.trial,
       trials: state.trials,
@@ -86,7 +87,7 @@ function mapDispatchToProps(dispatch) {
   return {
     onChromosomeAlleleChange: (index, chrom, side, prevAllele, newAllele) => dispatch(changeAllele(index, chrom, side, prevAllele, newAllele, true)),
     onSexChange: (index, newSex) => dispatch(changeSex(index, newSex, true)),
-    onDrakeSubmission: (targetPhenotype, userPhenotype, correct, incorrectAction) => 
+    onDrakeSubmission: (targetPhenotype, userPhenotype, correct, incorrectAction) =>
       dispatch(submitDrake(targetPhenotype, userPhenotype, correct, incorrectAction)),
     onNavigateNextChallenge: () => dispatch(navigateToNextChallenge()),
     onCompleteChallenge: () => dispatch(completeChallenge()),

--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -1,10 +1,14 @@
 import templates from '../../templates';
 
-function extractHiddenAlleles(state, authoredChallenge) {
-  const authoredHiddenAlleles = authoredChallenge.hiddenAlleles;
-  return authoredHiddenAlleles
-            ? authoredHiddenAlleles.split(',')
-            : state.hiddenAlleles;
+/**
+ * Tolerant splitter into a list of strings.
+ * @param list - null, "one, two" or ["one", "two"]
+ * returns ["one", "two"]
+ */
+function split(list) {
+  if (list && list.split) return list.split(",").map(item => item.trim());
+  if (list && list.constructor === Array) return list;
+  return [];
 }
 
 function processAuthoredBaskets(authoredChallenge, state) {
@@ -29,7 +33,7 @@ function processAuthoredDrakes(authoredChallenge, trial, template) {
       if (i === authoredChallenge.linkedGenes.drakes[0]) {
         linkedGeneDrake = drake;
       } else if (authoredChallenge.linkedGenes.drakes.indexOf(i)) {
-        let linkedGenes = authoredChallenge.linkedGenes.genes.split(",").map((g) => g.trim());
+        let linkedGenes = split(authoredChallenge.linkedGenes.genes);
         for (let gene of linkedGenes) {
           let copyIntoGenes = drake.genetics.genotype.getAlleleString([gene], drake.genetics);
           let masterGenes = linkedGeneDrake.genetics.genotype.getAlleleString([gene], drake.genetics);
@@ -61,7 +65,8 @@ export function loadStateFromAuthoring(state, authoring, progress={}) {
   const challengeType = authoredChallenge.challengeType,
         interactionType = authoredChallenge.interactionType,
         instructions = authoredChallenge.instructions,
-        hiddenAlleles = extractHiddenAlleles(state, authoredChallenge),
+        userChangeableGenes = split(authoredChallenge.userChangeableGenes),
+        visibleGenes = split(authoredChallenge.visibleGenes),
         baskets = processAuthoredBaskets(authoredChallenge, state),
         showUserDrake = (authoredChallenge.showUserDrake != null) ? authoredChallenge.showUserDrake : false,
         trials = authoredChallenge.targetDrakes,
@@ -83,7 +88,8 @@ export function loadStateFromAuthoring(state, authoring, progress={}) {
     interactionType,
     instructions,
     showUserDrake,
-    hiddenAlleles,
+    userChangeableGenes,
+    visibleGenes,
     baskets,
     drakes,
     gametes,
@@ -109,7 +115,8 @@ export function loadNextTrial(state, authoring, progress) {
   let authoredChallenge = authoring[state.case][state.challenge],
       templateName = state.template,
       template = templates[templateName],
-      hiddenAlleles = extractHiddenAlleles(state, authoredChallenge),
+      userChangeableGenes = split(authoredChallenge.userChangeableGenes),
+      visibleGenes = split(authoredChallenge.visibleGenes),
       baskets = authoredChallenge.baskets || state.baskets,
       drakes = processAuthoredDrakes(authoredChallenge, trial, template);
 
@@ -119,7 +126,8 @@ export function loadNextTrial(state, authoring, progress) {
   }
 
   return state.merge({
-    hiddenAlleles,
+    userChangeableGenes,
+    visibleGenes,
     baskets,
     drakes,
     trial,

--- a/src/code/reducers/index.js
+++ b/src/code/reducers/index.js
@@ -18,7 +18,8 @@ import notifications from './notifications';
 function initialState() {
   return Immutable({
             template: null,
-            hiddenAlleles: ['t','tk','h','c','a','b','d','bog','rh'],
+            userChangeableGenes: [],
+            visibleGenes: [],
             trial: 0,
             case: 0,
             challenge: 0,

--- a/src/code/templates/egg-game.js
+++ b/src/code/templates/egg-game.js
@@ -745,7 +745,7 @@ export default class EggGame extends Component {
 
   render() {
     const { challengeType, interactionType, instructions, showUserDrake, trial, drakes, gametes, gametePools,
-            hiddenAlleles, userDrakeHidden, onChromosomeAlleleChange,
+            userChangeableGenes, visibleGenes, userDrakeHidden, onChromosomeAlleleChange,
             onFertilize, onHatch, onResetGametes, onKeepOffspring, onDrakeSubmission } = this.props,
           { isIntroComplete, animatingGametes } = this.state,
           firstTargetDrakeIndex = 3, // 0: mother, 1: father, 2: child, 3-5: targets
@@ -959,7 +959,7 @@ export default class EggGame extends Component {
                               : { orgName: 'father', org: father,
                                   selectedChromosomes: fatherSelectedChromosomes };
       return <GenomeView className={parentGenomeClass}  {...uniqueProps}
-                        small={ true } editable={false} hiddenAlleles={ hiddenAlleles }
+                        small={ true } editable={false} userChangeableGenes={ userChangeableGenes } visibleGenes={ visibleGenes }
                         onAlleleChange={ handleAlleleChange }
                         onChromosomeSelected={_this.handleChromosomeSelected} />;
     }
@@ -971,7 +971,7 @@ export default class EggGame extends Component {
                               : { orgName: 'targetfather', chromosomes: maleGameteChromosomeMap,
                                   selectedChromosomes: spermSelected };
       return <GenomeView className={childGenomeClass} species={mother.species} {...uniqueProps}
-                        editable={false} hiddenAlleles={hiddenAlleles}
+                        editable={false} userChangeableGenes={ userChangeableGenes } visibleGenes={ visibleGenes }
                         small={true} displayStyle={chromosomeDisplayStyle} />;
     }
 
@@ -1081,7 +1081,8 @@ export default class EggGame extends Component {
     drakes: PropTypes.array.isRequired,
     gametes: PropTypes.array.isRequired,
     gametePools: PropTypes.array,
-    hiddenAlleles: PropTypes.array.isRequired,
+    userChangeableGenes: PropTypes.array.isRequired,
+    visibleGenes: PropTypes.array.isRequired,
     userDrakeHidden: PropTypes.bool,
     onChromosomeAlleleChange: PropTypes.func.isRequired,
     onGameteChromosomeAdded: PropTypes.func.isRequired,

--- a/src/code/templates/egg-sort-game.js
+++ b/src/code/templates/egg-sort-game.js
@@ -111,7 +111,7 @@ let animationEvents = {
           _this.handleBasketClick(targetBasketIndex, targetBasket);
           evt.stopPropagation();
         }
-        
+
         appendAnimation('fadeDrakeAway',
           <SlowEggHatch
               egg={animatingEgg} organism={animatingDrake} glow={true}
@@ -207,7 +207,8 @@ export default class EggSortGame extends Component {
     challenge: PropTypes.number.isRequired,
     trial: PropTypes.number.isRequired,
     drakes: PropTypes.array.isRequired,
-    hiddenAlleles: PropTypes.array.isRequired,
+    userChangeableGenes: PropTypes.array.isRequired,
+    visibleGenes: PropTypes.array.isRequired,
     baskets: PropTypes.array.isRequired,
     correct: PropTypes.number,
     errors: PropTypes.number,
@@ -333,7 +334,7 @@ export default class EggSortGame extends Component {
   }
 
   render() {
-    const { hiddenAlleles, drakes, baskets, correct, errors } = this.props,
+    const { userChangeableGenes, visibleGenes, drakes, baskets, correct, errors } = this.props,
           { animation, animatedComponents, eggs } = this.state,
           selectedBaskets = this.selectedBaskets(),
           { index: selectedEggIndex, egg: selectedEgg } = this.selectedEgg(),
@@ -363,7 +364,7 @@ export default class EggSortGame extends Component {
                                   </div>
                                 : null,
           genomeView = selectedEgg
-                        ? <GenomeView org={selectedEgg} hiddenAlleles={hiddenAlleles} editable={false} />
+                        ? <GenomeView org={selectedEgg} userChangeableGenes={userChangeableGenes} visibleGenes={visibleGenes} editable={false} />
                         : null,
           genomeOrInstructionsView = selectedEgg ? genomeView : instructionsView,
           disableSelection = (['moveEggToBasket', 'hatchDrakeInBasket', 'hatchDrakeInEgg']

--- a/src/code/templates/genome-challenge.js
+++ b/src/code/templates/genome-challenge.js
@@ -14,7 +14,7 @@ export default class GenomeChallengeTemplate extends Component {
 
   render() {
     const { drakes, instructions, onChromosomeAlleleChange, onSexChange, onDrakeSubmission,
-            hiddenAlleles, showUserDrake, userDrakeHidden, trial, trials } = this.props,
+            userChangeableGenes, visibleGenes, showUserDrake, userDrakeHidden, trial, trials } = this.props,
           userDrakeDef = drakes[userDrakeIndex],
           targetDrakeDef = drakes[targetDrakeIndex],
           userDrake   = new BioLogica.Organism(BioLogica.Species.Drake, userDrakeDef.alleleString, userDrakeDef.sex),
@@ -57,7 +57,7 @@ export default class GenomeChallengeTemplate extends Component {
         </div>
         <div className='column'>
           <div id="your-drake-label" className="column-label">Chromosome Control</div>
-          <GenomeView org={ userDrake } onAlleleChange={ handleAlleleChange } hiddenAlleles= { hiddenAlleles } />
+          <GenomeView org={ userDrake } onAlleleChange={ handleAlleleChange } userChangeableGenes= { userChangeableGenes } visibleGenes={ visibleGenes }/>
           <ButtonView label="~BUTTON.CHECK_DRAKE" onClick={ handleSubmit } />
         </div>
       </div>
@@ -67,7 +67,8 @@ export default class GenomeChallengeTemplate extends Component {
   static propTypes = {
     instructions: PropTypes.string,
     drakes: PropTypes.array.isRequired,
-    hiddenAlleles: PropTypes.array.isRequired,
+    userChangeableGenes: PropTypes.array.isRequired,
+    visibleGenes: PropTypes.array.isRequired,
     trial: PropTypes.number.isRequired,
     trials: PropTypes.array.isRequired,
     moves: PropTypes.number.isRequired,

--- a/src/code/templates/genome-playground.js
+++ b/src/code/templates/genome-playground.js
@@ -7,7 +7,7 @@ import ChangeSexButtons from '../components/change-sex-buttons';
 export default class GenomeContainer extends Component {
 
   render() {
-    const { drakes, onChromosomeAlleleChange, onSexChange, onCompleteChallenge, hiddenAlleles } = this.props,
+    const { drakes, onChromosomeAlleleChange, onSexChange, onCompleteChallenge, userChangeableGenes, visibleGenes } = this.props,
           drakeDef = drakes[0].alleleString,
           drakeSex = drakes[0].sex,
           drake = new BioLogica.Organism(BioLogica.Species.Drake, drakeDef, drakeSex);
@@ -28,7 +28,7 @@ export default class GenomeContainer extends Component {
       <div id="genome-playground">
         <div className='column'>
             <ChangeSexButtons id="change-sex-buttons" sex={ drakeSex } onChange= { handleSexChange } showLabel={true} species="Drake" />
-            <GenomeView className="drake-genome" org={ drake } onAlleleChange={ handleAlleleChange } hiddenAlleles= { hiddenAlleles } />
+            <GenomeView className="drake-genome" org={ drake } onAlleleChange={ handleAlleleChange } userChangeableGenes= { userChangeableGenes } visibleGenes={ visibleGenes }/>
         </div>
         <div className='column'>
             <OrganismGlowView id="drake-image" org={ drake } />
@@ -40,7 +40,8 @@ export default class GenomeContainer extends Component {
 
   static propTypes = {
     drakes: PropTypes.array.isRequired,
-    hiddenAlleles: PropTypes.array.isRequired,
+    userChangeableGenes: PropTypes.array.isRequired,
+    visibleGenes: PropTypes.array.isRequired,
     onChromosomeAlleleChange: PropTypes.func.isRequired,
     onSexChange: PropTypes.func.isRequired,
     onCompleteChallenge: PropTypes.func.isRequired

--- a/src/code/utilities/genetics-utils.js
+++ b/src/code/utilities/genetics-utils.js
@@ -169,6 +169,30 @@ export default class GeneticsUtils {
   }
 
   /**
+   * Filters out hidden alleles, given a list of changeable and visible genes.
+   * Returns array of objects with the allele and the editability
+   *
+   * @param {string[]} alleles - the set of alleles to be filtered
+   * @param {string[]} userChangeableGenes - genes that the user can edit (if the template allows)
+   * @param {string[]} visibleGenes - genes that the user can view (already includes the above list)
+   * @param {BioLogica.species} species - the species that defines the genotype
+   * @return {obj[]} - the filtered alleles, where each is an object with a name and whether it is editable
+   */
+  static filterVisibleAlleles(alleles, userChangeableGenes, visibleGenes, species) {
+    let showAll = userChangeableGenes.length + visibleGenes.length === 0;
+    return alleles.filter(a => {
+      if (showAll) return true;
+
+      const gene = BioLogica.Genetics.getGeneOfAllele(species, a),
+            geneName = gene ? gene.name : null;
+      return userChangeableGenes.indexOf(geneName) > -1 || visibleGenes.indexOf(geneName) > -1;
+    }).map(a => ({
+      allele: a,
+      editable: userChangeableGenes.indexOf(BioLogica.Genetics.getGeneOfAllele(species, a).name) > -1
+    }));
+  }
+
+  /**
    * Compute a map of traits -> traitValues -> traitCounts.
    *
    * @param {BioLogica.Organism[]} organisms - the set of organisms to compute stats for

--- a/src/code/utilities/genetics-utils.js
+++ b/src/code/utilities/genetics-utils.js
@@ -153,22 +153,6 @@ export default class GeneticsUtils {
   }
 
   /**
-   * Filters out hidden alleles from an original list of alleles
-   *
-   * @param {string[]} alleles - the set of alleles to be filtered
-   * @param {string[]} hiddenAlleles - the alleles identifying the hidden genes
-   * @param {BioLogica.species} species - the species that defines the genotype
-   * @return {string[]} - the filtered alleles
-   */
-  static filterAlleles(alleles, hiddenAlleles, species) {
-    const hiddenGenes = hiddenAlleles.map(a => BioLogica.Genetics.getGeneOfAllele(species, a));
-    return alleles.filter(a => {
-      const gene = BioLogica.Genetics.getGeneOfAllele(species, a);
-      return hiddenGenes.indexOf(gene) === -1;
-    });
-  }
-
-  /**
    * Filters out hidden alleles, given a list of changeable and visible genes.
    * Returns array of objects with the allele and the editability
    *

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -7,7 +7,8 @@
         "alleles": "T-T, w-w, h-h, A1-A1, C-C, B-B, D-D, rh-rh, Bog-Bog",
         "sex": 1
       },
-      "hiddenAlleles": "t,tk,h,c,a,b,d,bog,rh"
+      "userChangeableGenes": "metallic, wings, forelimbs, hindlimbs",
+      "visibleGenes": "nose",
     },
     {
       "comment": "*** Case 1: Challenge 2 - Single Drake (User Drake Visible) ***",
@@ -22,7 +23,7 @@
         "alleles": "w-, m-m, fl-, hl-",
         "sex": 1
       }],
-      "hiddenAlleles": "t,tk,h,c,a,b,d,bog,rh",
+      "userChangeableGenes": "metallic, wings, forelimbs, hindlimbs",
       "linkedGenes": {
         "drakes": [0, 1],
         "genes": "tail, horns, color, black, dilute, armor, nose, bogbreath"
@@ -41,7 +42,7 @@
         "alleles": "w-, m-m, fl-, hl-, T-T, h-h, C-C, A1-A1, B-B, D-D, rh-rh, Bog-Bog",
         "sex": 1
       }],
-      "hiddenAlleles": "t,tk,h,c,a,b,d,bog,rh"
+      "userChangeableGenes": "metallic, wings, forelimbs, hindlimbs",
     },
     {
       "comment": "*** Case 1: Challenge 4 - Three Drakes (User Drake Hidden) ***",
@@ -64,7 +65,7 @@
         ]
       },
       "targetDrakes": [{},{},{}],
-      "hiddenAlleles": "t,tk,h,c,a,b,d,bog,rh"
+      "userChangeableGenes": "metallic, wings, forelimbs, hindlimbs",
     }
   ],
   [
@@ -100,7 +101,7 @@
         "alleles": "w-W, m-m, T-T, h-h, A1-A1, C-C, B-B, D-D, rh-rh, Bog-Bog",
         "sex": 0
       },
-      "hiddenAlleles": "t,tk,h,c,a,b,d,bog,rh"
+      "visibleGenes": "metallic, wings, forelimbs, hindlimbs",
     }
   ],
   [
@@ -119,7 +120,7 @@
         "sex": 0
       },
       "targetDrakes": [{},{},{}],
-      "hiddenAlleles": "t,tk,h,c,a,b,d,bog,rh"
+      "visibleGenes": "metallic, wings, forelimbs, hindlimbs",
     },
     {
       "comment": "*** Case 3: Challenge 2 - Egg Game II (match three drakes, user drake hidden) ***",
@@ -136,7 +137,7 @@
         "sex": 0
       },
       "targetDrakes": [{},{},{}],
-      "hiddenAlleles": "t,tk,h,c,a,b,d,bog,rh"
+      "visibleGenes": "metallic, wings, forelimbs, hindlimbs",
     }
   ],
   [
@@ -157,7 +158,7 @@
           { "alleles": "w-w", "sex": 1 }
         ]
       },
-      "hiddenAlleles": "t,m,h,c,b,fl,hl,a,d,bog,rh",
+      "visibleGenes": "wings",
       "baskets": [
         { "label": "Males with wings", "alleles": ["W-","-W"], "sex": 0 },
         { "label": "Males without wings", "alleles": ["w-w"], "sex": 0 },
@@ -182,7 +183,7 @@
           { "alleles": "Fl-Fl, Hl-Hl" }
         ]
       },
-      "hiddenAlleles": "t,m,w,h,c,b,a,d,bog,rh",
+      "visibleGenes": "forelimbs, hindlimbs",
       "baskets": [
         { "label": "Drakes with only forelimbs", "alleles": ["Fl-, hl-hl", "-Fl, hl-hl"] },
         { "label": "Drakes with only hindlimbs", "alleles": ["fl-fl, Hl-", "fl-fl, -Hl"] },
@@ -208,7 +209,7 @@
           { "alleles": "h-h", "sex": 1 }
         ]
       },
-      "hiddenAlleles": "w,t,m,c,b,fl,hl,a,d,bog,rh",
+      "visibleGenes": "horns",
       "baskets": [
         { "label": "Males with horns", "alleles": ["h-h"], "sex": 0 },
         { "label": "Males without horns", "alleles": ["H-","-H"], "sex": 0 },
@@ -233,7 +234,7 @@
           { "alleles": "a-a", "sex": 1 }
         ]
       },
-      "hiddenAlleles": "t,m,w,h,c,b,fl,hl,d,bog,rh",
+      "visibleGenes": "armor",
       "baskets": [
         { "label": "Drakes with no armor plates", "alleles": ["a-a"] },
         { "label": "Drakes with three armor plates", "alleles": ["A1-a", "a-A1"] },
@@ -257,7 +258,7 @@
           { "alleles": "H-H, w-W, a-a" }
         ]
       },
-      "hiddenAlleles": "t,m,c,b,fl,hl,d,bog,rh",
+      "visibleGenes": "horns, wings, armor",
       "baskets": [
         { "label": "Drakes with horns", "alleles": ["h-h"] },
         { "label": "Drakes with wings", "alleles": ["W-", "-W"] },

--- a/test/components/allele-filters.js
+++ b/test/components/allele-filters.js
@@ -13,7 +13,7 @@ describe("<AlleleFilters />", function(){
         geneCount = Object.keys(geneList).length,
         alleleCount = Object.keys(geneList).reduce((sum, g) => sum += geneList[g].alleles.length, 0);
 
-  it("should create appropriate elements when no alleles are hidden or disabled", function() {
+  it("should create appropriate elements when no visible genes are specified", function() {
     const wrapper = shallow(<AlleleFilters species={BioLogica.Species.Drake}
                                           onFilterChange={function() {}}/>),
           checkboxWrapper = wrapper.find('input[type="checkbox"]'),
@@ -23,17 +23,18 @@ describe("<AlleleFilters />", function(){
     assert.lengthOf(checkedWrapper, alleleCount, "correct number of checked alleles");
   });
 
-  it("should create appropriate elements when alleles are hidden and/or disabled", function() {
+  it("should create appropriate elements when visible genes are specified and alleles are disabled", function() {
     const wrapper = shallow(<AlleleFilters species={BioLogica.Species.Drake}
-                                          hiddenAlleles={['T']} disabledAlleles={['A1', 'A2', 'a']}
+                                          visibleGenes={['tail', 'armor']} disabledAlleles={['A1', 'A2']}
                                           onFilterChange={function() {}}/>),
           checkboxWrapper = wrapper.find('input[type="checkbox"]'),
           checkedWrapper = checkboxWrapper.filterWhere(w => w.prop('defaultChecked'));
-    assert.lengthOf(wrapper.find('div.gene-allele-list'), geneCount - 1, "correct number of 'gene-allele-list' elements");
-                                    // -3 for hidden tail alleles
-    assert.lengthOf(checkboxWrapper, alleleCount - 3, "correct number of allele checkboxes");
-                                    // -3 for hidden tail alleles, -3 for disabled armor alleles
-    assert.lengthOf(checkedWrapper, alleleCount - 6, "correct number of checked alleles");
+                                    // just tail and armor
+    assert.lengthOf(wrapper.find('div.gene-allele-list'), 2, "correct number of 'gene-allele-list' elements");
+                                    // 3 tail 3 armor
+    assert.lengthOf(checkboxWrapper, 6, "correct number of allele checkboxes");
+                                    // -2 disabled armor alleles
+    assert.lengthOf(checkedWrapper, 4, "correct number of checked alleles");
   });
 
   it("onFilterChange() should be called when checkboxes are clicked", function() {

--- a/test/components/chromosome.js
+++ b/test/components/chromosome.js
@@ -40,6 +40,49 @@ describe("<ChromosomeView />", function(){
     assert.lengthOf(allelesWrapper, 1, "should create 1 <div> with 'alleles' class");
   });
 
+  it("should create appropriate labels and alleles when we don't specify changeable or visible genes", function() {
+    const wrapper = shallow(<ChromosomeView org={drake} chromosomeName='1' side='a' showAlleles={true}/>),
+          labels = wrapper.find('GeneLabelView'),
+          alleles = wrapper.find('AlleleView');
+    assert.lengthOf(labels, 4, "should create 4 GeneLabelViews");
+    assert.lengthOf(alleles, 4, "should create 4 AlleleViews");
+    for (let label of labels) {
+      assert.isFalse(label.props.editable);
+    }
+  });
+
+  it("should create appropriate labels and alleles when we only specify changeable genes", function() {
+    const wrapper = shallow(<ChromosomeView org={drake} chromosomeName='1' side='a' userChangeableGenes={["wings", "tail"]} showAlleles={true}/>),
+          labels = wrapper.find('GeneLabelView'),
+          alleles = wrapper.find('AlleleView');
+    assert.lengthOf(labels, 2, "should create 2 GeneLabelViews");
+    assert.lengthOf(alleles, 2, "should create 2 AlleleViews");
+    for (let label of labels) {
+      assert.isTrue(label.props.editable);
+    }
+  });
+
+  it("should create appropriate labels and alleles when we only specify visible genes", function() {
+    const wrapper = shallow(<ChromosomeView org={drake} chromosomeName='1' side='a' visibleGenes={["wings", "tail"]} showAlleles={true}/>),
+          labels = wrapper.find('GeneLabelView'),
+          alleles = wrapper.find('AlleleView');
+    assert.lengthOf(labels, 2, "should create 2 GeneLabelViews");
+    assert.lengthOf(alleles, 2, "should create 2 AlleleViews");
+    for (let label of labels) {
+      assert.isFalse(label.props.editable);
+    }
+  });
+
+  it("should create appropriate labels and alleles when we specify changeable and visible genes", function() {
+    const wrapper = shallow(<ChromosomeView org={drake} chromosomeName='1' side='a' userChangeableGenes={["wings", "tail"]} visibleGenes={["horns"]} showAlleles={true}/>),
+          labels = wrapper.find('GeneLabelView'),
+          alleles = wrapper.find('AlleleView'),
+          editableLabels = wrapper.find('GeneLabelView[editable=true]');
+    assert.lengthOf(labels, 3, "should create 3 GeneLabelViews");
+    assert.lengthOf(alleles, 3, "should create 3 AlleleViews");
+    assert.lengthOf(editableLabels, 2, "should create 2 editable GeneLabelViews");
+  });
+
   it("should create a <ChromosomeImageView> tag", function() {
     const wrapper = shallow(<ChromosomeView org={drake} chromosomeName='1' side='a'/>);
     assert.lengthOf(wrapper.find('ChromosomeImageView'), 1, "Should create a single <ChromosomeImageView> component");

--- a/test/components/genome-test.js
+++ b/test/components/genome-test.js
@@ -12,7 +12,7 @@ describe("<GenomeTestView />", function(){
     assert(wrapper.find('div').at(0).hasClass('genome-test'), "Should create a <div> with 'genome-test' class");
   });
 
-  it("should create appropriate child components with no filtering", function() {
+  it("should create appropriate child components when all genes are visible", function() {
     const wrapper = shallow(<GenomeTestView org={drake} onSelectionChange={function() {}}/>);
     assert.lengthOf(wrapper.find('div.items'), chromosomeNameCount, "Should create three <div>s with 'items' class");
     assert.lengthOf(wrapper.find('div.genome-test-options'), chromosomeNameCount, "Should create three <div>s with 'genome-test-options' class");
@@ -20,15 +20,13 @@ describe("<GenomeTestView />", function(){
     assert.lengthOf(wrapper.find('TestPulldownView'), geneCount, "Should create a <TestPulldownView> component for each gene");
   });
 
-  it("should create appropriate child components with allele filtering", function() {
-    const wrapper = shallow(<GenomeTestView org={drake} hiddenAlleles={['t', 'a']}
-                                            onSelectionChange={function() {}}/>),
-          hiddenGeneCount = 2,  // tail and armor genes are hidden
-          filteredGeneCount = Object.keys(BioLogica.Species.Drake.geneList).length - hiddenGeneCount;
+  it("should create appropriate child components when selected genes are visible", function() {
+    const wrapper = shallow(<GenomeTestView org={drake} userChangeableGenes={['tail', 'wings']}
+                                            onSelectionChange={function() {}}/>);
     assert.lengthOf(wrapper.find('div.items'), chromosomeNameCount, "Should create three <div>s with 'items' class");
     assert.lengthOf(wrapper.find('div.genome-test-options'), chromosomeNameCount, "Should create three <div>s with 'genome-test-options' class");
     assert.lengthOf(wrapper.find('ChromosomeImageView'), chromosomeCount, "Should create six <ChromosomeImageView> components");
-    assert.lengthOf(wrapper.find('TestPulldownView'), filteredGeneCount, "Should create a <TestPulldownView> component for each visible gene");
+    assert.lengthOf(wrapper.find('TestPulldownView'), 2, "Should create a <TestPulldownView> component for each visible gene");
   });
 
 });

--- a/test/utilities/genetics-utils.js
+++ b/test/utilities/genetics-utils.js
@@ -136,24 +136,17 @@ describe("GeneticsUtils.isCompleteAlleleString()", function() {
   });
 });
 
-describe("GeneticsUtils.filterAlleles()", function() {
-  const initialAlleles = ['T', 't', 'A1', 'a'];
+describe("GeneticsUtils.filterVisibleAlleles()", function() {
+  const initialAlleles = ['Tk', 'A1', 'w'];
 
-  it("should return the original array when not filtering", function() {
-    const filteredAlleles = GeneticsUtils.filterAlleles(initialAlleles, [], BioLogica.Species.Drake);
-    assert.deepEqual(filteredAlleles, initialAlleles, "result should be the original alleles");
+  it("should return all alleles, each as non-editable, when not filtering", function() {
+    const filteredAlleles = GeneticsUtils.filterVisibleAlleles(initialAlleles, [], [], BioLogica.Species.Drake);
+    assert.deepEqual(filteredAlleles, [{allele: 'Tk', editable: false}, {allele: 'A1', editable: false}, {allele: 'w', editable: false}], "result should be the original alleles");
   });
 
-  it("should return the original array when filtering by alleles not present", function() {
-    const filteredAlleles = GeneticsUtils.filterAlleles(initialAlleles, ['w'], BioLogica.Species.Drake);
-    assert.deepEqual(filteredAlleles, initialAlleles, "result should be the original alleles");
-  });
-
-  it("should remove all alleles of a gene when hiding any allele of that gene", function() {
-    const armorAlleles = GeneticsUtils.filterAlleles(initialAlleles, ['t'], BioLogica.Species.Drake);
-    assert.deepEqual(armorAlleles, ['A1', 'a'], "should remove all tail alleles");
-    const noAlleles = GeneticsUtils.filterAlleles(initialAlleles, ['t', 'a'], BioLogica.Species.Drake);
-    assert.deepEqual(noAlleles, [], "should remove all tail alleles");
+  it("should return correct editable and non-editable alleles when filtering", function() {
+    const filteredAlleles = GeneticsUtils.filterVisibleAlleles(initialAlleles, ['tail'], ['armor'], BioLogica.Species.Drake);
+    assert.deepEqual(filteredAlleles, [{allele: 'Tk', editable: true}, {allele: 'A1', editable: false}], "should remove all tail alleles");
   });
 
 });


### PR DESCRIPTION
This replaces `hiddenAlleles` across GeniBlocks with `userChangeableGenes` and `visibleGenes`, which specify, using gene names, genes which the user may modify (if the view allows) and additional genes that the user can see.

Updated GB example components, tests, and authoring.

https://www.pivotaltracker.com/story/show/137548373