### PR TITLE
Tutorial pen and consistent sex-linked traits

### DIFF
--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -554,7 +554,7 @@ export function hatch() {
 }
 
 
-function _keepOffspring(index, success, interactionType, keepDisplayBaby) {
+function _keepOffspring(index, success, interactionType, shouldKeepSourceDrake) {
   let incrementMoves = !success;
   return {
     type: actionTypes.OFFSPRING_KEPT,
@@ -562,15 +562,15 @@ function _keepOffspring(index, success, interactionType, keepDisplayBaby) {
     index,
     success,
     incrementMoves,
-    keepDisplayBaby
+    shouldKeepSourceDrake
   };
 }
 
-export function keepOffspring(index, success, maxDrakes, keepDisplayBaby) {
+export function keepOffspring(index, success, maxDrakes, shouldKeepSourceDrake) {
   return (dispatch, getState) => {
     const { interactionType } = getState();
 
-    dispatch(_keepOffspring(index, success, interactionType, keepDisplayBaby));
+    dispatch(_keepOffspring(index, success, interactionType, shouldKeepSourceDrake));
 
     if (success) {
       const { drakes } = getState();
@@ -583,7 +583,7 @@ export function keepOffspring(index, success, maxDrakes, keepDisplayBaby) {
         explanation: "~ALERT.DUPLICATE_DRAKE",
         rightButton: {
           label: "~BUTTON.TRY_AGAIN",
-          action: keepDisplayBaby ? "dismissModalDialog" : "resetGametes"
+          action: shouldKeepSourceDrake ? "dismissModalDialog" : "resetGametes"
         }
       }));
     }

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -554,22 +554,23 @@ export function hatch() {
 }
 
 
-function _keepOffspring(index, success, interactionType) {
+function _keepOffspring(index, success, interactionType, keepDisplayBaby) {
   let incrementMoves = !success;
   return {
     type: actionTypes.OFFSPRING_KEPT,
     interactionType,
     index,
     success,
-    incrementMoves
+    incrementMoves,
+    keepDisplayBaby
   };
 }
 
-export function keepOffspring(index, success, maxDrakes) {
+export function keepOffspring(index, success, maxDrakes, keepDisplayBaby) {
   return (dispatch, getState) => {
     const { interactionType } = getState();
 
-    dispatch(_keepOffspring(index, success, interactionType));
+    dispatch(_keepOffspring(index, success, interactionType, keepDisplayBaby));
 
     if (success) {
       const { drakes } = getState();
@@ -582,7 +583,7 @@ export function keepOffspring(index, success, maxDrakes) {
         explanation: "~ALERT.DUPLICATE_DRAKE",
         rightButton: {
           label: "~BUTTON.TRY_AGAIN",
-          action: "resetGametes"
+          action: keepDisplayBaby ? "dismissModalDialog" : "resetGametes"
         }
       }));
     }

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -566,15 +566,28 @@ function _keepOffspring(index, success, interactionType, shouldKeepSourceDrake) 
   };
 }
 
-export function keepOffspring(index, success, maxDrakes, shouldKeepSourceDrake) {
+export function keepOffspring(index, keptDrakesIndices, maxDrakes, shouldKeepSourceDrake) {
   return (dispatch, getState) => {
-    const { interactionType } = getState();
+    const { interactionType, drakes } = getState();
+
+    let offspringOrg = new BioLogica.Organism(BioLogica.Species.Drake, drakes[index].alleleString, drakes[index].sex),
+        success = true;
+    // Don't keep any drakes with the same phenotypes
+    keptDrakesIndices.forEach(function(keptDrakeIndex) {
+      let keptDrake = drakes[keptDrakeIndex],
+          keptImage = new BioLogica.Organism(BioLogica.Species.Drake, keptDrake.alleleString, keptDrake.sex).getImageName();
+
+      if (keptImage === offspringOrg.getImageName()) {
+        success = false;
+      }
+    });
 
     dispatch(_keepOffspring(index, success, interactionType, shouldKeepSourceDrake));
 
     if (success) {
-      const { drakes } = getState();
-      if (drakes.length === maxDrakes) {
+      // The size of the drakes array has changed since dispatching _keepOffspring
+      const { drakes: updatedDrakes } = getState();
+      if (updatedDrakes.length === maxDrakes) {
         dispatch(completeChallenge());
       }
     } else {

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -570,16 +570,14 @@ export function keepOffspring(index, keptDrakesIndices, maxDrakes, shouldKeepSou
   return (dispatch, getState) => {
     const { interactionType, drakes } = getState();
 
-    let offspringOrg = new BioLogica.Organism(BioLogica.Species.Drake, drakes[index].alleleString, drakes[index].sex),
-        success = true;
-    // Don't keep any drakes with the same phenotypes
-    keptDrakesIndices.forEach(function(keptDrakeIndex) {
+    let offspringOrg = new BioLogica.Organism(BioLogica.Species.Drake, drakes[index].alleleString, drakes[index].sex);
+
+    // Succeed if every kept drake has a different phenotype than the submitted drake
+    let success = keptDrakesIndices.every(keptDrakeIndex => {
       let keptDrake = drakes[keptDrakeIndex],
           keptImage = new BioLogica.Organism(BioLogica.Species.Drake, keptDrake.alleleString, keptDrake.sex).getImageName();
 
-      if (keptImage === offspringOrg.getImageName()) {
-        success = false;
-      }
+      return keptImage !== offspringOrg.getImageName();
     });
 
     dispatch(_keepOffspring(index, success, interactionType, shouldKeepSourceDrake));

--- a/src/code/containers/challenge-container.js
+++ b/src/code/containers/challenge-container.js
@@ -102,7 +102,7 @@ function mapDispatchToProps(dispatch) {
     onHatch: () => dispatch(hatch()),
     onResetGametes: () => dispatch(resetGametes()),
     onResetGametePools: () => dispatch(resetGametePools()),
-    onKeepOffspring: (index, success, maxDrakes, shouldKeepSourceDrake) => dispatch(keepOffspring(index, success, maxDrakes, shouldKeepSourceDrake)),
+    onKeepOffspring: (index, keptDrakesIndices, maxDrakes, shouldKeepSourceDrake) => dispatch(keepOffspring(index, keptDrakesIndices, maxDrakes, shouldKeepSourceDrake)),
     onChangeBasketSelection: (selectedIndices) => dispatch(changeBasketSelection(selectedIndices)),
     onChangeDrakeSelection: (selectedIndices) => dispatch(changeDrakeSelection(selectedIndices)),
     onSubmitEggForBasket: (...args) => dispatch(submitEggForBasket(...args))

--- a/src/code/containers/challenge-container.js
+++ b/src/code/containers/challenge-container.js
@@ -102,7 +102,7 @@ function mapDispatchToProps(dispatch) {
     onHatch: () => dispatch(hatch()),
     onResetGametes: () => dispatch(resetGametes()),
     onResetGametePools: () => dispatch(resetGametePools()),
-    onKeepOffspring: (index, success, maxDrakes) => dispatch(keepOffspring(index, success, maxDrakes)),
+    onKeepOffspring: (index, success, maxDrakes, keepDisplayBaby) => dispatch(keepOffspring(index, success, maxDrakes, keepDisplayBaby)),
     onChangeBasketSelection: (selectedIndices) => dispatch(changeBasketSelection(selectedIndices)),
     onChangeDrakeSelection: (selectedIndices) => dispatch(changeDrakeSelection(selectedIndices)),
     onSubmitEggForBasket: (...args) => dispatch(submitEggForBasket(...args))

--- a/src/code/containers/challenge-container.js
+++ b/src/code/containers/challenge-container.js
@@ -102,7 +102,7 @@ function mapDispatchToProps(dispatch) {
     onHatch: () => dispatch(hatch()),
     onResetGametes: () => dispatch(resetGametes()),
     onResetGametePools: () => dispatch(resetGametePools()),
-    onKeepOffspring: (index, success, maxDrakes, keepDisplayBaby) => dispatch(keepOffspring(index, success, maxDrakes, keepDisplayBaby)),
+    onKeepOffspring: (index, success, maxDrakes, shouldKeepSourceDrake) => dispatch(keepOffspring(index, success, maxDrakes, shouldKeepSourceDrake)),
     onChangeBasketSelection: (selectedIndices) => dispatch(changeBasketSelection(selectedIndices)),
     onChangeDrakeSelection: (selectedIndices) => dispatch(changeDrakeSelection(selectedIndices)),
     onSubmitEggForBasket: (...args) => dispatch(submitEggForBasket(...args))

--- a/src/code/reducers/drakes.js
+++ b/src/code/reducers/drakes.js
@@ -24,16 +24,15 @@ export default function drakes(state = initialState, action) {
           secondXAlleles = GeneticsUtils.computeExtraAlleles(oldOrg, newOrg);
           alleleString = newOrg.getAlleleString();
         }
-        else if (drakeDef.sex === BioLogica.MALE && action.newSex === BioLogica.FEMALE) {
+        else if (drakeDef.sex === BioLogica.MALE && action.newSex === BioLogica.FEMALE && drakeDef.secondXAlleles) {
           // Restore the fully specified female's alleles
           alleleString = oldOrg.getAlleleString() + "," + drakeDef.secondXAlleles;
           secondXAlleles = null;
         }
-        return {
+        return assign({}, secondXAlleles ? {secondXAlleles: secondXAlleles} : null, {
           sex: action.newSex,
           alleleString: alleleString,
-          secondXAlleles: secondXAlleles
-        };
+        });
       });
     case actionTypes.DRAKE_SELECTION_CHANGED:
       return state.map((drake, index) => {
@@ -56,7 +55,7 @@ export default function drakes(state = initialState, action) {
           alleleString: state[action.index].alleleString,
           sex: state[action.index].sex
         });
-        if (!action.keepDisplayBaby) {
+        if (!action.shouldKeepSourceDrake) {
           state = state.set(action.index, null);
         }
       }

--- a/src/code/reducers/drakes.js
+++ b/src/code/reducers/drakes.js
@@ -24,9 +24,16 @@ export default function drakes(state = initialState, action) {
           secondXAlleles = GeneticsUtils.computeExtraAlleles(oldOrg, newOrg);
           alleleString = newOrg.getAlleleString();
         }
-        else if (drakeDef.sex === BioLogica.MALE && action.newSex === BioLogica.FEMALE && drakeDef.secondXAlleles) {
-          // Restore the fully specified female's alleles
-          alleleString = oldOrg.getAlleleString() + "," + drakeDef.secondXAlleles;
+        else if (drakeDef.sex === BioLogica.MALE && action.newSex === BioLogica.FEMALE) {
+          if (drakeDef.secondXAlleles) {
+            // Restore the fully specified female's alleles
+            alleleString = oldOrg.getAlleleString() + "," + drakeDef.secondXAlleles;
+          }
+          else {
+            // Use the male's partial allele string; the remainder will be randomized
+            alleleString = oldOrg.getAlleleString();
+          }
+
           secondXAlleles = null;
         }
         return assign({}, secondXAlleles ? {secondXAlleles: secondXAlleles} : null, {

--- a/src/code/reducers/drakes.js
+++ b/src/code/reducers/drakes.js
@@ -38,7 +38,9 @@ export default function drakes(state = initialState, action) {
           alleleString: state[action.index].alleleString,
           sex: state[action.index].sex
         });
-        state = state.set(action.index, null);
+        if (!action.keepDisplayBaby) {
+          state = state.set(action.index, null);
+        }
       }
       return state;
     case actionTypes.EGG_ACCEPTED:

--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -1,6 +1,6 @@
 import templates from '../../templates';
 import GeneticsUtils from '../../utilities/genetics-utils';
-import { range, shuffle } from 'lodash';
+import { range, shuffle, assign } from 'lodash';
 
 /**
  * Tolerant splitter into a list of strings.
@@ -53,11 +53,11 @@ function processAuthoredDrakes(authoredChallenge, trial, template) {
       secondXAlleles = GeneticsUtils.computeExtraAlleles(fixedFemaleDrake, fixedDrake);
     }
 
-    return {
+    return assign({}, secondXAlleles ? {secondXAlleles: secondXAlleles} : null, {
       alleleString: fixedDrake.getAlleleString(),
       sex: fixedDrake.sex,
-      secondXAlleles: secondXAlleles
-    };
+    });
+
   });
   return drakes;
 }

--- a/src/code/templates/egg-game.js
+++ b/src/code/templates/egg-game.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import { assign, clone, cloneDeep } from 'lodash';
+import { assign, clone, cloneDeep, range } from 'lodash';
 import classNames from 'classnames';
 import { motherGametePool, fatherGametePool, gametePoolSelector,
         motherSelectedGameteIndex, fatherSelectedGameteIndex } from '../modules/gametes';
@@ -859,18 +859,10 @@ export default class EggGame extends Component {
 
     const handleSubmit = function () {
       let childImage = child.getImageName(),
-          [,,,...keptDrakes] = drakes,
           success = false;
       if (challengeType === 'create-unique') {
-        success = true;
-        for (let drake of keptDrakes) {
-          let org = new BioLogica.Organism(BioLogica.Species.Drake, drake.alleleString, drake.sex);
-          if (org.getImageName() === childImage) {
-            success = false;
-            break;
-          }
-        }
-        onKeepOffspring(2, success, 8);
+        let offspringIndices = range(3, drakes.length);
+        onKeepOffspring(2, offspringIndices, 8);
       }
       else if (challengeType === 'match-target') {
         const targetDrakeOrg = new BioLogica.Organism(BioLogica.Species.Drake,

--- a/src/code/templates/genome-playground.js
+++ b/src/code/templates/genome-playground.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import OrganismGlowView from '../components/organism-glow';
+import { range } from 'lodash';
 import GenomeView from '../components/genome';
 import ButtonView from '../components/button';
 import PenView from '../components/pen';
@@ -27,17 +28,8 @@ export default class GenomeContainer extends Component {
     };
 
     const handleSubmit = function() {
-      let childImage = userDrake.getImageName(),
-          [,...keptDrakes] = drakes,
-          success = true;
-      for (let drake of keptDrakes) {
-        let org = new BioLogica.Organism(BioLogica.Species.Drake, drake.alleleString, drake.sex);
-        if (org.getImageName() === childImage) {
-          success = false;
-          break;
-        }
-      }
-      onKeepOffspring(0, success, 6, true);
+      let offspringIndices = range(1, drakes.length);
+      onKeepOffspring(0, offspringIndices, 6, true);
     };
 
     return (

--- a/src/code/templates/genome-playground.js
+++ b/src/code/templates/genome-playground.js
@@ -11,7 +11,7 @@ export default class GenomeContainer extends Component {
     const { drakes, onChromosomeAlleleChange, onSexChange, userChangeableGenes, visibleGenes, hiddenAlleles, onKeepOffspring } = this.props,
           drakeDef = drakes[0].alleleString,
           drakeSex = drakes[0].sex,
-          drake = new BioLogica.Organism(BioLogica.Species.Drake, drakeDef, drakeSex);
+          userDrake = new BioLogica.Organism(BioLogica.Species.Drake, drakeDef, drakeSex);
     let [,...keptDrakes] = drakes;
     keptDrakes = keptDrakes.asMutable().map((org) => new BioLogica.Organism(BioLogica.Species.Drake, org.alleleString, org.sex));
     let penView = <div className='columns bottom'>
@@ -27,8 +27,7 @@ export default class GenomeContainer extends Component {
     };
 
     const handleSubmit = function() {
-      let child = new BioLogica.Organism(BioLogica.Species.Drake, drakes[0].alleleString, drakes[0].sex),
-          childImage = child.getImageName(),
+      let childImage = userDrake.getImageName(),
           [,...keptDrakes] = drakes,
           success = true;
       for (let drake of keptDrakes) {
@@ -45,10 +44,10 @@ export default class GenomeContainer extends Component {
       <div id="genome-playground">
         <div className='column'>
             <ChangeSexButtons id="change-sex-buttons" sex={ drakeSex } onChange= { handleSexChange } showLabel={true} species="Drake" />
-            <GenomeView className="drake-genome" org={ drake } onAlleleChange={ handleAlleleChange } userChangeableGenes= { userChangeableGenes } visibleGenes={ visibleGenes } hiddenAlleles={ hiddenAlleles }/>
+            <GenomeView className="drake-genome" org={ userDrake } onAlleleChange={ handleAlleleChange } userChangeableGenes= { userChangeableGenes } visibleGenes={ visibleGenes } hiddenAlleles={ hiddenAlleles }/>
         </div>
         <div className='column'>
-            <OrganismGlowView id="drake-image" org={ drake } />
+            <OrganismGlowView id="drake-image" org={ userDrake } />
             <ButtonView label="~BUTTON.SAVE_DRAKE" id="save-button" onClick={ handleSubmit } />
             {penView} 
         </div>

--- a/src/code/templates/genome-playground.js
+++ b/src/code/templates/genome-playground.js
@@ -2,16 +2,22 @@ import React, { Component, PropTypes } from 'react';
 import OrganismGlowView from '../components/organism-glow';
 import GenomeView from '../components/genome';
 import ButtonView from '../components/button';
+import PenView from '../components/pen';
 import ChangeSexButtons from '../components/change-sex-buttons';
 
 export default class GenomeContainer extends Component {
 
   render() {
-    const { drakes, onChromosomeAlleleChange, onSexChange, onCompleteChallenge, userChangeableGenes, visibleGenes, hiddenAlleles } = this.props,
+    const { drakes, onChromosomeAlleleChange, onSexChange, userChangeableGenes, visibleGenes, hiddenAlleles, onKeepOffspring } = this.props,
           drakeDef = drakes[0].alleleString,
           drakeSex = drakes[0].sex,
           drake = new BioLogica.Organism(BioLogica.Species.Drake, drakeDef, drakeSex);
-
+    let [,...keptDrakes] = drakes;
+    keptDrakes = keptDrakes.asMutable().map((org) => new BioLogica.Organism(BioLogica.Species.Drake, org.alleleString, org.sex));
+    let penView = <div className='columns bottom'>
+                    <PenView orgs={ keptDrakes } width={500} columns={5} rows={1} tightenRows={20}/>
+                  </div>;
+    
     const handleAlleleChange = function(chrom, side, prevAllele, newAllele) {
       onChromosomeAlleleChange(0, chrom, side, prevAllele, newAllele);
     };
@@ -20,8 +26,19 @@ export default class GenomeContainer extends Component {
       onSexChange(0, newSex);
     };
 
-    const handleAdvanceChallenge = function() {
-      onCompleteChallenge();
+    const handleSubmit = function() {
+      let child = new BioLogica.Organism(BioLogica.Species.Drake, drakes[0].alleleString, drakes[0].sex),
+          childImage = child.getImageName(),
+          [,...keptDrakes] = drakes,
+          success = true;
+      for (let drake of keptDrakes) {
+        let org = new BioLogica.Organism(BioLogica.Species.Drake, drake.alleleString, drake.sex);
+        if (org.getImageName() === childImage) {
+          success = false;
+          break;
+        }
+      }
+      onKeepOffspring(0, success, 6, true);
     };
 
     return (
@@ -32,7 +49,8 @@ export default class GenomeContainer extends Component {
         </div>
         <div className='column'>
             <OrganismGlowView id="drake-image" org={ drake } />
-            <ButtonView label="~BUTTON.PLAYGROUND_MOVE_FORWARD" id="advance-button" onClick={ handleAdvanceChallenge } />
+            <ButtonView label="~BUTTON.SAVE_DRAKE" id="save-button" onClick={ handleSubmit } />
+            {penView} 
         </div>
       </div>
     );
@@ -45,7 +63,7 @@ export default class GenomeContainer extends Component {
     hiddenAlleles: PropTypes.array.isRequired,
     onChromosomeAlleleChange: PropTypes.func.isRequired,
     onSexChange: PropTypes.func.isRequired,
-    onCompleteChallenge: PropTypes.func.isRequired
+    onKeepOffspring: PropTypes.func.isRequired
   }
 
   static authoredDrakesToDrakeArray = function(auth) {

--- a/src/code/utilities/genetics-utils.js
+++ b/src/code/utilities/genetics-utils.js
@@ -394,6 +394,22 @@ export default class GeneticsUtils {
   }
 
   /**
+   * Returns a string containing the alleles present in the fully specified organism, but not in
+   * the partially specified organism. For example, if a female and male organism are given, the returned string
+   * will represent the sex-linked chromosomes that the male organism lacks.
+   *
+   * @param {object} fullySpecifiedOrganism - the organism containing the extra alleles
+   * @param {object} partiallySpecifiedOrganism - the organism lacking the extra alleles
+   * @return {string} - a comma-separated string representing the extra alleles, e.g. "b:D,b:Bog,b:rh"
+   */
+  static computeExtraAlleles(fullySpecifiedOrganism, partiallySpecifiedOrganism) {
+    let fullAlleles = fullySpecifiedOrganism.getAlleleString().split(",");
+    let partialAlleles = partiallySpecifiedOrganism.getAlleleString().split(",");
+    let extraAlleles = fullAlleles.filter(function(allele) { return partialAlleles.indexOf(allele) === -1; });
+    return extraAlleles.join(",");
+  }
+
+  /**
    * Goes through the traitRules to find out what unique alleles are associated with each trait
    * e.g. For "tail" it will return ["T", "Tk", "t"]. Adapted from:
    * @see https://github.com/concord-consortium/Geniverse-SproutCore/blob/master/frameworks/geniverse/controllers/match.js

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -36,9 +36,9 @@
       }
     },
     {
-      "comment": "*** Dragon 1.1: Alazar (piece 2): #2/2 - Three Drakes (User Drake Hidden) ***",
+      "comment": "*** Dragon 1.1: Alazar (piece 2): #2/2 - Two Drakes (User Drake Hidden) ***",
       "template": "GenomeChallenge",
-      "instructions": "Match 3 drakes!",
+      "instructions": "Match 2 drakes!",
       "trialGenerator": {
         "type": "all-combinations",
         "baseDrake": "T-T, h-h, A1-A1, C-C, B-B, D-D, rh-rh, Bog-Bog",

--- a/test/actions/change-sex.js
+++ b/test/actions/change-sex.js
@@ -47,7 +47,6 @@ describe('changeSex action', () => {
       expect(nextState).toEqual(initialState.setIn(["drakes", 0], {
         alleleString: 'a:T,b:T,a:m,b:M,a:w,b:w,a:h,b:h,a:C,b:C,a:B,b:B,a:Fl,b:Fl,a:Hl,b:hl,a:A1,b:A1,a:D,a:Bog,a:rh,b:bog,a:Rh',
         sex: 1,
-        secondXAlleles: null
       }));
     });
   });
@@ -59,7 +58,6 @@ describe('changeSex action', () => {
         [{
           alleleString: "a:T,b:T,a:m,b:M,a:w,b:w,a:h,b:h,a:C,b:C,a:B,b:B,a:Fl,b:Fl,a:Hl,b:hl,a:A1,b:A1,a:D,b:D,a:Bog,a:rh,b:bog,b:Rh",
           sex: 1,
-          secondXAlleles: null
         }]);
 
       let nextState = reducer(initialState, {

--- a/test/actions/change-sex.js
+++ b/test/actions/change-sex.js
@@ -49,9 +49,7 @@ describe('changeSex action', () => {
         sex: 1,
       }));
     });
-  });
 
-  describe('the reducer', () => {
     it('should update the drakes sex and store the allele string when passed a SEX_CHANGED action to male', () => {
       let defaultState = reducer(undefined, {});
       let initialState = defaultState.set("drakes",
@@ -72,6 +70,24 @@ describe('changeSex action', () => {
         sex: 0,
         secondXAlleles: "b:D,b:bog,b:Rh"
       }));
+    });
+
+    it('should not modify the allele string if no secondXAlleles are specified when switching from male to female.', () => {
+      let defaultState = reducer(undefined, {});
+      let initialState = defaultState.set("drakes",
+        [{
+          alleleString: "a:T,b:T,a:m,b:M,a:w,b:w,a:h,b:h,a:C,b:C,a:B,b:B,a:Fl,b:Fl,a:Hl,b:hl,a:A1,b:A1,a:D,a:Bog,a:rh",
+          sex: 0
+        }]);
+
+      let nextState = reducer(initialState, {
+        type: types.SEX_CHANGED,
+        index: 0,
+        newSex: 1,
+        incrementMoves: false
+      });
+
+      expect(nextState.drakes[0].alleleString).toEqual(initialState.drakes[0].alleleString);
     });
   });
 });

--- a/test/actions/change-sex.js
+++ b/test/actions/change-sex.js
@@ -28,12 +28,13 @@ describe('changeSex action', () => {
   });
 
   describe('the reducer', () => {
-    it('should update the drakes sex when passed a SEX_CHANGED action', () => {
+    it('should update the drakes sex and expand the allele string when passed a SEX_CHANGED action to female', () => {
       let defaultState = reducer(undefined, {});
       let initialState = defaultState.set("drakes",
         [{
           alleleString: "a:T,b:T,a:m,b:M,a:w,b:w,a:h,b:h,a:C,b:C,a:B,b:B,a:Fl,b:Fl,a:Hl,b:hl,a:A1,b:A1,a:D,a:Bog,a:rh",
-          sex: 0
+          sex: 0,
+          secondXAlleles: "b:bog,a:Rh"
         }]);
 
       let nextState = reducer(initialState, {
@@ -44,8 +45,34 @@ describe('changeSex action', () => {
       });
 
       expect(nextState).toEqual(initialState.setIn(["drakes", 0], {
+        alleleString: 'a:T,b:T,a:m,b:M,a:w,b:w,a:h,b:h,a:C,b:C,a:B,b:B,a:Fl,b:Fl,a:Hl,b:hl,a:A1,b:A1,a:D,a:Bog,a:rh,b:bog,a:Rh',
+        sex: 1,
+        secondXAlleles: null
+      }));
+    });
+  });
+
+  describe('the reducer', () => {
+    it('should update the drakes sex and store the allele string when passed a SEX_CHANGED action to male', () => {
+      let defaultState = reducer(undefined, {});
+      let initialState = defaultState.set("drakes",
+        [{
+          alleleString: "a:T,b:T,a:m,b:M,a:w,b:w,a:h,b:h,a:C,b:C,a:B,b:B,a:Fl,b:Fl,a:Hl,b:hl,a:A1,b:A1,a:D,b:D,a:Bog,a:rh,b:bog,b:Rh",
+          sex: 1,
+          secondXAlleles: null
+        }]);
+
+      let nextState = reducer(initialState, {
+        type: types.SEX_CHANGED,
+        index: 0,
+        newSex: 0,
+        incrementMoves: false
+      });
+
+      expect(nextState).toEqual(initialState.setIn(["drakes", 0], {
         alleleString: 'a:T,b:T,a:m,b:M,a:w,b:w,a:h,b:h,a:C,b:C,a:B,b:B,a:Fl,b:Fl,a:Hl,b:hl,a:A1,b:A1,a:D,a:Bog,a:rh',
-        sex: 1
+        sex: 0,
+        secondXAlleles: "b:D,b:bog,b:Rh"
       }));
     });
   });

--- a/test/actions/keep-offspring.js
+++ b/test/actions/keep-offspring.js
@@ -1,0 +1,71 @@
+import expect from 'expect';
+import * as actions from '../../src/code/actions';
+
+const types = actions.actionTypes;
+
+describe('keepOffspring action', () => {
+  const interactionType = "select-chromosomes",
+        userDrakeIndex = 0, 
+        maxDrakes = 6, 
+        shouldKeepSourceDrake = false,
+        
+        alleleString =  "a:T,b:T,a:m,b:m,a:w,b:w,a:h,b:h,a:C,b:C,a:B,b:B,a:fl,b:fl,a:hl,b:Hl,a:A1,b:A1,a:D,b:D,a:Bog,b:Bog,a:rh,b:rh",
+        // different genotype, same phenotype/image
+        similarAlleleString = "a:T,b:T,a:m,b:m,a:w,b:w,a:h,b:h,a:C,b:C,a:B,b:B,a:fl,b:fl,a:hl,b:Hl,a:A1,b:A1,a:D,b:D,a:Bog,b:Bog,a:rh,b:rh";
+        
+  it('should create a function which dispatches the correct action when an offspring is kept', () => {
+    const keptDrakeIndices = [],
+          keepOffspringAction = { 
+            type: types.OFFSPRING_KEPT, 
+            interactionType, 
+            index: userDrakeIndex, 
+            success: true, 
+            incrementMoves: false, 
+            shouldKeepSourceDrake
+          };
+
+    const dispatch = expect.createSpy(),
+          getState = expect.createSpy().andReturn({
+            drakes: [{
+              alleleString: alleleString,
+              sex: 1
+            }],
+            interactionType: interactionType
+          });
+
+    actions.keepOffspring(userDrakeIndex, keptDrakeIndices, maxDrakes, shouldKeepSourceDrake)(dispatch, getState);
+
+    expect(dispatch).toHaveBeenCalledWith(keepOffspringAction);
+    expect(dispatch.calls.length).toBe(1);
+  });
+
+  it('should create a function which dispatches a failed action when a duplicate offspring is kept', () => {
+    const keptDrakeIndices = [1],
+          keepOffspringAction = { 
+            type: types.OFFSPRING_KEPT, 
+            interactionType, 
+            index: userDrakeIndex, 
+            success: false, 
+            incrementMoves: true, 
+            shouldKeepSourceDrake 
+          };
+
+    const dispatch = expect.createSpy(),
+          getState = expect.createSpy().andReturn({
+            drakes: [{
+              alleleString: alleleString,
+              sex: 1
+            },
+            {
+              alleleString: similarAlleleString,
+              sex: 1
+            }],
+            interactionType: interactionType
+          });
+
+    actions.keepOffspring(userDrakeIndex, keptDrakeIndices, maxDrakes, shouldKeepSourceDrake)(dispatch, getState);
+
+    expect(dispatch).toHaveBeenCalledWith(keepOffspringAction);
+    expect(dispatch.calls.length).toBe(2); // Keep offspring and failure actions are dispatched
+  });
+});

--- a/test/templates/egg-game.js
+++ b/test/templates/egg-game.js
@@ -83,7 +83,7 @@ describe('loading authored state into template', () => {
                 "alleles": "w-w, T-T",
                 "sex": 1
               },
-              "targetDrakes": [{"sex": 0},{"sex": 0},{"sex": 0}]
+              "targetDrakes": [{},{},{}]
             }
           ]
         ], ["alleles"]);
@@ -106,33 +106,28 @@ describe('loading authored state into template', () => {
           "drakes": [
             {
               "alleleString": nextState.drakes[0].alleleString, // we check valid alleles below
-              "secondXAlleles": null,
               "sex": 1
             },
             {
               "alleleString": nextState.drakes[1].alleleString,
-              "secondXAlleles": null,
               "sex": 1
             },
             null,
             {
               "alleleString": nextState.drakes[3].alleleString,
-              "secondXAlleles": null,
               "sex": nextState.drakes[3].sex
             },
             {
               "alleleString": nextState.drakes[4].alleleString,
-              "secondXAlleles": null,
               "sex": nextState.drakes[4].sex
             },
             {
               "alleleString": nextState.drakes[5].alleleString,
-              "secondXAlleles": null,
               "sex": nextState.drakes[5].sex
             }
           ],
           "goalMoves": nextState.goalMoves,
-          "trials": [ {"sex": 0}, {"sex": 0}, {"sex": 0} ],
+          "trials": [ {}, {}, {} ],
           "trialOrder": [0,1,2]
         }));
     });

--- a/test/templates/egg-game.js
+++ b/test/templates/egg-game.js
@@ -81,9 +81,9 @@ describe('loading authored state into template', () => {
               },
               "father": {
                 "alleles": "w-w, T-T",
-                "sex": 0
+                "sex": 1
               },
-              "targetDrakes": [{},{},{}]
+              "targetDrakes": [{"sex": 0},{"sex": 0},{"sex": 0}]
             }
           ]
         ], ["alleles"]);
@@ -106,28 +106,33 @@ describe('loading authored state into template', () => {
           "drakes": [
             {
               "alleleString": nextState.drakes[0].alleleString, // we check valid alleles below
+              "secondXAlleles": null,
               "sex": 1
             },
             {
               "alleleString": nextState.drakes[1].alleleString,
-              "sex": 0
+              "secondXAlleles": null,
+              "sex": 1
             },
             null,
             {
               "alleleString": nextState.drakes[3].alleleString,
+              "secondXAlleles": null,
               "sex": nextState.drakes[3].sex
             },
             {
               "alleleString": nextState.drakes[4].alleleString,
+              "secondXAlleles": null,
               "sex": nextState.drakes[4].sex
             },
             {
               "alleleString": nextState.drakes[5].alleleString,
+              "secondXAlleles": null,
               "sex": nextState.drakes[5].sex
             }
           ],
           "goalMoves": nextState.goalMoves,
-          "trials": [ {}, {}, {} ],
+          "trials": [ {"sex": 0}, {"sex": 0}, {"sex": 0} ],
           "trialOrder": [0,1,2]
         }));
     });

--- a/test/templates/genome-challenge.js
+++ b/test/templates/genome-challenge.js
@@ -46,8 +46,8 @@ describe('loading authored state into template', () => {
             {
               "template": "GenomeChallenge",
               "initialDrake":{
-                "alleles": "W-w",
-                "sex": 1
+                "alleles": "W-w, D-D, Bog-Bog, rh-rh",
+                "sex": 0
               },
               "targetDrakes": [{
                 "alleles": "W-W",
@@ -77,7 +77,8 @@ describe('loading authored state into template', () => {
           "drakes": [
             {
               "alleleString": nextState.drakes[0].alleleString, // we check valid alleles below
-              "sex": 1
+              "secondXAlleles": "b:D,b:Bog,b:rh",
+              "sex": 0
             },
             {
               "alleleString": nextState.drakes[1].alleleString,

--- a/test/templates/genome-challenge.js
+++ b/test/templates/genome-challenge.js
@@ -77,12 +77,10 @@ describe('loading authored state into template', () => {
           "drakes": [
             {
               "alleleString": nextState.drakes[0].alleleString, // we check valid alleles below
-              "secondXAlleles": null,
               "sex": 1
             },
             {
               "alleleString": nextState.drakes[1].alleleString,
-              "secondXAlleles": null,
               "sex": 1
             }
           ],

--- a/test/templates/genome-challenge.js
+++ b/test/templates/genome-challenge.js
@@ -77,10 +77,12 @@ describe('loading authored state into template', () => {
           "drakes": [
             {
               "alleleString": nextState.drakes[0].alleleString, // we check valid alleles below
+              "secondXAlleles": null,
               "sex": 1
             },
             {
               "alleleString": nextState.drakes[1].alleleString,
+              "secondXAlleles": null,
               "sex": 1
             }
           ],


### PR DESCRIPTION
@kswenson @sfentress These commits first change the "sandbox" tutorial level into a "create 5 drakes" level which includes a drake pen. This change uses many of the same actions as the other template which includes a pen- the main difference is that here the baby drake is not removed when it is added to the pen.

The other fix is to address issues with sex-linked traits changing as a dragon's sex is changed. Now, as in GV1.0, when a drake changes from female to male, it records any alleles it is losing in the Redux state. When the drake changes from male to female, it restores any alleles so that it returns to the same state as the original female drake.

One difference from GV1.0 is that you can now fully specify an initial drake, regardless of its sex. By over-specifying a male (i.e. providing a full set of sex linked alleles), you specify how the drake will look if converted to a female. This happens during the initialization of the drakes array, by comparing the male drake to a female drake created with the same authored alleles.