### PR TITLE
Randomize trials

### DIFF
--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -50,6 +50,31 @@ function processAuthoredDrakes(authoredChallenge, trial, template) {
   return drakes;
 }
 
+// Returns an array [0...len], optionally shuffled
+function createTrialOrder(trial, trials, currentTrialOrder, shuffle) {
+  if (trial > 0) {
+    return currentTrialOrder;
+  }
+  if (!trials || trials.length === 0) {
+    return [0];
+  }
+
+  let trialOrder = [];
+  for (let i = 0, ii = trials.length; i < ii; i++) {
+    trialOrder[i] = i;
+  }
+  if (shuffle) {
+    var j, x, i;
+    for (i = trialOrder.length; i; i--) {
+        j = Math.floor(Math.random() * i);
+        x = trialOrder[i - 1];
+        trialOrder[i - 1] = trialOrder[j];
+        trialOrder[j] = x;
+    }
+  }
+  return trialOrder;
+}
+
 export function loadStateFromAuthoring(state, authoring, progress={}) {
   let trial = state.trial ? state.trial : 0;
 
@@ -71,7 +96,8 @@ export function loadStateFromAuthoring(state, authoring, progress={}) {
         baskets = processAuthoredBaskets(authoredChallenge, state),
         showUserDrake = (authoredChallenge.showUserDrake != null) ? authoredChallenge.showUserDrake : false,
         trials = authoredChallenge.targetDrakes,
-        drakes = processAuthoredDrakes(authoredChallenge, trial, template);
+        trialOrder = createTrialOrder(trial, trials, state.trialOrder, authoredChallenge.randomizeTrials),
+        drakes = processAuthoredDrakes(authoredChallenge, trialOrder[trial], template);
 
   let goalMoves = null;
   if (template.calculateGoalMoves) {
@@ -97,6 +123,7 @@ export function loadStateFromAuthoring(state, authoring, progress={}) {
     gametes,
     trial,
     trials,
+    trialOrder,
     challenges,
     correct: 0,
     errors: 0,

--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -1,4 +1,5 @@
 import templates from '../../templates';
+import { range, shuffle } from 'lodash';
 
 /**
  * Tolerant splitter into a list of strings.
@@ -7,7 +8,7 @@ import templates from '../../templates';
  */
 function split(list) {
   if (list && list.split) return list.split(",").map(item => item.trim());
-  if (list && list.constructor === Array) return list;
+  if (Array.isArray(list)) return list;
   return [];
 }
 
@@ -51,28 +52,14 @@ function processAuthoredDrakes(authoredChallenge, trial, template) {
 }
 
 // Returns an array [0...len], optionally shuffled
-function createTrialOrder(trial, trials, currentTrialOrder, shuffle) {
-  if (trial > 0) {
+function createTrialOrder(trial, trials, currentTrialOrder, doShuffle) {
+  if (trial > 0)
     return currentTrialOrder;
-  }
-  if (!trials || trials.length === 0) {
+  if (!trials)
     return [0];
-  }
-
-  let trialOrder = [];
-  for (let i = 0, ii = trials.length; i < ii; i++) {
-    trialOrder[i] = i;
-  }
-  if (shuffle) {
-    var j, x, i;
-    for (i = trialOrder.length; i; i--) {
-        j = Math.floor(Math.random() * i);
-        x = trialOrder[i - 1];
-        trialOrder[i - 1] = trialOrder[j];
-        trialOrder[j] = x;
-    }
-  }
-  return trialOrder;
+  if (doShuffle)
+    return shuffle( range(trials.length) );
+  return range(trials.length);
 }
 
 export function loadStateFromAuthoring(state, authoring, progress={}) {
@@ -138,7 +125,7 @@ export function loadStateFromAuthoring(state, authoring, progress={}) {
 export function loadNextTrial(state, authoring, progress) {
   let trial = state.trial;
   if (state.trialSuccess){
-    trial = (state.trial < state.trials.length) ? (trial+1) : 1;
+    trial = (state.trial < state.trials.length) ? (trial+1) : 0;
   }
   let nextState = state.merge({
     trial: trial

--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -113,34 +113,9 @@ export function loadNextTrial(state, authoring, progress) {
   if (state.trialSuccess){
     trial = (state.trial < state.trials.length) ? (trial+1) : 1;
   }
-
-  let authoredChallenge = authoring[state.case][state.challenge],
-      templateName = state.template,
-      template = templates[templateName],
-      userChangeableGenes = split(authoredChallenge.userChangeableGenes),
-      visibleGenes = split(authoredChallenge.visibleGenes),
-      hiddenAlleles = split(authoredChallenge.hiddenAlleles),
-      baskets = authoredChallenge.baskets || state.baskets,
-      drakes = processAuthoredDrakes(authoredChallenge, trial, template);
-
-  let goalMoves = null;
-  if (template.calculateGoalMoves) {
-    goalMoves = template.calculateGoalMoves(drakes);
-  }
-
-  return state.merge({
-    userChangeableGenes,
-    visibleGenes,
-    hiddenAlleles,
-    baskets,
-    drakes,
-    trial,
-    correct: 0,
-    errors: 0,
-    moves: 0,
-    goalMoves,
-    userDrakeHidden: true,
-    challengeProgress: progress
+  let nextState = state.merge({
+    trial: trial
   });
 
+  return  loadStateFromAuthoring(nextState, authoring, progress);
 }

--- a/src/code/templates/genome-challenge.js
+++ b/src/code/templates/genome-challenge.js
@@ -84,6 +84,8 @@ export default class GenomeChallengeTemplate extends Component {
   static authoredDrakesToDrakeArray = function(authoredChallenge, trial) {
     if (authoredChallenge.trialGenerator) {
       return generateTrialDrakes(authoredChallenge.trialGenerator, trial);
+    } else if (authoredChallenge.initialDrake.constructor === Array) {
+      return [authoredChallenge.initialDrake[trial], authoredChallenge.targetDrakes[trial]];
     } else {
       return [authoredChallenge.initialDrake, authoredChallenge.targetDrakes[trial]];
     }

--- a/src/code/templates/genome-challenge.js
+++ b/src/code/templates/genome-challenge.js
@@ -84,7 +84,7 @@ export default class GenomeChallengeTemplate extends Component {
   static authoredDrakesToDrakeArray = function(authoredChallenge, trial) {
     if (authoredChallenge.trialGenerator) {
       return generateTrialDrakes(authoredChallenge.trialGenerator, trial);
-    } else if (authoredChallenge.initialDrake.constructor === Array) {
+    } else if (Array.isArray(authoredChallenge.initialDrake)) {
       return [authoredChallenge.initialDrake[trial], authoredChallenge.targetDrakes[trial]];
     } else {
       return [authoredChallenge.initialDrake, authoredChallenge.targetDrakes[trial]];

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -277,6 +277,37 @@
       "userChangeableGenes": "tail, metallic, wings, armor",
       "hiddenAlleles": ["T"],
       "visibleGenes": "nose",
+    },
+    {
+      "comment": "*** Case 6: Challenge 2 - Multiple initial drakes ***",
+      "template": "GenomeChallenge",
+      "instructions": "Match the target drake!",
+      "showUserDrake": true,
+      "initialDrake": [
+        {
+          "alleles": "W-W, Bog-, D-, rh-",
+          "sex": 1
+        },
+        {
+          "alleles": "W-w, Bog-, D-, rh-",
+          "sex": 1
+        }
+      ],
+      "targetDrakes": [
+        {
+          "alleles": "w-w",
+          "sex": 1
+        },
+        {
+          "alleles": "w-w",
+          "sex": 1
+        }
+      ],
+      "userChangeableGenes": "metallic, wings, forelimbs, hindlimbs",
+      "linkedGenes": {
+        "drakes": [0, 1],
+        "genes": "tail, horns, color, black, dilute, armor, nose, bogbreath"
+      }
     }
   ]
 ]

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -281,6 +281,7 @@
     {
       "comment": "*** Case 6: Challenge 2 - Multiple initial drakes ***",
       "template": "GenomeChallenge",
+      "randomizeTrials": true,
       "instructions": "Match the target drake!",
       "showUserDrake": true,
       "initialDrake": [

--- a/test/templates/egg-game.js
+++ b/test/templates/egg-game.js
@@ -128,7 +128,8 @@ describe('loading authored state into template', () => {
           ],
           "gametes": [ {}, {} ],
           "goalMoves": nextState.goalMoves,
-          "trials": [ {}, {}, {} ]
+          "trials": [ {}, {}, {} ],
+          "trialOrder": [0,1,2]
         }));
     });
 

--- a/test/templates/genome-challenge.js
+++ b/test/templates/genome-challenge.js
@@ -94,7 +94,8 @@ describe('loading authored state into template', () => {
               "alleles": "a:w,b:w",
               "sex": 1
             }
-          ]
+          ],
+          "trialOrder": [0,1]
         }));
     });
 
@@ -157,6 +158,39 @@ describe('loading authored state into template', () => {
 
         expect(nextState.drakes[1].alleleString.indexOf(tailGenotype) > -1).toBe(true);
         expect(nextState.drakes[1].alleleString.indexOf(hornsGenotype) > -1).toBe(true);
+      });
+    });
+  });
+
+  describe('with randomized trials', () => {
+    describe('in the GenomeChallenge template', () => {
+      let authoring = GeneticsUtils.convertDashAllelesObjectToABAlleles([
+            [
+              {},
+              {
+                "template": "GenomeChallenge",
+                "randomizeTrials": true,
+                "initialDrake": {
+                  "alleles": "W-w",
+                  "sex": 1
+                },
+                "targetDrakes": [{}, {}, {}, {}, {}, {}, {}, {}]
+              }
+            ]
+          ], ["alleles"]);
+
+      let defaultState = reducer(undefined, {});
+      let initialState = defaultState.merge({
+        case: 0,
+        challenge: 0,
+        authoring: authoring
+      });
+
+      let nextState = reducer(initialState, navigateToChallenge(0, 1));
+
+      it('should create a random ordering of trials', () => {
+        expect(nextState.trialOrder.length).toBe(8);
+        expect(nextState.trialOrder).toNotEqual([0,1,2,3,4,5,6,7]); // 1/40320 chance that this will fail
       });
     });
   });


### PR DESCRIPTION
This adds a generic way to randomize trials whenever an author is creating a list of predefined trials (e.g. the targetDrakes list for the genomeChallenge). It works by creating a shuffled array of trial-numbers, and passing that value in, instead of the actual trial number, whenever we use the trial number to calculate state (currently just in `authoredDrakesToDrakeArray`).

This also adds the ability to define an array of initial drakes for the genome challenge.