### PR TITLE
Add baseUser URL parameter [#142141187]

### DIFF
--- a/src/code/app.js
+++ b/src/code/app.js
@@ -43,7 +43,7 @@ window.GV2Authoring = convertAuthoring(authoring);
 
 // TODO: session ID and application name could be passed in via a container
 // use placeholder ID for duration of session and hard-coded name for now.
-const loggingMetadata = {
+let loggingMetadata = {
   applicationName: "GeniStarDev"
 };
 
@@ -75,8 +75,12 @@ const guideServer = "wss://guide.intellimedia.ncsu.edu",
       guideProtocol  = "guide-protocol-v2";
 initializeITSSocket(guideServer, guideProtocol, store);
 
+// generate pseudo-random sessionID and username
+const sessionID = uuid.v4(),
+      userNameBase = urlParams.baseUser || "gv2-user";
+loggingMetadata.userName = `${userNameBase}-${sessionID.split("-")[0]}`;
 // start the session before syncing history, which triggers navigation
-store.dispatch(startSession(uuid.v4()));
+store.dispatch(startSession(sessionID));
 
 const history = syncHistoryWithStore(hashHistory, store);
 

--- a/src/code/middleware/gv-log.js
+++ b/src/code/middleware/gv-log.js
@@ -76,7 +76,7 @@ function createLogEntry(loggingMetadata, action, nextState){
   const message =
     {
       application: loggingMetadata.applicationName,
-      username: "testuser-"+session.split("-")[0],
+      username: loggingMetadata.userName,
       session: session,
       time: Date.now(),
       activity: activity,

--- a/src/code/middleware/its-log.js
+++ b/src/code/middleware/its-log.js
@@ -29,7 +29,7 @@ export function initializeITSSocket(guideServer, guideProtocol, store) {
   return socket;
 }
 
-export default () => store => next => action => {
+export default loggingMetadata => store => next => action => {
 
   let result = next(action),
       nextState = store.getState();
@@ -67,7 +67,7 @@ export default () => store => next => action => {
     default: {
       // other action types - send to ITS
       if (action.meta && action.meta.itsLog){
-        let message = createLogEntry(action, nextState);
+        let message = createLogEntry(loggingMetadata, action, nextState);
         if (!isConnectonEstablished) {
           console.log("Queuing message for ITS:", message);
           msgQueue.push(message);
@@ -127,7 +127,7 @@ export function changePropertyValues(obj, key, func) {
     }
 }
 
-function createLogEntry(action, nextState){
+function createLogEntry(loggingMetadata, action, nextState){
   let event = { ...action.meta.itsLog },
       context = { ...action },
       routeSpec = nextState.routeSpec;
@@ -168,7 +168,7 @@ function createLogEntry(action, nextState){
 
   const message =
     {
-      username: "testuser-"+session.split("-")[0],
+      username: loggingMetadata.userName,
       session: session,
       time: Date.now(),
       sequence: sequence,


### PR DESCRIPTION
- `baseUser` defaults to "gv2-user" if URL parameter is not specified
- `userName` = "{baseUser}-{partialSessionID}"
- `userName` is constructed in app.js and passed to CC logger and ITS via `loggingMetadata`

Note: Currently depends on PR#89. This PR should be rebased once that one has been merged.
PR#89 has been merged and this PR has been rebased.