### PR TITLE
Fertilize the Egg game

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -9,29 +9,28 @@
     <div>
       <ul>
         <!-- "gv2" is a sibling of "examples" -->
-        <li><a href="../gv2/#/1/1">Case 1: Match Drake</a></li>
-        <li><a href="../gv2/#/2/1">Case 2: Egg Game I</a></li>
-        <li><a href="../gv2/#/3/1">Case 3: Egg Game II</a></li>
-        <li><a href="../gv2/#/4/1">Case 4: Egg Game III</a></li>
-        <li><a href="../gv2/#/5/1">Case 5: More Egg Game III</a></li>
+        <li><a href="../gv2/#/1/1">Dragon 0.1: Zorro (Case 1)</a></li>
+        <li><a href="../gv2/#/2/1">Dragon 1.1: Alazar (Case 2)</a></li>
+        <li><a href="../gv2/#/3/1">Dragon 1.2: Beezel (Case 3)</a></li>
+        <li><a href="../gv2/#/4/1">Dragon 1.3: Cezar (Case 4)</a></li>
+        <li><a href="../gv2/#/5/1">Dragon 3.1: Draco (Case 5)</a></li>
         <li><strong>Alternate URLs which allow selection of a local authoring file:</strong></li>
-        <li><a href="../gv2/?author=upload#/1/1">Case 1: Match Drake</a></li>
-        <li><a href="../gv2/?author=upload#/2/1">Case 2: Egg Game I</a></li>
-        <li><a href="../gv2/?author=upload#/3/1">Case 3: Egg Game II</a></li>
-        <li><a href="../gv2/?author=upload#/4/1">Case 4: Egg Game III</a></li>
-        <li><a href="../gv2/?author=upload#/5/1">Case 5: More Egg Game III</a></li>
+        <li><a href="../gv2/?author=upload#/1/1">Dragon 0.1: Zorro (Case 1)</a></li>
+        <li><a href="../gv2/?author=upload#/2/1">Dragon 1.1: Alazar (Case 2)</a></li>
+        <li><a href="../gv2/?author=upload#/3/1">Dragon 1.2: Beezel (Case 3)</a></li>
+        <li><a href="../gv2/?author=upload#/4/1">Dragon 1.3: Cezar (Case 4)</a></li>
+        <li><a href="../gv2/?author=upload#/5/1">Dragon 3.1: Draco (Case 5)</a></li>
         <li><a href="https://github.com/concord-consortium/geniblocks/blob/master/src/resources/authoring/gv2.json">Authoring File</a><span style="margin-left: 6px">(Download and edit locally)</span></li>
         <li><strong>October classroom test:</strong></li>
         <li><a href="http://geniverse.concord.org/drakes-traits/">GeniConnect Drakes & Traits</a><span style="margin-left: 6px">(Ethan McElroy)</span></li>
         <li><strong>Alternate Egg Game III behaviors for consideration/evaluation:</strong></li>
-        <li><a href="../gv2/?collectInBasket=1#/4/1">Case 4: Egg Game III (collect eggs in basket)</a></li>
-        <li><a href="../gv2/?collectInBasket=1#/5/1">Case 5: More Egg Game III (collect eggs in basket)</a></li>
+        <li><a href="../gv2/?collectInBasket=1#/3/1">Case 3: Egg Game III (collect eggs in basket)</a></li>
         <li><strong>Alternate URLs which return to Github Examples page at end of each case:</strong></li>
