### PR TITLE
Fix animations when document is scrolled

### DIFF
--- a/src/code/utilities/unscale-properties.js
+++ b/src/code/utilities/unscale-properties.js
@@ -1,10 +1,32 @@
 import { forIn } from 'lodash';
 
+export function unscaleXPos(value, scale) {
+  // account for horizontal scroll position
+  return (value + window.pageXOffset) / scale;
+}
+
+export function unscaleYPos(value, scale) {
+  // account for vertical scroll position
+  return (value + window.pageYOffset) / scale;
+}
+
+export function unscaleExtent(value, scale) {
+  // extents aren't affected by scroll position
+  return value / scale;
+}
+
 export default function unscaleProperties(obj, scale=1) {
   let scaledObj = {};
+  const xPosProps = ['x', 'left', 'right'],
+        yPosProps = ['y', 'top', 'bottom'];
   forIn(obj, function(value, key) {
-    if (typeof value === 'number')
-      scaledObj[key] = value / scale;
+    if (typeof value === 'number') {
+      scaledObj[key] = xPosProps.indexOf(key) >= 0
+                        ? unscaleXPos(value, scale)
+                        : (yPosProps.indexOf(key) >= 0
+                            ? unscaleYPos(value, scale)
+                            : unscaleExtent(value, scale));
+    }
   });
   return scaledObj;
 }


### PR DESCRIPTION
- unscaling code must take scroll position into account

Note: although I'm tempted to try to get this in before tomorrow's classroom test, I think prudence suggests that we hold off on any more deployments unless a true showstopper is encountered.