### PR TITLE
Move ITS notifications next to user drake [#142012501]

### DIFF
--- a/src/code/components/notifications.js
+++ b/src/code/components/notifications.js
@@ -7,6 +7,7 @@ import t from '../utilities/translate';
 class Notifications extends React.Component {
 
   static propTypes = {
+    location: PropTypes.object,
     notifications: PropTypes.array
   }
 
@@ -15,12 +16,14 @@ class Notifications extends React.Component {
   }
 
   render() {
-    const messages = this.props.notifications.map((message, i) =>
-        <div key={i} className="notification">{ t(message) }</div>
-      );
+    const { location } = this.props,
+          style = location ? { left: location.left, top: location.top, right: 'auto' } : null,
+          messages = this.props.notifications.map((message, i) =>
+                        <div key={i} className="notification">{ t(message) }</div>);
+
 
     return (
-      <div className="geniblocks notification-container">
+      <div className="geniblocks notification-container" style={style}>
         { messages }
       </div>
     );

--- a/src/code/containers/notification-container.js
+++ b/src/code/containers/notification-container.js
@@ -3,6 +3,13 @@ import Notifications from '../components/notifications';
 
 function mapStateToProps (state) {
     return {
+      // TODO: For the purposes of the upcoming classroom test we simply stash the location
+      // in a global. Beyond the classroom test, the ITS feedback will presumably end up in
+      // the HUD or some other such location so that this mechanism can be eliminated.
+      // If it weren't temporary, a better long-term solution would be to put the location
+      // in the state and have it handled via normal redux mechanisms, but that effort
+      // doesn't seem worth it given the temporary nature of the need.
+      location: window.gNotificationLocation,
       notifications: state.notifications
     };
   }

--- a/src/code/fv-components/breed-button-area.js
+++ b/src/code/fv-components/breed-button-area.js
@@ -2,6 +2,7 @@ import React, {PropTypes} from 'react';
 import BreedButtonView from './breed-button';
 import OrganismView from '../components/organism';
 import classNames from 'classnames';
+import unscaleProperties from '../utilities/unscale-properties';
 
 function isCompleteChromosomeSet(chromosomes) {
   return chromosomes && (chromosomes.length >= 3) &&
@@ -12,6 +13,7 @@ class BreedButtonAreaView extends React.Component {
 
   static propTypes = {
     challengeClasses: PropTypes.string,
+    scale: PropTypes.number,
     ovumChromosomes: PropTypes.array,
     spermChromosomes: PropTypes.array,
     userDrake: PropTypes.object,
@@ -51,6 +53,34 @@ class BreedButtonAreaView extends React.Component {
         { userDrakeView }
       </div>
     );
+  }
+
+  updateNotificationLocation() {
+    const breedButtonAreaNodes = document.getElementsByClassName('geniblocks breed-button-area'),
+          breedButtonAreaNode = breedButtonAreaNodes && breedButtonAreaNodes[0],
+          drakeImageNodes = breedButtonAreaNode &&
+                              breedButtonAreaNode.getElementsByClassName('geniblocks organism'),
+          drakeImageNode = drakeImageNodes && drakeImageNodes[0],
+          drakeImageBounds = drakeImageNode && drakeImageNode.getBoundingClientRect(),
+          unscaledDrakeImageBounds = drakeImageBounds && unscaleProperties(drakeImageBounds);
+    if (unscaledDrakeImageBounds) {
+      // TODO: For the purposes of the upcoming classroom test we simply stash the location
+      // in a global. Beyond the classroom test, the ITS feedback will presumably end up in
+      // the HUD or some other such location so that this mechanism can be eliminated.
+      // If it weren't temporary, a better long-term solution would be to put the location
+      // in the state and have it handled via normal redux mechanisms, but that effort
+      // doesn't seem worth it given the temporary nature of the need.
+      window.gNotificationLocation = { top: unscaledDrakeImageBounds.top - 12,
+                                      left: unscaledDrakeImageBounds.right + 2 };
+    }
+  }
+
+  componentDidMount() {
+    this.updateNotificationLocation();
+  }
+
+  componentDidUpdate() {
+    this.updateNotificationLocation();
   }
 
 }

--- a/src/code/templates/fv-egg-game.js
+++ b/src/code/templates/fv-egg-game.js
@@ -8,7 +8,7 @@
  */
 
 import React, { Component, PropTypes } from 'react';
-import { assign, clone, cloneDeep, forIn, shuffle, range } from 'lodash';
+import { assign, clone, cloneDeep, shuffle, range } from 'lodash';
 import classNames from 'classnames';
 import { motherGametePool, fatherGametePool, gametePoolSelector,
         motherSelectedGameteIndex, fatherSelectedGameteIndex } from '../modules/gametes';
@@ -22,6 +22,7 @@ import AnimatedComponentView from '../components/animated-component';
 import TargetDrakeView from '../fv-components/target-drake';
 import FVChromosomeImageView from '../fv-components/fv-chromosome-image';
 import TimerSet from '../utilities/timer-set';
+import unscaleProperties from '../utilities/unscale-properties';
 import t from '../utilities/translate';
 
 // debugging options to shorten animation/randomization for debugging purposes
@@ -89,15 +90,6 @@ function lookupGameteChromosomeDOMElement(sex, chromosomeName) {
       chromosomePositions = {"1": 0, "2": 1, "XY": 2};
   let genomeWrapper = wrapper.getElementsByClassName("genome")[0];
   return genomeWrapper.querySelectorAll(".fv-chromosome-image")[chromosomePositions[chromosomeName]];
-}
-
-function unscaleProperties(obj, scale=1) {
-  let scaledObj = {};
-  forIn(obj, function(value, key) {
-    if (typeof value === 'number')
-      scaledObj[key] = value / scale;
-  });
-  return scaledObj;
 }
 
 function findBothElements(sex, name, el, scale=1){
@@ -934,7 +926,7 @@ export default class FVEggGame extends Component {
   }
 
   render() {
-    const { challengeType, interactionType, showUserDrake, trial, drakes, gametes,
+    const { challengeType, interactionType, scale, showUserDrake, trial, drakes, gametes,
             userChangeableGenes, visibleGenes, userDrakeHidden, onChromosomeAlleleChange,
             onFertilize, onHatch, onResetGametes, onKeepOffspring, onDrakeSubmission } = this.props,
           { currentGametes } = gametes,
@@ -1145,7 +1137,7 @@ export default class FVEggGame extends Component {
           </div>
           <div className='egg column'>
             {offspringButtons}
-            <BreedButtonAreaView challengeClasses={classNames(challengeClasses)}
+            <BreedButtonAreaView challengeClasses={classNames(challengeClasses)} scale={scale}
                                   ovumChromosomes={ovumChromosomes} spermChromosomes={spermChromosomes}
                                   userDrake={child} showUserDrake={showUserDrake} userDrakeHidden={userDrakeHidden}
                                   isHatchingInProgress={animationEvents.hatch.inProgress}

--- a/src/code/utilities/unscale-properties.js
+++ b/src/code/utilities/unscale-properties.js
@@ -1,0 +1,10 @@
+import { forIn } from 'lodash';
+
+export default function unscaleProperties(obj, scale=1) {
+  let scaledObj = {};
+  forIn(obj, function(value, key) {
+    if (typeof value === 'number')
+      scaledObj[key] = value / scale;
+  });
+  return scaledObj;
+}


### PR DESCRIPTION
For the classroom test, Frieda requested that the ITS feedback be placed next to the user user drake. Ultimately, we expect it to come from a character in the HUD, so this approach is temporary and will likely be removed after the classroom test.

Note: after review, let me merge so I can rebase appropriately.