### PR TITLE
Hidden alleles

### DIFF
--- a/examples/basic-examples/chromosomes.html
+++ b/examples/basic-examples/chromosomes.html
@@ -85,6 +85,7 @@
             showAlleles: true,
             userChangeableGenes: ["tail", "metallic"],
             visibleGenes: ["wings"],
+            hiddenAlleles: ["T"],
             onAlleleChange
           }),
           document.getElementById('chromosome-selective')

--- a/examples/basic-examples/chromosomes.html
+++ b/examples/basic-examples/chromosomes.html
@@ -98,7 +98,7 @@
         );
       }
 
-      dragon = new BioLogica.Organism(BioLogica.Species.Drake, "", 0);
+      dragon = new BioLogica.Organism(BioLogica.Species.Drake, "a:Tk/t", 0);
       render();
     </script>
   </body>

--- a/src/code/components/chromosome.js
+++ b/src/code/components/chromosome.js
@@ -10,7 +10,7 @@ import GeneticsUtils from '../utilities/genetics-utils';
  * chromosome name and side.
  */
 
-const ChromosomeView = ({chromosome, org, chromosomeName, side, userChangeableGenes = [], visibleGenes = [], small = false, editable = true, selected = false, onAlleleChange, onChromosomeSelected, showLabels = true, showAlleles = false, labelsOnRight = true, orgName, displayStyle = {}}) => {
+const ChromosomeView = ({chromosome, org, chromosomeName, side, userChangeableGenes = [], visibleGenes = [], hiddenAlleles = [], small = false, editable = true, selected = false, onAlleleChange, onChromosomeSelected, showLabels = true, showAlleles = false, labelsOnRight = true, orgName, displayStyle = {}}) => {
   var containerClass = "items",
       empty = false,
       yChromosome = false,
@@ -28,6 +28,7 @@ const ChromosomeView = ({chromosome, org, chromosomeName, side, userChangeableGe
       let labels = visibleAlleles.map(a => {
         return (
           <GeneLabelView key={a.allele} species={chromosome.species} allele={a.allele} editable={editable && a.editable}
+          hiddenAlleles={ hiddenAlleles }
           onAlleleChange={function(event) {
             onAlleleChange(a.allele, event.target.value);
           }}/>
@@ -94,6 +95,7 @@ ChromosomeView.propTypes = {
   chromosome: PropTypes.object,
   userChangeableGenes: PropTypes.array,
   visibleGenes: PropTypes.array,
+  hiddenAlleles: PropTypes.array,
   small: PropTypes.bool,
   editable: PropTypes.bool,
   selected: PropTypes.bool,

--- a/src/code/components/gene-label.js
+++ b/src/code/components/gene-label.js
@@ -1,6 +1,6 @@
 import React, {PropTypes} from 'react';
 
-const GeneLabelView = ({species, allele, editable=false, onAlleleChange}) => {
+const GeneLabelView = ({species, allele, editable=false, hiddenAlleles=[], onAlleleChange}) => {
   if (!editable) {
     const alleleName = species.alleleLabelMap[allele];
     return (
@@ -12,9 +12,10 @@ const GeneLabelView = ({species, allele, editable=false, onAlleleChange}) => {
     );
   } else {
     const alleles = BioLogica.Genetics.getGeneOfAllele(species, allele).alleles,
-          alleleNames = alleles.map(a => species.alleleLabelMap[a]),
+          visibleAlleles = alleles.filter(a => hiddenAlleles.indexOf(a) === -1),
+          alleleNames = visibleAlleles.map(a => species.alleleLabelMap[a]),
           alleleOptions = alleleNames.map((name, i) => (
-                            <option key={name} value={alleles[i]}>{name}</option>)
+                            <option key={name} value={visibleAlleles[i]}>{name}</option>)
                           );
     return (
       <div className="geniblocks gene-label allele editable">
@@ -30,6 +31,7 @@ GeneLabelView.propTypes = {
   species: PropTypes.object.isRequired,
   allele: PropTypes.string.isRequired,
   editable: PropTypes.bool,
+  hiddenAlleles: PropTypes.array,
   onAlleleChange: PropTypes.func
 };
 

--- a/src/code/components/genome.js
+++ b/src/code/components/genome.js
@@ -7,7 +7,7 @@ import ChromosomeView from './chromosome';
  * Usually defined by passing in a Biologica Organism, but may also be defined by
  * passing in a map of Biologica Chromosomes and a Biologica Species.
  */
-const GenomeView = ({org, className="", chromosomes, species, userChangeableGenes=[], visibleGenes=[], editable=true, showLabels=true, showAlleles=false, selectedChromosomes={}, small=false, orgName, displayStyle, onAlleleChange, onChromosomeSelected}) => {
+const GenomeView = ({org, className="", chromosomes, species, userChangeableGenes=[], visibleGenes=[], hiddenAlleles=[], editable=true, showLabels=true, showAlleles=false, selectedChromosomes={}, small=false, orgName, displayStyle, onAlleleChange, onChromosomeSelected}) => {
   let pairWrappers = [];
   if (org) {
     chromosomes = org.genetics.genotype.chromosomes;
@@ -24,6 +24,7 @@ const GenomeView = ({org, className="", chromosomes, species, userChangeableGene
           key={pairs.length + 1}
           userChangeableGenes={userChangeableGenes}
           visibleGenes={visibleGenes}
+          hiddenAlleles={hiddenAlleles}
           labelsOnRight={pairs.length>0 || side==="b"}
           editable={editable}
           selected={selectedChromosomes[chromosomeName] === side}
@@ -62,6 +63,7 @@ GenomeView.propTypes = {
   species: PropTypes.object,
   userChangeableGenes: PropTypes.array,
   visibleGenes: PropTypes.array,
+  hiddenAlleles: PropTypes.array,
   onAlleleChange: PropTypes.func,
   editable: PropTypes.bool,
   showLabels: PropTypes.bool,

--- a/src/code/containers/challenge-container.js
+++ b/src/code/containers/challenge-container.js
@@ -70,6 +70,7 @@ function mapStateToProps (state) {
       gametePools: state.gametePools,
       userChangeableGenes: state.userChangeableGenes,
       visibleGenes: state.visibleGenes,
+      hiddenAlleles: state.hiddenAlleles,
       baskets: state.baskets,
       trial: state.trial,
       trials: state.trials,

--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -67,6 +67,7 @@ export function loadStateFromAuthoring(state, authoring, progress={}) {
         instructions = authoredChallenge.instructions,
         userChangeableGenes = split(authoredChallenge.userChangeableGenes),
         visibleGenes = split(authoredChallenge.visibleGenes),
+        hiddenAlleles = split(authoredChallenge.hiddenAlleles),
         baskets = processAuthoredBaskets(authoredChallenge, state),
         showUserDrake = (authoredChallenge.showUserDrake != null) ? authoredChallenge.showUserDrake : false,
         trials = authoredChallenge.targetDrakes,
@@ -90,6 +91,7 @@ export function loadStateFromAuthoring(state, authoring, progress={}) {
     showUserDrake,
     userChangeableGenes,
     visibleGenes,
+    hiddenAlleles,
     baskets,
     drakes,
     gametes,
@@ -117,6 +119,7 @@ export function loadNextTrial(state, authoring, progress) {
       template = templates[templateName],
       userChangeableGenes = split(authoredChallenge.userChangeableGenes),
       visibleGenes = split(authoredChallenge.visibleGenes),
+      hiddenAlleles = split(authoredChallenge.hiddenAlleles),
       baskets = authoredChallenge.baskets || state.baskets,
       drakes = processAuthoredDrakes(authoredChallenge, trial, template);
 
@@ -128,6 +131,7 @@ export function loadNextTrial(state, authoring, progress) {
   return state.merge({
     userChangeableGenes,
     visibleGenes,
+    hiddenAlleles,
     baskets,
     drakes,
     trial,

--- a/src/code/reducers/index.js
+++ b/src/code/reducers/index.js
@@ -20,6 +20,7 @@ function initialState() {
             template: null,
             userChangeableGenes: [],
             visibleGenes: [],
+            hiddenAlleles: [],
             trial: 0,
             case: 0,
             challenge: 0,

--- a/src/code/templates/genome-challenge.js
+++ b/src/code/templates/genome-challenge.js
@@ -14,7 +14,7 @@ export default class GenomeChallengeTemplate extends Component {
 
   render() {
     const { drakes, instructions, onChromosomeAlleleChange, onSexChange, onDrakeSubmission,
-            userChangeableGenes, visibleGenes, showUserDrake, userDrakeHidden, trial, trials } = this.props,
+            userChangeableGenes, visibleGenes, hiddenAlleles, showUserDrake, userDrakeHidden, trial, trials } = this.props,
           userDrakeDef = drakes[userDrakeIndex],
           targetDrakeDef = drakes[targetDrakeIndex],
           userDrake   = new BioLogica.Organism(BioLogica.Species.Drake, userDrakeDef.alleleString, userDrakeDef.sex),
@@ -57,7 +57,7 @@ export default class GenomeChallengeTemplate extends Component {
         </div>
         <div className='column'>
           <div id="your-drake-label" className="column-label">Chromosome Control</div>
-          <GenomeView org={ userDrake } onAlleleChange={ handleAlleleChange } userChangeableGenes= { userChangeableGenes } visibleGenes={ visibleGenes }/>
+          <GenomeView org={ userDrake } onAlleleChange={ handleAlleleChange } userChangeableGenes= { userChangeableGenes } visibleGenes={ visibleGenes } hiddenAlleles={ hiddenAlleles }/>
           <ButtonView label="~BUTTON.CHECK_DRAKE" onClick={ handleSubmit } />
         </div>
       </div>
@@ -69,6 +69,7 @@ export default class GenomeChallengeTemplate extends Component {
     drakes: PropTypes.array.isRequired,
     userChangeableGenes: PropTypes.array.isRequired,
     visibleGenes: PropTypes.array.isRequired,
+    hiddenAlleles: PropTypes.array.isRequired,
     trial: PropTypes.number.isRequired,
     trials: PropTypes.array.isRequired,
     moves: PropTypes.number.isRequired,

--- a/src/code/templates/genome-playground.js
+++ b/src/code/templates/genome-playground.js
@@ -7,7 +7,7 @@ import ChangeSexButtons from '../components/change-sex-buttons';
 export default class GenomeContainer extends Component {
 
   render() {
-    const { drakes, onChromosomeAlleleChange, onSexChange, onCompleteChallenge, userChangeableGenes, visibleGenes } = this.props,
+    const { drakes, onChromosomeAlleleChange, onSexChange, onCompleteChallenge, userChangeableGenes, visibleGenes, hiddenAlleles } = this.props,
           drakeDef = drakes[0].alleleString,
           drakeSex = drakes[0].sex,
           drake = new BioLogica.Organism(BioLogica.Species.Drake, drakeDef, drakeSex);
@@ -28,7 +28,7 @@ export default class GenomeContainer extends Component {
       <div id="genome-playground">
         <div className='column'>
             <ChangeSexButtons id="change-sex-buttons" sex={ drakeSex } onChange= { handleSexChange } showLabel={true} species="Drake" />
-            <GenomeView className="drake-genome" org={ drake } onAlleleChange={ handleAlleleChange } userChangeableGenes= { userChangeableGenes } visibleGenes={ visibleGenes }/>
+            <GenomeView className="drake-genome" org={ drake } onAlleleChange={ handleAlleleChange } userChangeableGenes= { userChangeableGenes } visibleGenes={ visibleGenes } hiddenAlleles={ hiddenAlleles }/>
         </div>
         <div className='column'>
             <OrganismGlowView id="drake-image" org={ drake } />
@@ -42,6 +42,7 @@ export default class GenomeContainer extends Component {
     drakes: PropTypes.array.isRequired,
     userChangeableGenes: PropTypes.array.isRequired,
     visibleGenes: PropTypes.array.isRequired,
+    hiddenAlleles: PropTypes.array.isRequired,
     onChromosomeAlleleChange: PropTypes.func.isRequired,
     onSexChange: PropTypes.func.isRequired,
     onCompleteChallenge: PropTypes.func.isRequired

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -271,7 +271,7 @@
       "comment": "*** Case 6: Challenge 1 - Playground, no T ***",
       "template": "GenomePlayground",
       "initialDrake": {
-        "alleles": "T-T, w-w, h-h, A1-A1, C-C, B-B, D-D, rh-rh, Bog-Bog",
+        "alleles": "Tk/t-Tk/t, w-w, h-h, A1-A1, C-C, B-B, D-D, rh-rh, Bog-Bog",
         "sex": 1
       },
       "userChangeableGenes": "tail, metallic, wings, armor",

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -265,5 +265,18 @@
         { "label": "Drakes with armor", "alleles": ["A1-","-A1"] }
       ]
     }
+  ],
+  [
+    {
+      "comment": "*** Case 6: Challenge 1 - Playground, no T ***",
+      "template": "GenomePlayground",
+      "initialDrake": {
+        "alleles": "T-T, w-w, h-h, A1-A1, C-C, B-B, D-D, rh-rh, Bog-Bog",
+        "sex": 1
+      },
+      "userChangeableGenes": "tail, metallic, wings, armor",
+      "hiddenAlleles": ["T"],
+      "visibleGenes": "nose",
+    }
   ]
 ]

--- a/test/components/gene-label.js
+++ b/test/components/gene-label.js
@@ -35,4 +35,9 @@ describe("<GeneLabelView />", function(){
     assert.lengthOf(wrapper.find('option'), 3, "Should create three <option> tags");
   });
 
+  it("should create appropriate options we specify hidden alleles", function() {
+    const wrapper = shallow(<GeneLabelView species={drake} allele={tailAllele} editable={true} hiddenAlleles={["Tk"]}/>);
+    assert.lengthOf(wrapper.find('option'), 2, "Should create two <option> tags");
+  });
+
 });


### PR DESCRIPTION
Adds support for `hiddenAlleles` property, which now refers to explicit alleles (not as a short-hand for genes) to prevent certain options from being shown in gene pull-down menus.

This also demos the new biologica.js feature, which is authoring genes with limited-choice selection between alleles, e.g. `T/t-T/t`, which would leave out the `Tk` allele.