### PR TITLE
Preventing columns from wrapping in playground.

### DIFF
--- a/src/stylus/challenges.styl
+++ b/src/stylus/challenges.styl
@@ -43,10 +43,11 @@
     margin: 160px 0 30px -100px;
   }
 
-  #genome-playground #change-sex-buttons {
-    margin: 60px 0 30px -100px;
-  }
-
+  #genome-playground
+    display: flex;
+    #change-sex-buttons
+      margin: 60px 0 30px -100px;
+      
   #genome-challenge #change-sex-buttons {
     margin: 60px 0 0 0;
   }


### PR DESCRIPTION
The playground's display was getting set to `block` by default, so here I'm forcing it to `flex` so it no longer wraps when the window becomes smaller (because of the `nowrap` property set elsewhere). I wanted to check that makes sense, and one more thing: most of the rules in this file use brackets for rules, but I can't seem to use the stylus-style indenting if I include them here. Is it ok to omit them? 