### PR TITLE
Updating chromosome layouts to FV style

### DIFF
--- a/src/code/components/chromosome.js
+++ b/src/code/components/chromosome.js
@@ -27,13 +27,16 @@ const ChromosomeView = ({chromosome, org, ChromosomeImageClass=ChromosomeImageVi
 
     if (showLabels) {
       let labels = visibleAlleles.map(a => {
-        return (
+        if (ChromosomeImageClass === ChromosomeImageView) {
+          return (
           <GeneLabelView key={a.allele} species={chromosome.species} allele={a.allele} editable={editable && a.editable}
           hiddenAlleles={ hiddenAlleles }
           onAlleleChange={function(event) {
             onAlleleChange(a.allele, event.target.value);
-          }}/>
-        );
+          }}/>);
+        } else {
+          return <div className="geniblocks fv-gene-label allele noneditable">{chromosome.species.alleleLabelMap[a.allele]}</div>;
+        }
       });
 
       labelsContainer = (

--- a/src/stylus/fablevision/fv-chromosome.styl
+++ b/src/stylus/fablevision/fv-chromosome.styl
@@ -22,3 +22,8 @@
 
   &.yChromosome
     background: url('../resources/fablevision/layout-c/chromosome_half_dark.png')
+
+.geniblocks.fv-gene-label
+  font-family: 'Yanone Kaffeesatz'
+  font-size: 1.5rem
+  color: white


### PR DESCRIPTION
Simple fix to update chromosome labels to static text, switching on the `ChromosomeImageClass`