-        <li><a href="../gv2/?start=http://concord-consortium.github.io/geniblocks/examples/#/1/1">Case 1: Match Drake</a></li>
-        <li><a href="../gv2/?start=http://concord-consortium.github.io/geniblocks/examples/#/2/1">Case 2: Egg Game I</a></li>
-        <li><a href="../gv2/?start=http://concord-consortium.github.io/geniblocks/examples/#/3/1">Case 3: Egg Game II</a></li>
-        <li><a href="../gv2/?start=http://concord-consortium.github.io/geniblocks/examples/#/4/1">Case 4: Egg Game III</a></li>
-        <li><a href="../gv2/?start=http://concord-consortium.github.io/geniblocks/examples/#/5/1">Case 5: More Egg Game III</a></li>
+        <li><a href="../gv2/?start=http://concord-consortium.github.io/geniblocks/examples/#/1/1">Dragon 0.1: Zorro (Case 1)</a></li>
+        <li><a href="../gv2/?start=http://concord-consortium.github.io/geniblocks/examples/#/2/1">Dragon 1.1: Alazar (Case 2)</a></li>
+        <li><a href="../gv2/?start=http://concord-consortium.github.io/geniblocks/examples/#/3/1">Dragon 1.2: Beezel (Case 3)</a></li>
+        <li><a href="../gv2/?start=http://concord-consortium.github.io/geniblocks/examples/#/4/1">Dragon 1.3: Cezar (Case 4)</a></li>
+        <li><a href="../gv2/?start=http://concord-consortium.github.io/geniblocks/examples/#/5/1">Dragon 3.1: Draco (Case 5)</a></li>
       </ul>
     </div>
     <h3>Geniverse 2.0 Prototype</h3>

