### PR TITLE
Fix previous challenges

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,6 @@
     "react": "latest",
     "react-dnd": "https://unpkg.com/react-dnd@latest/dist/ReactDnD.min.js",
     "react-dnd-html5-backend": "https://unpkg.com/react-dnd-html5-backend@2.1.2/dist/ReactDnDHTML5Backend.min.js",
-    "biologica.js": "latest"
+    "biologica.js": "0.0.2"
   }
 }

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -271,7 +271,10 @@ function _submitDrake(targetDrakeIndex, userDrakeIndex, correct, state) {
         userDrakeOrg = GeneticsUtils.convertDrakeToOrg(state.drakes[userDrakeIndex]),
         initialDrakeOrg = state.initialDrakes[userDrakeIndex] ? GeneticsUtils.convertDrakeToOrg(state.initialDrakes[userDrakeIndex]) : null,
         routeSpec = state.routeSpec,
-        editableGenes = state.authoring[routeSpec.level][routeSpec.mission][routeSpec.challenge].visibleGenes.split(", ");
+        visibleGenes = state.authoring[routeSpec.level][routeSpec.mission][routeSpec.challenge].visibleGenes,
+        // TODO: figure out whether ITS really wants "editableGenes" or "visibleGenes"
+        // because it doesn't make sense to log the latter as the former
+        editableGenes = visibleGenes && visibleGenes.split(", ");
 
   return {
     type: actionTypes.DRAKE_SUBMITTED,

--- a/src/code/containers/challenge-container.js
+++ b/src/code/containers/challenge-container.js
@@ -54,8 +54,10 @@ function mapStateToProps (state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    onChromosomeAlleleChange: (index, chrom, side, prevAllele, newAllele) => dispatch(changeAllele(index, chrom, side, prevAllele, newAllele, true)),
-    onSexChange: (index, newSex) => dispatch(changeSex(index, newSex, true)),
+    onChromosomeAlleleChange: (index, chrom, side, prevAllele, newAllele, incrementMoves=true) =>
+      dispatch(changeAllele(index, chrom, side, prevAllele, newAllele, incrementMoves)),
+    onSexChange: (index, newSex, incrementMoves=true) =>
+      dispatch(changeSex(index, newSex, incrementMoves)),
     onDrakeSubmission: (targetDrakeIndex, userDrakeIndex, correct, incorrectAction) =>
       dispatch(submitDrake(targetDrakeIndex, userDrakeIndex, correct, incorrectAction)),
     onNavigateNextChallenge: () => dispatch(navigateToNextChallenge()),

--- a/src/code/containers/fv-challenge-container.js
+++ b/src/code/containers/fv-challenge-container.js
@@ -98,8 +98,10 @@ function mapStateToProps (state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    onChromosomeAlleleChange: (index, chrom, side, prevAllele, newAllele) => dispatch(changeAllele(index, chrom, side, prevAllele, newAllele, true)),
-    onSexChange: (index, newSex) => dispatch(changeSex(index, newSex, true)),
+    onChromosomeAlleleChange: (index, chrom, side, prevAllele, newAllele, incrementMoves=true) =>
+      dispatch(changeAllele(index, chrom, side, prevAllele, newAllele, incrementMoves)),
+    onSexChange: (index, newSex, incrementMoves=true) =>
+      dispatch(changeSex(index, newSex, incrementMoves)),
     onDrakeSubmission: (targetDrakeIndex, userDrakeIndex, correct, incorrectAction) =>
       dispatch(submitDrake(targetDrakeIndex, userDrakeIndex, correct, incorrectAction)),
     onNavigateNextChallenge: () => dispatch(navigateToNextChallenge()),

--- a/src/code/reducers/modal-dialog.js
+++ b/src/code/reducers/modal-dialog.js
@@ -1,6 +1,6 @@
 import Immutable from 'seamless-immutable';
 import actionTypes from '../action-types';
-import { GUIDE_MESSAGE_RECEIVED } from '../modules/notifications';
+import { GUIDE_ALERT_RECEIVED, GUIDE_MESSAGE_RECEIVED } from '../modules/notifications';
 
 const initialState = Immutable({
   show: false,
@@ -33,6 +33,7 @@ export default function modalDialog(state = initialState, action) {
     // while a dialog is being shown
     case actionTypes.BASKET_SELECTION_CHANGED:
     case actionTypes.DRAKE_SELECTION_CHANGED:
+    case GUIDE_ALERT_RECEIVED:
     case GUIDE_MESSAGE_RECEIVED:
       return state;
     // Assume for now that all other actions also close dialog

--- a/src/code/templates/genome-playground.js
+++ b/src/code/templates/genome-playground.js
@@ -18,13 +18,15 @@ export default class GenomeContainer extends Component {
     let penView = <div className='columns bottom'>
                     <PenView orgs={ keptDrakes } width={500} columns={5} rows={1} tightenRows={20}/>
                   </div>;
-    
+
+    // we don't increment the score, so users always get top mark from playground
+    const kNoScoreIncrement = false;
     const handleAlleleChange = function(chrom, side, prevAllele, newAllele) {
-      onChromosomeAlleleChange(0, chrom, side, prevAllele, newAllele);
+      onChromosomeAlleleChange(0, chrom, side, prevAllele, newAllele, kNoScoreIncrement);
     };
 
     const handleSexChange = function(newSex) {
-      onSexChange(0, newSex);
+      onSexChange(0, newSex, kNoScoreIncrement);
     };
 
     const handleSubmit = function() {
@@ -41,7 +43,7 @@ export default class GenomeContainer extends Component {
         <div className='column'>
             <OrganismGlowView id="drake-image" org={ userDrake } />
             <ButtonView label="~BUTTON.SAVE_DRAKE" id="save-button" onClick={ handleSubmit } />
-            {penView} 
+            {penView}
         </div>
       </div>
     );

--- a/src/stylus/challenges.styl
+++ b/src/stylus/challenges.styl
@@ -40,7 +40,11 @@ body
     align-items: center;
     flex-direction: column;
     float: left;
+    margin-top: 25px;
   }
+  &.fv-layout-c
+    .column
+      margin-top: 40px
   .column-label {
     margin-top: 125px;
     margin-bottom: 25px;
@@ -272,6 +276,10 @@ body
 
   &.centered
     flex-direction: row
+    justify-content: center
+
+.fv-layout-c
+  .columns.centered
     justify-content: space-around
 
 
@@ -366,7 +374,6 @@ body
 
   .fertilization
     display: flex
-    flex-direction: row
     align-items: flex-start
     height: 218px
 
@@ -391,7 +398,6 @@ body
         width: 76px
 
   .gametes
-    margin-top: -35px
     display: flex
     justify-content: space-between
     >div
@@ -413,23 +419,23 @@ body
     .ovum
       position: absolute
       transition: left 2s
-      top: -140px
+      top: -135px
       left: 110px
       &.matching
         top: -160px
     .sperm
       position: absolute
       transition: left 2s
-      top: -141px
+      top: -117px
       left: -12px
       &.matching
         top: -142px
 
     &.unfertilized
       .ovum
-        left: 20px
+        left: 75px
       .sperm
-        left: 110px
+        left: 65px
 
   .fertilize-button
     margin-top: 45px
@@ -467,6 +473,9 @@ body
     margin-top: 40px
     .egg .gametes
       margin-top: 20px
+  .egg
+    .fertilization
+      flex-direction: row
   .egg .gametes
     margin-top: 50px
     &.unfertilized


### PR DESCRIPTION
Fix a handful of issues in which changes for the new layout adversely affected old challenges. Some of these are layout issues, some are functionality.

- Redo some layout changes that adversely affected previous challenges in ways that don't have the adverse effects.
- Like regular guide messages, guide alert messages shouldn't dismiss dialogs before users have had a chance to read them
- Add null test for `visibleGenes` before dereferencing it
- Lock Biologia.js version at 0.0.2 to force usage of old allele strings
- User always gets gold coin for first playground level

Note: Currently depends on PR#89. This PR should be rebased once that one has been merged.
PR#89 has been merged and this PR has been rebased.