### PR TITLE
Windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "axios": "^0.15.3",
     "babel-polyfill": "^6.20.0",
     "classnames": "^2.2.5",
+    "es6-object-assign": "^1.0.3",
     "lodash": "^4.17.3",
     "mustache": "^2.3.0",
     "react": "^15.4.1",

--- a/src/code/app.js
+++ b/src/code/app.js
@@ -31,6 +31,10 @@ import urlParams from './utilities/url-params';
 import GuideProtocol from './utilities/guide-protocol';
 import uuid from 'uuid';
 
+// trivial check for Windows as part of user agent string
+if (navigator.userAgent.indexOf('Windows') >= 0)
+  document.body.className += ' os-windows';
+
 function convertAuthoring(authoring) {
   return GeneticsUtils.convertDashAllelesObjectToABAlleles(authoring,
                           ["alleles", "baseDrake","initialDrakeCombos", "targetDrakeCombos"]);

--- a/src/code/app.js
+++ b/src/code/app.js
@@ -1,3 +1,6 @@
+// Polyfill, modifying the global Object
+require('es6-object-assign').polyfill();
+
 import React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';

--- a/src/code/app.js
+++ b/src/code/app.js
@@ -1,5 +1,6 @@
 // Polyfill, modifying the global Object
 require('es6-object-assign').polyfill();
+import 'babel-polyfill';
 
 import React from 'react';
 import { render } from 'react-dom';

--- a/src/code/containers/modal-message-container.js
+++ b/src/code/containers/modal-message-container.js
@@ -2,7 +2,8 @@ import { connect } from 'react-redux';
 import ModalAlert from '../components/modal-alert';
 import * as actions from '../actions';
 import { resetGametes } from '../modules/gametes';
-Object.assign(actions, { resetGametes });
+// merge with the other actions
+actions.resetGametes = resetGametes;
 
 function mapStateToProps (state) {
   let props = state.modalDialog;

--- a/src/code/geniblocks.js
+++ b/src/code/geniblocks.js
@@ -4,6 +4,9 @@
  * for description of some of the details involved in mixing ES6 export with require().
  */
 
+// Polyfill, modifying the global Object
+require('es6-object-assign').polyfill();
+
 // components
 export { default as AlleleFiltersView } from './components/allele-filters';
 export { default as AlleleView } from './components/allele';

--- a/src/stylus/fablevision/breed-button.styl
+++ b/src/stylus/fablevision/breed-button.styl
@@ -37,3 +37,9 @@
 
     .breed-button-label
       font-size: 3rem
+
+.os-windows
+  .geniblocks.breed-button-surround
+    .breed-button
+      .breed-button-label
+        margin-top: 0.4rem

--- a/src/stylus/fablevision/fv-stable.styl
+++ b/src/stylus/fablevision/fv-stable.styl
@@ -30,3 +30,8 @@
     margin-top: 20px
     margin-right: 30px
     align-self: flex-end
+
+.os-windows
+  .geniblocks.fv-stable
+    .stable-counter
+      margin-top: 0.4rem

--- a/src/stylus/fablevision/parent-drake.styl
+++ b/src/stylus/fablevision/parent-drake.styl
@@ -33,3 +33,8 @@
     margin-top: 10px
   .organism
     margin-top: -8px
+
+.os-windows
+  .geniblocks.parentDrake
+    .parentTitle
+      margin-top: 1rem

--- a/yarn.lock
+++ b/yarn.lock
@@ -1774,6 +1774,10 @@ es6-map@^0.1.3:
     es6-symbol "~3.1.0"
     event-emitter "~0.3.4"
 
+es6-object-assign@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.0.3.tgz#40a192e0fda5ee44ee8cf6f5b5d9b47cd0f69b14"
+
 es6-promise@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-2.3.0.tgz#96edb9f2fdb01995822b263dd8aadab6748181bc"


### PR DESCRIPTION
- add polyfills for IE11 support
- add text adjustments for all Windows browsers

All Windows browsers tested (Chrome, Firefox, IE11) showed the same text offsets, suggesting that it may be a font-metrics issue rather than a browser issue. We "fix" it for the time being by user agent-sniffing for Windows and adding the `os-windows` class to the `<body>` tag if appropriate. Then CSS is used on a case-by-case basis to adjust the text where appropriate.

Note: after review, let me merge so I can rebase appropriately.