--- a/src/code/components/gamete-pen.js
+++ b/src/code/components/gamete-pen.js
@@ -105,7 +105,7 @@ GametePenView.propTypes = {
   containerWidth: PropTypes.number,
   containerHeight: PropTypes.number,
   gameteSize: PropTypes.number,
-  showChromosomes: PropTypes.bool,
+  showChromosomes: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   rows: PropTypes.number,
   columns: PropTypes.number,
   tightenColumns: PropTypes.number,

--- a/src/code/components/gamete-pen.js
+++ b/src/code/components/gamete-pen.js
@@ -10,7 +10,15 @@ import GameteImageView from './gamete-image';
  * @param {number} tightenRows - If given, will shrink the vertical height of the pen by this amount
  *                        per row, crowding the org images as needed.
  */
-const GametePenView = ({id, sex, gametes, idPrefix='gamete-', gameteSize=1.0, showChromosomes=true, containerWidth, containerHeight, rows, columns, tightenRows=0, tightenColumns=0, selectedIndex, selectedColor='#FF6666', onClick}) => {
+
+export function getGameteLocation(layout, index) {
+  const row = Math.floor(index / layout.columns),
+        indexInRow = index - (row * layout.columns);
+  return { left: layout.xMargin + indexInRow * layout.effectiveWidth,
+            top: layout.yMargin + row * layout.effectiveHeight };
+}
+
+const GametePenView = ({id, sex, gametes, idPrefix='gamete-', gameteSize=1.0, showChromosomes=true, containerWidth, containerHeight, rows, columns, tightenRows=0, tightenColumns=0, selectedIndex, selectedColor='#FF6666', onClick, onReportLayoutConstants}) => {
 
   function handleGameteClick(evt, gameteID) {
     const prefixIndex = gameteID.indexOf(idPrefix),
@@ -27,7 +35,9 @@ const GametePenView = ({id, sex, gametes, idPrefix='gamete-', gameteSize=1.0, sh
   const availableWidth = containerWidth - 12,
         availableHeight = containerHeight - 4,
         gameteImageWidth = Math.ceil((sex === BioLogica.FEMALE ? 68 : 145) * gameteSize),
-        gameteImageHeight = Math.ceil((sex === BioLogica.FEMALE ? 78 : 40) * gameteSize);
+        gameteImageHeight = Math.ceil((sex === BioLogica.FEMALE ? 78 : 40) * gameteSize),
+        xMargin = 2,
+        yMargin = sex === BioLogica.MALE ? 14 : 2;
   let   effectiveWidth = gameteImageWidth * (1 - tightenColumns),
         effectiveHeight = gameteImageHeight * (1 - tightenRows),
         gametesPerRow = Math.floor(availableWidth / effectiveWidth);
@@ -54,14 +64,14 @@ const GametePenView = ({id, sex, gametes, idPrefix='gamete-', gameteSize=1.0, sh
     effectiveHeight = gameteImageHeight * (1 - tightenRows);
   }
 
+  const layoutConstants = { rows, columns, xMargin, yMargin, effectiveWidth, effectiveHeight };
+
+  if (onReportLayoutConstants) {
+    onReportLayoutConstants(layoutConstants);
+  }
+
   function getGameteStyle(index) {
-    const row = Math.floor(index / columns),
-          indexInRow = index - (row * columns),
-          xMargin = 2,
-          yMargin = sex === BioLogica.MALE ? 14 : 2;
-    return { position: 'absolute',
-              left: xMargin + indexInRow * effectiveWidth,
-              top: yMargin + row * effectiveHeight };
+    return assign(getGameteLocation(layoutConstants, index), { position: 'absolute' });
   }
 
   function shouldShowChromosomes(index) {
@@ -112,7 +122,8 @@ GametePenView.propTypes = {
   tightenRows: PropTypes.number,
   selectedIndex: PropTypes.number,
   selectedColor: PropTypes.string,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  onReportLayoutConstants: PropTypes.func
 };
 
 const containerStyle = { height: 48, padding: 0, border: 0 };

--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -17,6 +17,14 @@ function processAuthoredBaskets(authoredChallenge, state) {
   return baskets || state.baskets;
 }
 
+function processAuthoredGametes(authoredChallenge, state) {
+  const authoredGametes = authoredChallenge && authoredChallenge.gametes;
+  // for now we just stash it in an 'authored' property so the template has access to it
+  return authoredGametes
+            ? state.gametes.merge({ authored: authoredGametes })
+            : state.gametes;
+}
+
 function processAuthoredDrakes(authoredChallenge, trial, template) {
   // takes authored list of named drakes ("mother", etc) and returns an
   // array specific for this template
@@ -81,6 +89,7 @@ export function loadStateFromAuthoring(state, authoring, progress={}) {
         visibleGenes = split(authoredChallenge.visibleGenes),
         hiddenAlleles = split(authoredChallenge.hiddenAlleles),
         baskets = processAuthoredBaskets(authoredChallenge, state),
+        gametes = processAuthoredGametes(authoredChallenge, state),
         showUserDrake = (authoredChallenge.showUserDrake != null) ? authoredChallenge.showUserDrake : false,
         trials = authoredChallenge.targetDrakes,
         trialOrder = createTrialOrder(trial, trials, state.trialOrder, authoredChallenge.randomizeTrials),
@@ -101,6 +110,7 @@ export function loadStateFromAuthoring(state, authoring, progress={}) {
     visibleGenes,
     hiddenAlleles,
     baskets,
+    gametes,
     drakes,
     trial,
     trials,

--- a/src/code/templates/egg-game.js
+++ b/src/code/templates/egg-game.js
@@ -6,7 +6,7 @@ import { motherGametePool, fatherGametePool, gametePoolSelector,
 import OrdinalOrganismView from '../components/ordinal-organism';
 import OrganismView from '../components/organism';
 import GenomeView from '../components/genome';
-import GametePenView from '../components/gamete-pen';
+import GametePenView, { getGameteLocation } from '../components/gamete-pen';
 import ButtonView from '../components/button';
 import PenView from '../components/pen';
 import GameteImageView from '../components/gamete-image';
@@ -110,6 +110,7 @@ var _this,
   animationTimeline = {},
   mother, father,
   authoredGameteCounts = [0, 0],
+  gameteLayoutConstants = [{}, {}],
   authoredDrakes = [],
   challengeDidChange = true,
   ovumTarget, spermTarget,
@@ -487,16 +488,21 @@ var animationEvents = {
   },
   moveGameteToPool: { id: 4, sexes: [], complete: false, ready: false,
     animate: function(sex, speed, onFinish) {
+      function getGameteLocationInPen(sex, index) {
+        let loc = gameteLayoutConstants[sex]
+                    ? getGameteLocation(gameteLayoutConstants[sex], index)
+                    : { top: BioLogica.MALE ? 14 : 2, left: 3 + 31.125 * index };
+        return loc;
+      }
       const gameteComponent = sex === BioLogica.MALE ? animatedSpermView : animatedOvumView,
             srcGameteBounds = sex === BioLogica.MALE ? spermTarget : ovumTarget,
             gametePoolId = sex === BioLogica.MALE ? 'father-gamete-pen' : 'mother-gamete-pen',
             gametePoolElt = document.getElementById(gametePoolId),
             gametePoolBounds = gametePoolElt.getBoundingClientRect(),
             gameteCount = gametePoolSelector(sex)(_this.props.gametes).length,
-            topOffset = sex === BioLogica.MALE ? 15 : 3,
-            leftOffset = 3 + 31.125 * gameteCount,
-            dstGameteBounds = { top: gametePoolBounds.top + topOffset,
-                                left: gametePoolBounds.left + leftOffset,
+            loc = getGameteLocationInPen(sex, gameteCount),
+            dstGameteBounds = { top: gametePoolBounds.top + loc.top + 1,
+                                left: gametePoolBounds.left + loc.left + 1,
                                 width: srcGameteBounds.width / 2,
                                 height: srcGameteBounds.height / 2 },
             positions = { startPositionRect: srcGameteBounds, startSize: 1.0,
@@ -1080,7 +1086,10 @@ export default class EggGame extends Component {
       return <GametePenView {...uniqueProps} gameteSize={0.6} rows={1} sex={sex}
                             columns={authoredGameteCounts[sex]}
                             showChromosomes='selected'
-                            onClick={_this.handleGameteSelected} />;
+                            onClick={_this.handleGameteSelected}
+                            onReportLayoutConstants={function(layout) {
+                                                        gameteLayoutConstants[sex] = clone(layout);
+                                                      }}  />;
     }
 
     return (

--- a/src/code/templates/egg-game.js
+++ b/src/code/templates/egg-game.js
@@ -587,7 +587,7 @@ var animationEvents = {
   @param {boolean}  options.clearAnimatedComponents - whether to clear the animatedComponents array (default: false)
   @param {Object}   options.reactState - React state to set (default: { animation: 'complete', animatingGametes: null })
  */
-function resetAnimationEvents(options){
+function resetAnimationEvents(options = {}){
   if (timerSet) timerSet.reset();
   clearTimeouts();
   animationEvents.showGametes.count = 0;
@@ -951,12 +951,15 @@ export default class EggGame extends Component {
                                   <OrganismView className="target" org={targetDrakeOrg} width={140} key={0} />
                                 </div>
                               : null,
+          targetCountersView = drakes.length - firstTargetDrakeIndex > 1
+                                ? <div className='target-counters'>
+                                      {mapTargetDrakesToFeedbackViews(drakes, trial)}
+                                  </div>
+                                : null,
           targetDrakeSection = isMatchingChallenge
                                 ? <div className='target-section'>
                                     {targetDrakeView}
-                                    <div className='target-counters'>
-                                      {mapTargetDrakesToFeedbackViews(drakes, trial)}
-                                    </div>
+                                    {targetCountersView}
                                   </div>
                                 : null,
           eggClasses = classNames('egg-image', challengeClasses),

--- a/src/code/templates/egg-game.js
+++ b/src/code/templates/egg-game.js
@@ -132,6 +132,12 @@ function oneOf(array) {
   return array[Math.floor(array.length * Math.random())];
 }
 
+function initialAnimGametes() {
+  // gametes [0,1] represent the highlighted chromosomes in the parent genomes
+  // gametes [2,3] represent the highlighted chromosomes in the half-genomes (proto-child)
+  return [{}, {}, {}, {}];
+}
+
 var animationEvents = {
   showGametes: { id: 0, count: 0, complete: false,
     animate: function() {
@@ -324,7 +330,7 @@ var animationEvents = {
       }
 
       function selectStageChromosomes(speed, chroms) {
-        let animatingGametes = cloneDeep(_this.state.animatingGametes) || [{}, {}, {}, {}];
+        let animatingGametes = cloneDeep(_this.state.animatingGametes) || initialAnimGametes();
         chroms.forEach(({ sex, name }) => {
           let gamete = animatingGametes[sex],
               side = gamete[name];
@@ -345,7 +351,7 @@ var animationEvents = {
       }
 
       function toggleAnimatingGameteChromosome(sex, chromName, sides) {
-        let animatingGametes = _this.state.animatingGametes || [{}, {}, {}, {}],
+        let animatingGametes = _this.state.animatingGametes || initialAnimGametes(),
             gamete = animatingGametes[sex],
             currSide = gamete[chromName],
             newSide = currSide != null
@@ -463,13 +469,13 @@ var animationEvents = {
           animationEvents.moveChromosomesToGamete.onFinish(animationEvents.moveChromosomesToGamete.id);
         }
       }
-      let animatingGametes = _this.state.animatingGametes || [{}, {}, {}, {}],
+      let animatingGametes = _this.state.animatingGametes || initialAnimGametes(),
           createdGametes = _this.state.createdGametes || [[], []];
       if (Object.keys(animatingGametes[2]).length)
         createdGametes[0].push(animatingGametes[2]);
       if (Object.keys(animatingGametes[3]).length)
         createdGametes[1].push(animatingGametes[3]);
-      animatingGametes = [{}, {}, {}, {}];
+      animatingGametes = initialAnimGametes();
 
       _this.setState({ animation: 'moveChromosomesToGamete', animatingGametes, createdGametes });
     },
@@ -868,7 +874,7 @@ export default class EggGame extends Component {
                                   });
         // selected gametes don't include just-selected chromosomes (no labels)
         // until the animation completes.
-        animatingGametes.push(currentGametes[0].asMutable(), clone(currentGametes[1].asMutable()));
+        animatingGametes.push(currentGametes[0].asMutable(), currentGametes[1].asMutable());
         ++this.activeSelectionAnimations;
         this.setState({ animatingGametes });
         // delay selection of chromosome until animation arrives

--- a/src/code/templates/egg-game.js
+++ b/src/code/templates/egg-game.js
@@ -470,11 +470,11 @@ var animationEvents = {
         }
       }
       let animatingGametes = _this.state.animatingGametes || initialAnimGametes(),
-          createdGametes = _this.state.createdGametes || [[], []];
+          createdGametes = _this.state.createdGametes || [0, 0];
       if (Object.keys(animatingGametes[2]).length)
-        createdGametes[0].push(animatingGametes[2]);
+        ++ createdGametes[0];
       if (Object.keys(animatingGametes[3]).length)
-        createdGametes[1].push(animatingGametes[3]);
+        ++ createdGametes[1];
       animatingGametes = initialAnimGametes();
 
       _this.setState({ animation: 'moveChromosomesToGamete', animatingGametes, createdGametes });
@@ -534,10 +534,10 @@ var animationEvents = {
     onFinish: function() {
       animatedComponents = [];
       if (animationEvents.moveGameteToPool.sexes) {
-        let createdGametes = _this.state.createdGametes || [[], []],
+        let createdGametes = _this.state.createdGametes || [0, 0],
             animatingGametesInPools = _this.state.animatingGametesInPools || [0, 0];
         animationEvents.moveGameteToPool.sexes.forEach((sex) => {
-          animatingGametesInPools[sex] += createdGametes[sex] ? createdGametes[sex].length : 0;
+          animatingGametesInPools[sex] += createdGametes[sex];
           createdGametes[sex] = [];
         });
         if ((animatingGametesInPools[0] >= fatherGametePool(_this.props.gametes).length) &&
@@ -803,34 +803,15 @@ export default class EggGame extends Component {
       this.selectChromosomes(org.sex, defaultAnimationSpeed, [{name, side, elt }]);
   }
 
-  fillGametePools() {
-    const { gametes, onAddGametesToPool } = this.props;
-    let   createdGametes = this.state.createdGametes || [[], []],
-          shouldUpdateCreatedGametes = false;
-
-    for (let sex = 0; sex <= 1; ++sex) {
-      const poolLength = gametePoolSelector(sex)(gametes).length;
-      while (poolLength + createdGametes[sex].length < authoredGameteCounts[sex])
-        createdGametes[sex].push(randomGamete(sex));
-      if (createdGametes[sex].length) {
-        onAddGametesToPool(sex, createdGametes[sex]);
-        createdGametes[sex] = [];
-        shouldUpdateCreatedGametes = true;
-      }
-    }
-    if (shouldUpdateCreatedGametes)
-      this.setState({ createdGametes });
-  }
-
   handleGameteSelected = (poolID, sex, gameteIndex, /*gameteID, gamete*/) => {
     if (!this.state.isIntroComplete) {
       // user selection of a gamete terminates intro animation
       resetAnimationEvents({ showStaticGametes: true,
                             clearAnimatedComponents: true,
                             reactState: { animatingGametesInPools: null,
+                                          createdGametes: null,
                                           isIntroComplete: true } });
       chromosomeDisplayStyle = {};
-      this.fillGametePools();
     }
     this.props.onSelectGameteInPool(sex, gameteIndex);
   }
@@ -1267,7 +1248,6 @@ export default class EggGame extends Component {
     userDrakeHidden: PropTypes.bool,
     onChromosomeAlleleChange: PropTypes.func.isRequired,
     onGameteChromosomeAdded: PropTypes.func.isRequired,
-    onAddGametesToPool: PropTypes.func.isRequired,
     onSelectGameteInPool: PropTypes.func.isRequired,
     onFertilize: PropTypes.func.isRequired,
     onHatch: PropTypes.func,

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -300,7 +300,7 @@
         "alleles": "w-W, m-m, T-T, h-h, A1-A1, C-C, B-B, D-D, rh-rh, Bog-Bog",
         "sex": 0
       },
-      "gametes": [[{}, {}, {}, {}, {}, {}, {}, {}], [{}, {}, {}, {}, {}, {}, {}, {}]],
+      "gameteCounts": [8, 8],
       "visibleGenes": "metallic, wings, forelimbs, hindlimbs"
     },
     {
@@ -318,7 +318,7 @@
         "alleles": "w-W, m-m, T-T, h-h, A1-A1, C-C, B-B, D-D, rh-rh, Bog-Bog",
         "sex": 0
       },
-      "gametes": [[{}, {}, {}, {}], [{}, {}, {}, {}]],
+      "gameteCounts": [[2, 1], [1, 3], [4, 4]],
       "targetDrakes": [{}, {}, {}],
       "visibleGenes": "metallic, wings, forelimbs, hindlimbs"
     }

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -300,6 +300,7 @@
         "alleles": "w-W, m-m, T-T, h-h, A1-A1, C-C, B-B, D-D, rh-rh, Bog-Bog",
         "sex": 0
       },
+      "gametes": [[{}, {}, {}, {}, {}, {}, {}, {}], [{}, {}, {}, {}, {}, {}, {}, {}]],
       "visibleGenes": "metallic, wings, forelimbs, hindlimbs"
     },
     {
@@ -317,6 +318,7 @@
         "alleles": "w-W, m-m, T-T, h-h, A1-A1, C-C, B-B, D-D, rh-rh, Bog-Bog",
         "sex": 0
       },
+      "gametes": [[{}, {}, {}, {}], [{}, {}, {}, {}]],
       "targetDrakes": [{}],
       "visibleGenes": "metallic, wings, forelimbs, hindlimbs"
     }

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -319,7 +319,7 @@
         "sex": 0
       },
       "gametes": [[{}, {}, {}, {}], [{}, {}, {}, {}]],
-      "targetDrakes": [{}],
+      "targetDrakes": [{}, {}, {}],
       "visibleGenes": "metallic, wings, forelimbs, hindlimbs"
     }
   ],

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -284,6 +284,41 @@
         "sex": 0
       },
       "visibleGenes": "metallic, wings, forelimbs, hindlimbs"
+    },
+    {
+      "comment": "*** Dragon 3.1: Draco (piece 2): #5/2 - Egg Game I(g) (select gametes to create five unique drakes) ***",
+      "template": "EggGame",
+      "challengeType": "create-unique",
+      "interactionType": "select-gametes",
+      "instructions": "Create 5 different baby drakes!",
+      "showUserDrake": true,
+      "mother":{
+        "alleles": "w-W, M-m, fl-, hl-, T-T, h-h, C-C, A1-A1, B-B, D-D, rh-rh, Bog-Bog",
+        "sex": 1
+      },
+      "father": {
+        "alleles": "w-W, m-m, T-T, h-h, A1-A1, C-C, B-B, D-D, rh-rh, Bog-Bog",
+        "sex": 0
+      },
+      "visibleGenes": "metallic, wings, forelimbs, hindlimbs"
+    },
+    {
+      "comment": "*** Dragon 3.1: Draco (piece 3): #5/3 - Egg Game II(g) (select gametes for breeding to match drakes) ***",
+      "template": "EggGame",
+      "challengeType": "match-target",
+      "interactionType": "select-gametes",
+      "instructions": "Match the target drakes!",
+      "showUserDrake": true,
+      "mother":{
+        "alleles": "w-W, M-m, fl-, hl-, T-T, h-h, C-C, A1-A1, B-B, D-D, rh-rh, Bog-Bog",
+        "sex": 1
+      },
+      "father": {
+        "alleles": "w-W, m-m, T-T, h-h, A1-A1, C-C, B-B, D-D, rh-rh, Bog-Bog",
+        "sex": 0
+      },
+      "targetDrakes": [{}],
+      "visibleGenes": "metallic, wings, forelimbs, hindlimbs"
     }
   ],
   [

--- a/src/stylus/challenges.styl
+++ b/src/stylus/challenges.styl
@@ -67,7 +67,7 @@
   #case-wrapper #drake-image {
     margin: 100px 25px 0;
   }
-  
+
   #genome-challenge
     .instructions-banner
       margin-left: 25px
@@ -217,9 +217,9 @@
   .geniblocks.genome
     position: relative
     top: -33px
-    &.matching
+    &.matching.child
       top: -60px
-    &.matching.parent
+    &.matching.select-chromosomes.parent
       top: 50px
   .geniblocks.organism
     height: 202px
@@ -235,16 +235,16 @@
   position: relative
   display: flex
   width: 420px
-  
+
   .target-section
     display: flex
     flex-direction: row
     justify-content: center
     margin-left: -40px;
-  
+
   .target-drake
     margin-top: -20px;
-  
+
   .target-counters
     display: flex
     flex-direction: column
@@ -346,13 +346,13 @@
   position: relative
   width: 1000px
   height: 600px
-  
+
   #baskets
     position: absolute
     top: 35px
     width: 660px
     height: 300px
-  
+
   .geniblocks.basket-set
     display: flex
     align-items: center
@@ -361,7 +361,7 @@
 
     .basket
       margin-top: 100px
-      
+
       .basket-image
         // https://openclipart.org/detail/203250/garden-basket-game-component-superb-quality
         background-image: url('../resources/images/garden-basket.png')
@@ -369,7 +369,7 @@
         background-repeat: no-repeat
         width: 150px
         height: 100px
-      
+
       .basket-label
         width: 150px
         color: white
@@ -383,7 +383,7 @@
     position: absolute
     top: 350px
     width: 660px
-  
+
   .geniblocks.egg-clutch
     display: flex
     flex-wrap: wrap
@@ -402,7 +402,7 @@
     .clutch-egg.selected
       cursor: default
       opacity: 1.0
-    
+
     .clutch-egg.hidden
       visibility: hidden
 
@@ -418,7 +418,7 @@
       text-align: center
       color: white
       margin-top: 10px
-      
+
     .section-title.instructions
       font-size: 2em
       color: lightGray
@@ -429,7 +429,7 @@
       height: 100%
       border: 3px #888 solid
       border-radius: 10px
-      
+
       #background
         position: absolute
         width: 314px


### PR DESCRIPTION
@sfentress Final commit added which wraps up all existing stories (to this point). You should be able to just review the most recent commits since you last reviewed the code.

Update: most recent commits wrap up basic functionality that was missing at the point the PR was first submitted:
- gametes are generated at the beginning of each trial/challenge and animation just syncs to pre-generated gametes
- generated gametes are guaranteed to include ones that can match the target
- gamete counts can be specified on a per-trial basis
- gamete counts are specified as integers rather than sets of `{}`s
- if there's only one gamete for a given parent it is selected automatically

@sfentress You may review the changes at your convenience.

Add challenges to authoring document
- Dragon 3.1: Draco (piece 2): #5/2 - Egg Game I(g) (select gametes to create five unique drakes)
- Dragon 3.1: Draco (piece 3): #5/3 - Egg Game II(g) (select gametes for breeding to match drakes)
- Currently, all trials act like Trial 3 in the spec document (4 gametes for mother, 4 gametes for father) [#138978405]
- Layout tweaks for Fertilize the Egg game
- Number of gametes is authorable and mother/father can have different number of gametes
- Gametes animate to correct location in pool with arbitrary numbers of gametes
- Fertilize the Egg game supports multiple trials

Note: The random selection of the target is currently unrelated to the random selection of the gametes, i.e. there's no guarantee that there is a combination of gametes that will generate a given target drake. That will obviously be fixed in an upcoming Pull Request.

Update examples page to match Trudi's new order

Bug-fixes
- Add default value for options argument of resetAnimationEvents()
- Fix PropTypes declaration for `showChromosomes`
