### PR TITLE
Authoring restructure

### DIFF
--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -88,14 +88,16 @@ export function navigateToNextChallenge() {
         nextLevel = routeSpec.level,
         nextMission = routeSpec.mission,
         nextChallenge = currentChallenge+1,
-        challengeCountInMission = authoring.levelHierarchy[currentLevel][currentMission].length;
+        challengeCountInMission = AuthoringUtils.getChallengeCount(authoring, currentLevel, currentMission);
     if (challengeCountInMission <= nextChallenge) {
+      let missionCountInLevel = AuthoringUtils.getMissionCount(authoring, currentLevel);
       // there are not enough challenges...if the next mission exists, navigate to it
-      if (authoring.levelHierarchy[currentLevel][currentMission+1]) {
+      if (currentMission + 1 < missionCountInLevel) {
         nextMission++;
       } else {
+        let levelCount = AuthoringUtils.getLevelCount(authoring);
         // otherwise, check if the next level exists
-        if (authoring.levelHierarchy[currentLevel+1]) {
+        if (currentLevel + 1 < levelCount) {
           nextLevel++;
         } else {
           // if no next level exists, loop around
@@ -147,12 +149,12 @@ function restrictToIntegerRange(value, minValue, maxValue) {
 export function navigateToCurrentRoute(routeSpec) {
   const {level, mission, challenge} = routeSpec;
   return (dispatch, getState) => {
-    const levels = getState().authoring.levelHierarchy,
-          levelCount = levels.length,
+    const authoring = getState().authoring,
+          levelCount = AuthoringUtils.getLevelCount(authoring),
           nextLevel = restrictToIntegerRange(level, 0, levelCount - 1),
-          missionCount = levels[nextLevel].length,
+          missionCount = AuthoringUtils.getMissionCount(authoring, nextLevel),
           nextMission = restrictToIntegerRange(mission, 0, missionCount - 1),
-          challengeCount = levels[nextLevel][nextMission].length,
+          challengeCount = AuthoringUtils.getChallengeCount(authoring, nextLevel, nextMission),
           nextChallenge = restrictToIntegerRange(challenge, 0, challengeCount - 1),
           routeChangeRequired = (level !== nextLevel) || (mission !== nextMission) || (challenge !== nextChallenge);
     // TODO: Ideally, route changes would be handled in their own module (see routing.js)
@@ -306,12 +308,10 @@ export function submitDrake(targetDrakeIndex, userDrakeIndex, correct, incorrect
     const state = getState();
     dispatch(_submitDrake(targetDrakeIndex, userDrakeIndex, correct, state));
 
-    const levels = state.authoring.levelHierarchy,
-          levelCount = levels.length,
-          missions = levels[state.routeSpec.level],
-          missionCount = missions.length,
-          challenges = missions[state.routeSpec.mission],
-          challengeCount = challenges.length,
+    const authoring = state.authoring,
+          levelCount = AuthoringUtils.getLevelCount(authoring),
+          missionCount = AuthoringUtils.getMissionCount(authoring, state.routeSpec.level),
+          challengeCount = AuthoringUtils.getChallengeCount(authoring, state.routeSpec.level, state.routeSpec.mission),
           trials = state.trials,
           trialCount = trials.length;
     let challengeComplete = false,
@@ -495,7 +495,7 @@ export function showCompleteChallengeDialog() {
   return (dispatch, getState) => {
     const state = getState();
 
-    const missionComplete = (state.authoring.levelHierarchy[state.routeSpec.level][state.routeSpec.mission].length <= state.routeSpec.challenge + 1);
+    const missionComplete = (AuthoringUtils.getChallengeCount(state.authoring, state.routeSpec.level, state.routeSpec.mission) <= state.routeSpec.challenge + 1);
 
     let dialog = {};
 

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -1,6 +1,7 @@
 import actionTypes from './action-types';
 import { ITS_ACTORS, ITS_ACTIONS, ITS_TARGETS } from './its-constants';
 import GeneticsUtils from './utilities/genetics-utils';
+import AuthoringUtils from './utilities/authoring-utils';
 
 export { actionTypes };
 
@@ -87,14 +88,14 @@ export function navigateToNextChallenge() {
         nextLevel = routeSpec.level,
         nextMission = routeSpec.mission,
         nextChallenge = currentChallenge+1,
-        challengeCountInMission = authoring[currentLevel][currentMission].length;
+        challengeCountInMission = authoring.levelHierarchy[currentLevel][currentMission].length;
     if (challengeCountInMission <= nextChallenge) {
       // there are not enough challenges...if the next mission exists, navigate to it
-      if (authoring[currentLevel][currentMission+1]) {
+      if (authoring.levelHierarchy[currentLevel][currentMission+1]) {
         nextMission++;
       } else {
         // otherwise, check if the next level exists
-        if (authoring[currentLevel+1]) {
+        if (authoring.levelHierarchy[currentLevel+1]) {
           nextLevel++;
         } else {
           // if no next level exists, loop around
@@ -146,7 +147,7 @@ function restrictToIntegerRange(value, minValue, maxValue) {
 export function navigateToCurrentRoute(routeSpec) {
   const {level, mission, challenge} = routeSpec;
   return (dispatch, getState) => {
-    const { authoring: levels } = getState(),
+    const levels = getState().authoring.levelHierarchy,
           levelCount = levels.length,
           nextLevel = restrictToIntegerRange(level, 0, levelCount - 1),
           missionCount = levels[nextLevel].length,
@@ -271,7 +272,7 @@ function _submitDrake(targetDrakeIndex, userDrakeIndex, correct, state) {
         userDrakeOrg = GeneticsUtils.convertDrakeToOrg(state.drakes[userDrakeIndex]),
         initialDrakeOrg = state.initialDrakes[userDrakeIndex] ? GeneticsUtils.convertDrakeToOrg(state.initialDrakes[userDrakeIndex]) : null,
         routeSpec = state.routeSpec,
-        visibleGenes = state.authoring[routeSpec.level][routeSpec.mission][routeSpec.challenge].visibleGenes,
+        visibleGenes = AuthoringUtils.getChallengeDefinition(state.authoring, routeSpec).visibleGenes,
         // TODO: figure out whether ITS really wants "editableGenes" or "visibleGenes"
         // because it doesn't make sense to log the latter as the former
         editableGenes = visibleGenes && visibleGenes.split(", ");
@@ -305,7 +306,7 @@ export function submitDrake(targetDrakeIndex, userDrakeIndex, correct, incorrect
     const state = getState();
     dispatch(_submitDrake(targetDrakeIndex, userDrakeIndex, correct, state));
 
-    const levels = state.authoring,
+    const levels = state.authoring.levelHierarchy,
           levelCount = levels.length,
           missions = levels[state.routeSpec.level],
           missionCount = missions.length,
@@ -494,7 +495,7 @@ export function showCompleteChallengeDialog() {
   return (dispatch, getState) => {
     const state = getState();
 
-    const missionComplete = (state.authoring[state.routeSpec.level][state.routeSpec.mission].length <= state.routeSpec.challenge + 1);
+    const missionComplete = (state.authoring.levelHierarchy[state.routeSpec.level][state.routeSpec.mission].length <= state.routeSpec.challenge + 1);
 
     let dialog = {};
 

--- a/src/code/app.js
+++ b/src/code/app.js
@@ -100,6 +100,7 @@ function renderApp() {
                     : <div>
                         <Router history={history}>
                           <Route path="/(:level/:mission/:challenge)" component={ChallengeContainerSelector} />
+                          <Route path="/(:challengeId)" component={ChallengeContainerSelector} />
                         </Router>
                         <ModalMessageContainer />
                         <NotificationContainer />

--- a/src/code/containers/challenge-container-selector.js
+++ b/src/code/containers/challenge-container-selector.js
@@ -3,10 +3,11 @@ import { connect } from 'react-redux';
 import { navigateToCurrentRoute, navigateToChallenge } from '../actions';
 import ChallengeContainer from './challenge-container';
 import FVChallengeContainer from './fv-challenge-container';
+import AuthoringUtils from '../utilities/authoring-utils';
+import urlParams from '../utilities/url-params';
 
-function hasChangedRouteParams(props) {
-  const { currentRouteSpec, routeParams } = props,
-        { level: currLevel, mission: currMission, challenge: currChallenge } = currentRouteSpec,
+function hasChangedRouteParams(currentRouteSpec, routeParams) {
+  const { level: currLevel, mission: currMission, challenge: currChallenge } = currentRouteSpec,
         currLevelStr = String(currLevel + 1),
         currMissionStr = String(currMission + 1),
         currChallengeStr = String(currChallenge + 1);
@@ -43,8 +44,13 @@ class ChallengeContainerSelector extends Component {
   }
 
   componentWillMount() {
-    const { routeParams, navigateToCurrentRoute, navigateToChallenge } = this.props;
-    if (hasChangedRouteParams(this.props)) {
+    const { navigateToCurrentRoute, navigateToChallenge, authoring } = this.props;
+    // the URL's challengeId is only used for initial routing, so prioritize the numeric route params
+    let routeParams = this.props.routeParams;
+    if (!routeParams.challenge && urlParams.challengeId) {
+      routeParams = AuthoringUtils.challengeIdToRouteParams(authoring, urlParams.challengeId);
+    }
+    if (hasChangedRouteParams(this.props.currentRouteSpec, routeParams)) {
       navigateToCurrentRoute({level: routeParams.level-1, mission: routeParams.mission-1, challenge: routeParams.challenge-1});
     } else {
       navigateToChallenge({level: 0, mission: 0, challenge: 0});
@@ -52,18 +58,19 @@ class ChallengeContainerSelector extends Component {
   }
 
   componentWillReceiveProps(newProps) {
-    const { routeParams, navigateToCurrentRoute } = newProps;
-    if (hasChangedRouteParams(newProps)) {
+    const { navigateToCurrentRoute, authoring } = newProps;
+    let routeParams = this.props.routeParams;
+    if (!routeParams.challenge && urlParams.challengeId) {
+      routeParams = AuthoringUtils.challengeIdToRouteParams(authoring, urlParams.challengeId);
+    }
+    if (hasChangedRouteParams(newProps.currentRouteSpec, routeParams)) {
       navigateToCurrentRoute({level: routeParams.level-1, mission: routeParams.mission-1, challenge: routeParams.challenge-1});
     }
   }
 
   render() {
     const { authoring, currentRouteSpec, ...otherProps } = this.props,
-          { level: currLevel, mission: currMission, challenge: currChallenge } = currentRouteSpec,
-          missionsInLevel = authoring.levelHierarchy[currLevel],
-          challengesInMission = missionsInLevel[currMission],
-          authoredChallenge = authoring.definitions[challengesInMission[currChallenge].challengeId],
+          authoredChallenge = AuthoringUtils.getChallengeDefinition(authoring, currentRouteSpec),
           containerName = authoredChallenge.container,
           ContainerClass = mapContainerNameToContainer(containerName);
     return (

--- a/src/code/containers/challenge-container-selector.js
+++ b/src/code/containers/challenge-container-selector.js
@@ -26,7 +26,7 @@ function mapContainerNameToContainer(containerName) {
 class ChallengeContainerSelector extends Component {
 
   static propTypes = {
-    authoring: PropTypes.array.isRequired,
+    authoring: PropTypes.object.isRequired,
     currentRouteSpec: PropTypes.shape({
       level: PropTypes.number,
       mission: PropTypes.number,
@@ -61,9 +61,9 @@ class ChallengeContainerSelector extends Component {
   render() {
     const { authoring, currentRouteSpec, ...otherProps } = this.props,
           { level: currLevel, mission: currMission, challenge: currChallenge } = currentRouteSpec,
-          missionsInLevel = authoring[currLevel],
+          missionsInLevel = authoring.levelHierarchy[currLevel],
           challengesInMission = missionsInLevel[currMission],
-          authoredChallenge = challengesInMission[currChallenge],
+          authoredChallenge = authoring.definitions[challengesInMission[currChallenge]],
           containerName = authoredChallenge.container,
           ContainerClass = mapContainerNameToContainer(containerName);
     return (

--- a/src/code/containers/challenge-container-selector.js
+++ b/src/code/containers/challenge-container-selector.js
@@ -4,7 +4,6 @@ import { navigateToCurrentRoute, navigateToChallenge } from '../actions';
 import ChallengeContainer from './challenge-container';
 import FVChallengeContainer from './fv-challenge-container';
 import AuthoringUtils from '../utilities/authoring-utils';
-import urlParams from '../utilities/url-params';
 
 function hasChangedRouteParams(currentRouteSpec, routeParams) {
   const { level: currLevel, mission: currMission, challenge: currChallenge } = currentRouteSpec,
@@ -47,8 +46,8 @@ class ChallengeContainerSelector extends Component {
     const { navigateToCurrentRoute, navigateToChallenge, authoring } = this.props;
     // the URL's challengeId is only used for initial routing, so prioritize the numeric route params
     let routeParams = this.props.routeParams;
-    if (!routeParams.challenge && urlParams.challengeId) {
-      routeParams = AuthoringUtils.challengeIdToRouteParams(authoring, urlParams.challengeId);
+    if (routeParams.challengeId) {
+      routeParams = AuthoringUtils.challengeIdToRouteParams(authoring, routeParams.challengeId);
     }
     if (hasChangedRouteParams(this.props.currentRouteSpec, routeParams)) {
       navigateToCurrentRoute({level: routeParams.level-1, mission: routeParams.mission-1, challenge: routeParams.challenge-1});
@@ -60,8 +59,8 @@ class ChallengeContainerSelector extends Component {
   componentWillReceiveProps(newProps) {
     const { navigateToCurrentRoute, authoring } = newProps;
     let routeParams = this.props.routeParams;
-    if (!routeParams.challenge && urlParams.challengeId) {
-      routeParams = AuthoringUtils.challengeIdToRouteParams(authoring, urlParams.challengeId);
+    if (routeParams.challengeId) {
+      routeParams = AuthoringUtils.challengeIdToRouteParams(authoring, routeParams.challengeId);
     }
     if (hasChangedRouteParams(newProps.currentRouteSpec, routeParams)) {
       navigateToCurrentRoute({level: routeParams.level-1, mission: routeParams.mission-1, challenge: routeParams.challenge-1});

--- a/src/code/containers/challenge-container-selector.js
+++ b/src/code/containers/challenge-container-selector.js
@@ -63,7 +63,7 @@ class ChallengeContainerSelector extends Component {
           { level: currLevel, mission: currMission, challenge: currChallenge } = currentRouteSpec,
           missionsInLevel = authoring.levelHierarchy[currLevel],
           challengesInMission = missionsInLevel[currMission],
-          authoredChallenge = authoring.definitions[challengesInMission[currChallenge]],
+          authoredChallenge = authoring.definitions[challengesInMission[currChallenge].challengeId],
           containerName = authoredChallenge.container,
           ContainerClass = mapContainerNameToContainer(containerName);
     return (

--- a/src/code/middleware/gv-log.js
+++ b/src/code/middleware/gv-log.js
@@ -1,6 +1,7 @@
 import actionTypes from '../action-types';
 import templates from '../templates';
 import urlParams from '../utilities/url-params';
+import AuthoringUtils from '../utilities/authoring-utils';
 
 function isLocalHostUrl() {
   const host = window.location.hostname;
@@ -46,7 +47,7 @@ function getValue(obj, path) {
 function createLogEntry(loggingMetadata, action, nextState){
   const eventName = action.type,
         routeSpec = nextState.routeSpec,
-        activity  = nextState.authoring[routeSpec.level][routeSpec.mission][routeSpec.challenge].challengeId;
+        activity  = AuthoringUtils.getChallengeId(nextState.authoring, routeSpec);
   let parameters = { ...action };
 
   if (action.meta && action.meta.logNextState) {

--- a/src/code/middleware/its-log.js
+++ b/src/code/middleware/its-log.js
@@ -2,8 +2,9 @@ import actionTypes from '../action-types';
 import templates from '../templates';
 import GuideProtocol from '../utilities/guide-protocol';
 import { GUIDE_CONNECTED, GUIDE_ERRORED,
-          GUIDE_MESSAGE_RECEIVED, GUIDE_ALERT_RECEIVED } from '../modules/notifications';
+         GUIDE_MESSAGE_RECEIVED, GUIDE_ALERT_RECEIVED } from '../modules/notifications';
 import io from 'socket.io-client';
+import AuthoringUtils from '../utilities/authoring-utils';
 
 var socket = null,
     session = "",
@@ -134,7 +135,7 @@ function createLogEntry(loggingMetadata, action, nextState){
 
   context["routeSpec"] = routeSpec;
   context["groupId"] = "verticalBite";
-  context["challengeId"] = nextState.authoring[routeSpec.level][routeSpec.mission][routeSpec.challenge].challengeId;
+  context["challengeId"] = AuthoringUtils.getChallengeId(nextState.authoring, routeSpec);
 
   if (action.meta.logNextState) {
     for (let prop in action.meta.logNextState) {

--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -1,6 +1,7 @@
 import templates from '../../templates';
 import GeneticsUtils from '../../utilities/genetics-utils';
 import { range, shuffle, assign } from 'lodash';
+import AuthoringUtils from '../../utilities/authoring-utils';
 
 /**
  * Tolerant splitter into a list of strings.
@@ -96,10 +97,8 @@ function createTrialOrder(trial, trials, currentTrialOrder, doShuffle) {
 export function loadStateFromAuthoring(state, authoring, progress={}) {
   let trial = state.trial ? state.trial : 0;
 
-  const missionArray = authoring.levelHierarchy[state.routeSpec.level],
-        challengeArray = missionArray[state.routeSpec.mission],
-        challenges = challengeArray && challengeArray.length,
-        authoredChallenge = challengeArray && authoring.definitions[challengeArray[state.routeSpec.challenge].challengeId];
+  const challenges = AuthoringUtils.getChallengeCount(authoring, state.routeSpec.level, state.routeSpec.mission),
+        authoredChallenge = AuthoringUtils.getChallengeDefinition(authoring, state.routeSpec);
   if (!authoredChallenge) return state;
 
   const templateName = authoredChallenge.template,

--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -96,10 +96,10 @@ function createTrialOrder(trial, trials, currentTrialOrder, doShuffle) {
 export function loadStateFromAuthoring(state, authoring, progress={}) {
   let trial = state.trial ? state.trial : 0;
 
-  const missionArray = authoring[state.routeSpec.level],
+  const missionArray = authoring.levelHierarchy[state.routeSpec.level],
         challengeArray = missionArray[state.routeSpec.mission],
         challenges = challengeArray && challengeArray.length,
-        authoredChallenge = challengeArray && challengeArray[state.routeSpec.challenge];
+        authoredChallenge = challengeArray && authoring.definitions[challengeArray[state.routeSpec.challenge]];
   if (!authoredChallenge) return state;
 
   const templateName = authoredChallenge.template,

--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -99,7 +99,7 @@ export function loadStateFromAuthoring(state, authoring, progress={}) {
   const missionArray = authoring.levelHierarchy[state.routeSpec.level],
         challengeArray = missionArray[state.routeSpec.mission],
         challenges = challengeArray && challengeArray.length,
-        authoredChallenge = challengeArray && authoring.definitions[challengeArray[state.routeSpec.challenge]];
+        authoredChallenge = challengeArray && authoring.definitions[challengeArray[state.routeSpec.challenge].challengeId];
   if (!authoredChallenge) return state;
 
   const templateName = authoredChallenge.template,

--- a/src/code/utilities/authoring-utils.js
+++ b/src/code/utilities/authoring-utils.js
@@ -1,0 +1,10 @@
+export default class AuthoringUtils {
+  static getChallengeDefinition(authoring, routeSpec) {
+    const challengeId = this.getChallengeId(authoring, routeSpec);
+    return authoring.definitions[challengeId];
+  }
+
+  static getChallengeId(authoring, routeSpec) {
+    return authoring.levelHierarchy[routeSpec.level][routeSpec.mission][routeSpec.challenge];
+  }
+}

--- a/src/code/utilities/authoring-utils.js
+++ b/src/code/utilities/authoring-utils.js
@@ -1,10 +1,51 @@
 export default class AuthoringUtils {
   static getChallengeDefinition(authoring, routeSpec) {
-    const challengeId = this.getChallengeId(authoring, routeSpec);
-    return authoring.definitions[challengeId];
+    const challengeId = this.getChallengeId(authoring, routeSpec),
+          challenges = authoring.challenges;
+    return challengeId && challenges ? authoring.challenges[challengeId] : null;
   }
 
   static getChallengeId(authoring, routeSpec) {
-    return authoring.levelHierarchy[routeSpec.level][routeSpec.mission][routeSpec.challenge].challengeId;
+    const levels = authoring.levelHierarchy,
+          missions = levels ? levels[routeSpec.level] : null,
+          challenges = missions ? missions[routeSpec.mission] : null,
+          challenge = challenges ? challenges[routeSpec.challenge] : null;
+    return challenge ? challenge.challengeId : null;
+  }
+
+  static getLevelCount(authoring) {
+    const levels = authoring.levelHierarchy;
+    return levels ? levels.length : null;
+  }
+
+  static getMissionCount(authoring, level) {
+    const levels = authoring.levelHierarchy,
+          missions = levels ? levels[level] : null;
+    return missions ? missions.length : null;
+  }
+
+  static getChallengeCount(authoring, level, mission) {
+    const levels = authoring.levelHierarchy,
+          missions = levels ? levels[level] : null,
+          challenges = missions ? missions[mission] : null;
+    return challenges.length;
+  }
+
+  static challengeIdToRouteParams(authoring, targetChallengeId) {
+    if (!authoring || !targetChallengeId) {
+      return null;
+    }
+
+    let routeSpec = null;
+    authoring.levelHierarchy.forEach((level, levelIndex) => {
+      level.forEach((mission, missionIndex) => {
+        mission.forEach((challenge, challengeIndex) => {
+          if (challenge.challengeId === targetChallengeId) {
+            routeSpec = {level: String(levelIndex + 1), mission: String(missionIndex + 1), challenge: String(challengeIndex + 1)};
+          }
+        });
+      });
+    });
+    return routeSpec;
   }
 }

--- a/src/code/utilities/authoring-utils.js
+++ b/src/code/utilities/authoring-utils.js
@@ -5,6 +5,6 @@ export default class AuthoringUtils {
   }
 
   static getChallengeId(authoring, routeSpec) {
-    return authoring.levelHierarchy[routeSpec.level][routeSpec.mission][routeSpec.challenge];
+    return authoring.levelHierarchy[routeSpec.level][routeSpec.mission][routeSpec.challenge].challengeId;
   }
 }

--- a/src/code/utilities/authoring-utils.js
+++ b/src/code/utilities/authoring-utils.js
@@ -6,28 +6,28 @@ export default class AuthoringUtils {
   }
 
   static getChallengeId(authoring, routeSpec) {
-    const levels = authoring.levelHierarchy,
-          missions = levels ? levels[routeSpec.level] : null,
-          challenges = missions ? missions[routeSpec.mission] : null,
+    const levels = authoring.application.levels,
+          missions = levels ? levels[routeSpec.level].missions : null,
+          challenges = missions ? missions[routeSpec.mission].challenges : null,
           challenge = challenges ? challenges[routeSpec.challenge] : null;
-    return challenge ? challenge.challengeId : null;
+    return challenge ? challenge.id : null;
   }
 
   static getLevelCount(authoring) {
-    const levels = authoring.levelHierarchy;
+    const levels = authoring.application.levels;
     return levels ? levels.length : null;
   }
 
   static getMissionCount(authoring, level) {
-    const levels = authoring.levelHierarchy,
-          missions = levels ? levels[level] : null;
+    const levels = authoring.application.levels,
+          missions = levels ? levels[level].missions : null;
     return missions ? missions.length : null;
   }
 
   static getChallengeCount(authoring, level, mission) {
-    const levels = authoring.levelHierarchy,
-          missions = levels ? levels[level] : null,
-          challenges = missions ? missions[mission] : null;
+    const levels = authoring.application.levels,
+          missions = levels ? levels[level].missions : null,
+          challenges = missions ? missions[mission].challenges : null;
     return challenges.length;
   }
 
@@ -37,10 +37,10 @@ export default class AuthoringUtils {
     }
 
     let routeSpec = null;
-    authoring.levelHierarchy.forEach((level, levelIndex) => {
+    authoring.application.levels.forEach((level, levelIndex) => {
       level.forEach((mission, missionIndex) => {
         mission.forEach((challenge, challengeIndex) => {
-          if (challenge.challengeId === targetChallengeId) {
+          if (challenge.id === targetChallengeId) {
             routeSpec = {level: String(levelIndex + 1), mission: String(missionIndex + 1), challenge: String(challengeIndex + 1)};
           }
         });

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -401,52 +401,156 @@
   },
 
 
-  "levelHierarchy": [
-    [
-      [
-        {"challengeId": "playground"}
-      ]
-    ],
+  "application": {
+    "levels": [
+      {
+        "name": "Level 1",
+        "missions": [
+          {
+            "name": "Mission 1.1",
+            "challenges": [
+              {
+                "name": "Challenge 1.1.1",
+                "id": "playground"
+              }
+            ]
+          }
+        ]
+      },
+
+      {
+        "name": "Level 2",
+        "missions": [
+          {
+            "name": "Mission 2.1",
+            "challenges": [
+              {
+                "name": "Challenge 2.1.1",
+                "id": "basicsIntroVisible"
+              },
+              {
+                "name": "Challenge 2.1.2",
+                "id": "basicsIntroHidden"
+              }
+            ]
+          },
+          {
+            "name": "Mission 2.2",
+            "challenges": [
+              {
+                "name": "Challenge 2.2.1",
+                "id": "eggSortingWings"
+              },
+              {
+                "name": "Challenge 2.2.2",
+                "id": "eggSortingLimbs"
+              }
+            ]
+          },
+          {
+            "name": "Mission 2.3",
+            "challenges": [
+              {
+                "name": "Challenge 2.3.1",
+                "id": "genomeChallengeArmorVisible"
+              },
+              {
+                "name": "Challenge 2.3.2",
+                "id": "genomeChallengeArmorHidden"
+              },
+              {
+                "name": "Challenge 2.3.3",
+                "id": "eggSortingHorns"
+              },
+              {
+                "name": "Challenge 2.3.4",
+                "id": "eggSortingArmor"
+              },
+              {
+                "name": "Challenge 2.3.5",
+                "id": "eggSortingHornsWingsArmor"
+              }
+            ]
+          }
+        ]
+      },
+
+      {
+        "name": "Level 3",
+        "missions": [
+          {
+            "name": "Mission 3.1",
+            "challenges": [
+              {
+                "name": "Challenge 3.1.1",
+                "id": "incompleteLevel"
+              }
+            ]
+          }
+        ]
+      },
+
+      {
+        "name": "Level 4",
+        "missions": [
+          {
+            "name": "Mission 4.1",
+            "challenges": [
+              {
+                "name": "Challenge 4.1.1",
+                "id": "eggBreedingBasicChromosomesUnique"
+              },
+              {
+                "name": "Challenge 4.1.2",
+                "id": "eggBreedingBasicGametesUnique"
+              },
+              {
+                "name": "Challenge 4.1.3",
+                "id": "eggBreedingBasicGametesTarget"
+              }
+            ]
+          }
+        ]
+      },
 
 
-    [
-      [
-        {"challengeId": "basicsIntroVisible"}, {"challengeId": "basicsIntroHidden"}
-      ],
-      [
-        {"challengeId": "eggSortingWings"}, {"challengeId": "eggSortingLimbs"}
-      ],
-      [
-        {"challengeId": "genomeChallengeArmorVisible"}, {"challengeId": "genomeChallengeArmorHidden"}, {"challengeId": "eggSortingHorns"}, {"challengeId": "eggSortingArmor"}, {"challengeId": "eggSortingHornsWingsArmor"}
-      ]
-    ],
+      {
+        "name": "Level 5",
+        "missions": [
+          {
+            "name": "Mission 5.1",
+            "challenges": [
+              {
+                "name": "Challenge 5.1.1",
+                "id": "eggBreedingProtoVisible"
+              },
+              {
+                "name": "Challenge 5.1.2",
+                "id": "eggBreedingProtoHidden"
+              }
+            ]
+          }
+        ]
+      },
 
-
-    [
-      [
-        {"challengeId": "incompleteLevel"}
-      ]
-    ],
-
-    [
-      [
-        {"challengeId": "eggBreedingBasicChromosomesUnique"}, {"challengeId": "eggBreedingBasicGametesUnique"}, {"challengeId": "eggBreedingBasicGametesTarget"}
-      ]
-    ],
-
-
-    [
-      [
-        {"challengeId": "eggBreedingProtoVisible"}, {"challengeId": "eggBreedingProtoHidden"}
-      ]
-    ],
-
-
-    [
-      [
-        {"challengeId": "gamete-5unique-simple"}, {"challengeId": "gamete-1target-simple"}
-      ]
+      {
+        "name": "Level 6",
+        "missions": [
+          {
+            "name": "Mission 6.1",
+            "challenges": [
+              {
+                "name": "Challenge 6.1.1",
+                "id": "gamete-5unique-simple"
+              },
+              {
+                "name": "Challenge 6.1.2",
+                "id": "gamete-1target-simple"
+              }
+            ]
+          }
+        ]
+      }
     ]
-
-  ]
+  }
 }

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -1,67 +1,60 @@
-[
-  [
-    [
-      {
-        "comment": "*** Level 1, Mission 1.1: Playground ***",
-        "template": "GenomePlayground",
-        "initialDrake": {
-          "alleles": "M-M, T-T, w-w, C-C, B-B, D-D, rh-rh, Bog-Bog",
-          "sex": 1
-        },
-        "userChangeableGenes": "wings, forelimbs, hindlimbs, armor, horns"
-      }
-    ],
-  ],
-  [
-    [
-      {
-        "comment": "*** Level 2, Mission 1.1: Genome Challenge (basics intro, user drake visible) ***",
-        "template": "GenomeChallenge",
-        "instructions": "Match the target drake!",
-        "showUserDrake": true,
-        "randomizeTrials": true,
-        "initialDrake": {
-          "alleles": "Bog-, D-, rh-rh",
-          "sex": 1
-        },
-        "targetDrakes": [{
-          "alleles": "",
-          "sex": 0
-        },
-        {
-          "alleles": "",
-          "sex": 1
-        }],
-        "userChangeableGenes": "wings, forelimbs, hindlimbs",
-        "linkedGenes": {
-          "drakes": [0, 1],
-          "genes": "metallic, tail, horns, color, black, dilute, armor, nose, bogbreath"
-        }
+{
+  "definitions": {
+    "playground": {
+      "comment": "*** Level 1, Mission 1.1: Playground ***",
+      "template": "GenomePlayground",
+      "initialDrake": {
+        "alleles": "M-M, T-T, w-w, C-C, B-B, D-D, rh-rh, Bog-Bog",
+        "sex": 1
+      },
+      "userChangeableGenes": "wings, forelimbs, hindlimbs, armor, horns"
+    },
+    "basicsIntroVisible": {
+      "comment": "*** Level 2, Mission 1.1: Genome Challenge (basics intro, user drake visible) ***",
+      "template": "GenomeChallenge",
+      "instructions": "Match the target drake!",
+      "showUserDrake": true,
+      "randomizeTrials": true,
+      "initialDrake": {
+        "alleles": "Bog-, D-, rh-rh",
+        "sex": 1
+      },
+      "targetDrakes": [{
+        "alleles": "",
+        "sex": 0
       },
       {
-        "comment": "*** Level 2, Mission 1.2: Genome Challenge (basics intro, user drake hidden) ***",
-        "template": "GenomeChallenge",
-        "instructions": "Match 2 drakes!",
-        "trialGenerator": {
-          "type": "all-combinations",
-          "baseDrake": "M-M, T-T, h-h, A1-A1, C-C, B-B, D-D, rh-rh, Bog-Bog",
-          "initialDrakeCombos": [
-            ["W-W",   "W-w",   "w-W",   "w-w"],
-            ["Fl-Fl", "Fl-fl", "fl-Fl", "fl-fl"],
-            ["Hl-Hl", "Hl-hl", "hl-Hl", "hl-hl"]
-          ],
-          "targetDrakeCombos": [
-            ["W-W",   "w-w"],
-            ["Fl-Fl", "fl-fl"],
-            ["Hl-Hl", "hl-hl"]
-          ]
-        },
-        "targetDrakes": [{},{}],
-        "userChangeableGenes": "wings, forelimbs, hindlimbs"
+        "alleles": "",
+        "sex": 1
+      }],
+      "userChangeableGenes": "wings, forelimbs, hindlimbs",
+      "linkedGenes": {
+        "drakes": [0, 1],
+        "genes": "metallic, tail, horns, color, black, dilute, armor, nose, bogbreath"
       }
-    ],
-    [
-      {
+    },
+    "basicsIntroHidden": {
+      "comment": "*** Level 2, Mission 1.2: Genome Challenge (basics intro, user drake hidden) ***",
+      "template": "GenomeChallenge",
+      "instructions": "Match 2 drakes!",
+      "trialGenerator": {
+        "type": "all-combinations",
+        "baseDrake": "M-M, T-T, h-h, A1-A1, C-C, B-B, D-D, rh-rh, Bog-Bog",
+        "initialDrakeCombos": [
+          ["W-W",   "W-w",   "w-W",   "w-w"],
+          ["Fl-Fl", "Fl-fl", "fl-Fl", "fl-fl"],
+          ["Hl-Hl", "Hl-hl", "hl-Hl", "hl-hl"]
+        ],
+        "targetDrakeCombos": [
+          ["W-W",   "w-w"],
+          ["Fl-Fl", "fl-fl"],
+          ["Hl-Hl", "hl-hl"]
+        ]
+      },
+      "targetDrakes": [{},{}],
+      "userChangeableGenes": "wings, forelimbs, hindlimbs"
+    },
+    "eggSortingWings": {
         "comment": "*** Level 2, Mission 2.1: Egg Sorting Game (wings) ***",
         "template": "EggSortGame",
         "trialGenerator": {
@@ -86,7 +79,7 @@
           { "label": "Females without wings", "alleles": ["w-w"], "sex": 1 }
         ]
       },
-      {
+      "eggSortingLimbs": {
         "comment": "*** Level 2, Mission 2.2: Egg Sorting Game (forelimbs/hindlimbs) ***",
         "template": "EggSortGame",
         "trialGenerator": {
@@ -109,10 +102,8 @@
           { "label": "Drakes with only hindlimbs", "alleles": ["fl-fl, Hl-", "fl-fl, -Hl"] },
           { "label": "Drakes with forelimbs and hindlimbs", "alleles": ["Fl-, Hl-","Fl-, -Hl","-Fl, Hl-","-Fl, -Hl"] }
         ]
-      }
-    ],
-    [
-      {
+      },
+      "genomeChallengeArmorVisible": {
         "comment": "*** Level 2, Mission 3.1: Genome Challenge (armor intro, user drake visible) ***",
         "template": "GenomeChallenge",
         "randomizeTrials": true,
@@ -154,7 +145,7 @@
           "genes": "metallic, wings, forelimbs, hindlimbs, tail, color, black, dilute, nose, bogbreath"
         }
       },
-      {
+      "genomeChallengeArmorHidden": {
         "comment": "*** Level 2, Mission 3.2: Genome Challenge (armor intro, user drake hidden) ***",
         "template": "GenomeChallenge",
         "randomizeTrials": true,
@@ -196,7 +187,7 @@
           "genes": "metallic, wings, forelimbs, hindlimbs, tail, color, black, dilute, nose, bogbreath"
         }
       },
-      {
+      "eggSortingHorns": {
         "comment": "*** Level 2, Mission 3.3: Egg Sorting Game (horns) ***",
         "template": "EggSortGame",
         "trialGenerator": {
@@ -221,7 +212,7 @@
           { "label": "Females without horns", "alleles": ["H-","-H"], "sex": 1 }
         ]
       },
-      {
+      "eggSortingArmor": {
         "comment": "*** Level 2, Mission 3.4: Egg Sorting Game (armor) ***",
         "template": "EggSortGame",
         "trialGenerator": {
@@ -245,7 +236,7 @@
           { "label": "Drakes with five armor plates", "alleles": ["A1-A1"] }
         ]
       },
-      {
+      "eggSortingHornsWingsArmor": {
         "comment": "*** Level 2, Mission 3.5: Egg Sorting Game (horns/wings/armor) ***",
         "template": "EggSortGame",
         "trialGenerator": {
@@ -268,12 +259,8 @@
           { "label": "Drakes with wings", "alleles": ["W-", "-W"] },
           { "label": "Drakes with armor", "alleles": ["A1-","-A1"] }
         ]
-      }
-    ]
-  ],
-  [
-    [
-      {
+      },
+      "incompleteLevel": {
         "comment": "*** Level 3 Stand In ***",
         "template": "GenomeChallenge",
         "instructions": "THIS LEVEL NOT YET COMPLETE",
@@ -285,12 +272,8 @@
         },
         "targetDrakes": [{}],
         "userChangeableGenes": "metallic"
-      }
-    ]
-  ],
-  [
-    [
-      {
+      },
+      "eggBreedingBasicChromosomesUnique": {
         "comment": "*** Level 4, Mission 1.1: Egg Breeding (select chromosome to create 5 unique drakes) ***",
         "template": "EggGame",
         "challengeType": "create-unique",
@@ -307,7 +290,7 @@
         },
         "visibleGenes": "metallic, wings, forelimbs, hindlimbs"
       },
-      {
+      "eggBreedingBasicGametesUnique": {
         "comment": "*** Level 4, Mission 1.2: Egg Breeding (select gametes to create 5 unique drakes) ***",
         "template": "EggGame",
         "challengeType": "create-unique",
@@ -325,7 +308,7 @@
         "gameteCounts": [8, 8],
         "visibleGenes": "metallic, wings, forelimbs, hindlimbs"
       },
-      {
+      "eggBreedingBasicGametesTarget": {
         "comment": "*** Level 4, Mission 1.3: Egg Breeding (select gametes to match drakes) ***",
         "template": "EggGame",
         "challengeType": "match-target",
@@ -343,12 +326,8 @@
         "gameteCounts": [[2, 1], [1, 3], [4, 4]],
         "targetDrakes": [{}, {}, {}],
         "visibleGenes": "metallic, wings, forelimbs, hindlimbs"
-      }
-    ]
-  ],
-  [
-    [
-      {
+      },
+      "eggBreedingProtoVisible": {
         "comment": "*** Demo: Egg Breeding (match three drakes, user drake visible) ***",
         "challengeId": "egg-breeding-basic-match-visible",
         "template": "EggGame",
@@ -366,7 +345,7 @@
         "targetDrakes": [{},{},{}],
         "visibleGenes": "metallic, wings, forelimbs, hindlimbs"
       },
-      {
+      "eggBreedingProtoHidden": {
         "comment": "*** Demo: Egg Breeding (match three drakes, user drake hidden) ***",
         "challengeId": "egg-breeding-basic-match-hidden",
         "template": "EggGame",
@@ -383,12 +362,8 @@
         },
         "targetDrakes": [{},{},{}],
         "visibleGenes": "metallic, wings, forelimbs, hindlimbs"
-      }
-    ]
-  ],
-  [
-    [
-      {
+      },
+      "gamete-5unique-simple": {
         "comment": "*** FV Test Level ***",
         "container": "FVContainer",
         "template": "FVEggGame",
@@ -406,9 +381,9 @@
         },
         "visibleGenes": "metallic, wings, forelimbs, hindlimbs"
       },
-      {
+      "gamete-1target-simple": {
         "comment": "*** FV Test Level 2 ***",
-        "challengeId": "gamete-1target-simple",
+        "challengeId": "gamete-1target-simple", //TODO: delete this
         "container": "FVContainer",
         "template": "FVEggGame",
         "challengeType": "match-target",
@@ -426,6 +401,57 @@
         },
         "visibleGenes": "metallic, wings, forelimbs, hindlimbs"
       }
+  },
+
+
+  "levelHierarchy": [
+    // Level 1
+    [
+      [
+        "playground"
+      ]
+    ],
+
+    // Level 2
+    [
+      [
+        "basicsIntroVisible", "basicsIntroHidden"
+      ],
+      [
+        "eggSortingWings", "eggSortingLimbs"
+      ],
+      [
+        "genomeChallengeArmorVisible", "genomeChallengeArmorHidden", "eggSortingHorns", "eggSortingArmor", "eggSortingHornsWingsArmor"
+      ]
+    ],
+
+    // Level 3
+    [
+      [
+        "incompleteLevel"
+      ]
+    ],
+
+    // Level 4
+    [
+      [
+        "eggBreedingBasicChromosomesUnique", "eggBreedingBasicGametesUnique", "eggBreedingBasicGametesTarget"
+      ]
+    ],
+
+    // Level 5 (testing)
+    [
+      [
+        "eggBreedingProtoVisible", "eggBreedingProtoHidden"
+      ]
+    ],
+
+    // Level 6 (FV testing)
+    [
+      [
+        "gamete-5unique-simple", "gamete-1target-simple"
+      ]
     ]
+
   ]
-]
+}

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -1,5 +1,5 @@
 {
-  "definitions": {
+  "challenges": {
     "playground": {
       "comment": "*** Level 1, Mission 1.1: Playground ***",
       "template": "GenomePlayground",
@@ -402,14 +402,13 @@
 
 
   "levelHierarchy": [
-    // Level 1
     [
       [
         {"challengeId": "playground"}
       ]
     ],
 
-    // Level 2
+
     [
       [
         {"challengeId": "basicsIntroVisible"}, {"challengeId": "basicsIntroHidden"}
@@ -422,28 +421,27 @@
       ]
     ],
 
-    // Level 3
+
     [
       [
         {"challengeId": "incompleteLevel"}
       ]
     ],
 
-    // Level 4
     [
       [
         {"challengeId": "eggBreedingBasicChromosomesUnique"}, {"challengeId": "eggBreedingBasicGametesUnique"}, {"challengeId": "eggBreedingBasicGametesTarget"}
       ]
     ],
 
-    // Level 5 (testing)
+
     [
       [
         {"challengeId": "eggBreedingProtoVisible"}, {"challengeId": "eggBreedingProtoHidden"}
       ]
     ],
 
-    // Level 6 (FV testing)
+
     [
       [
         {"challengeId": "gamete-5unique-simple"}, {"challengeId": "gamete-1target-simple"}

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -329,7 +329,6 @@
       },
       "eggBreedingProtoVisible": {
         "comment": "*** Demo: Egg Breeding (match three drakes, user drake visible) ***",
-        "challengeId": "egg-breeding-basic-match-visible",
         "template": "EggGame",
         "challengeType": "match-target",
         "instructions": "Match 3 drakes!",
@@ -347,7 +346,6 @@
       },
       "eggBreedingProtoHidden": {
         "comment": "*** Demo: Egg Breeding (match three drakes, user drake hidden) ***",
-        "challengeId": "egg-breeding-basic-match-hidden",
         "template": "EggGame",
         "challengeType": "match-target",
         "instructions": "Match 3 drakes!",
@@ -383,7 +381,6 @@
       },
       "gamete-1target-simple": {
         "comment": "*** FV Test Level 2 ***",
-        "challengeId": "gamete-1target-simple", //TODO: delete this
         "container": "FVContainer",
         "template": "FVEggGame",
         "challengeType": "match-target",
@@ -408,48 +405,48 @@
     // Level 1
     [
       [
-        "playground"
+        {"challengeId": "playground"}
       ]
     ],
 
     // Level 2
     [
       [
-        "basicsIntroVisible", "basicsIntroHidden"
+        {"challengeId": "basicsIntroVisible"}, {"challengeId": "basicsIntroHidden"}
       ],
       [
-        "eggSortingWings", "eggSortingLimbs"
+        {"challengeId": "eggSortingWings"}, {"challengeId": "eggSortingLimbs"}
       ],
       [
-        "genomeChallengeArmorVisible", "genomeChallengeArmorHidden", "eggSortingHorns", "eggSortingArmor", "eggSortingHornsWingsArmor"
+        {"challengeId": "genomeChallengeArmorVisible"}, {"challengeId": "genomeChallengeArmorHidden"}, {"challengeId": "eggSortingHorns"}, {"challengeId": "eggSortingArmor"}, {"challengeId": "eggSortingHornsWingsArmor"}
       ]
     ],
 
     // Level 3
     [
       [
-        "incompleteLevel"
+        {"challengeId": "incompleteLevel"}
       ]
     ],
 
     // Level 4
     [
       [
-        "eggBreedingBasicChromosomesUnique", "eggBreedingBasicGametesUnique", "eggBreedingBasicGametesTarget"
+        {"challengeId": "eggBreedingBasicChromosomesUnique"}, {"challengeId": "eggBreedingBasicGametesUnique"}, {"challengeId": "eggBreedingBasicGametesTarget"}
       ]
     ],
 
     // Level 5 (testing)
     [
       [
-        "eggBreedingProtoVisible", "eggBreedingProtoHidden"
+        {"challengeId": "eggBreedingProtoVisible"}, {"challengeId": "eggBreedingProtoHidden"}
       ]
     ],
 
     // Level 6 (FV testing)
     [
       [
-        "gamete-5unique-simple", "gamete-1target-simple"
+        {"challengeId": "gamete-5unique-simple"}, {"challengeId": "gamete-1target-simple"}
       ]
     ]
 

--- a/test/actions/egg-accepted.js
+++ b/test/actions/egg-accepted.js
@@ -39,7 +39,7 @@ describe('acceptEggInBasket action', () => {
                                         };
 
     const dispatch = expect.createSpy();
-    const getState = () => ({routeSpec: {level: 0, mission: 0, challenge: 0}, trial: 0, trials: [{}], authoring: [[[{}]]] });
+    const getState = () => ({routeSpec: {level: 0, mission: 0, challenge: 0}, trial: 0, trials: [{}], authoring: {definitions: {}, "levelHierarchy": [[[]]]} });
 
     actions.acceptEggInBasket(acceptEggArgs)(dispatch, getState);
     expect(dispatch.calls[0].arguments).toEqual([acceptEggAction]);

--- a/test/actions/egg-accepted.js
+++ b/test/actions/egg-accepted.js
@@ -39,7 +39,7 @@ describe('acceptEggInBasket action', () => {
                                         };
 
     const dispatch = expect.createSpy();
-    const getState = () => ({routeSpec: {level: 0, mission: 0, challenge: 0}, trial: 0, trials: [{}], authoring: {definitions: {}, "levelHierarchy": [[[]]]} });
+    const getState = () => ({routeSpec: {level: 0, mission: 0, challenge: 0}, trial: 0, trials: [{}], authoring: {challenges: {}, "levelHierarchy": [[[]]]} });
 
     actions.acceptEggInBasket(acceptEggArgs)(dispatch, getState);
     expect(dispatch.calls[0].arguments).toEqual([acceptEggAction]);

--- a/test/actions/egg-accepted.js
+++ b/test/actions/egg-accepted.js
@@ -39,7 +39,10 @@ describe('acceptEggInBasket action', () => {
                                         };
 
     const dispatch = expect.createSpy();
-    const getState = () => ({routeSpec: {level: 0, mission: 0, challenge: 0}, trial: 0, trials: [{}], authoring: {challenges: {}, "levelHierarchy": [[[]]]} });
+    const getState = () => ({routeSpec: {level: 0, mission: 0, challenge: 0}, trial: 0, trials: [{}], authoring: {
+      challenges: {}, 
+      "application": {"levels": [{"missions": [{"challenges": []}]}]}
+    }});
 
     actions.acceptEggInBasket(acceptEggArgs)(dispatch, getState);
     expect(dispatch.calls[0].arguments).toEqual([acceptEggAction]);

--- a/test/actions/egg-rejected.js
+++ b/test/actions/egg-rejected.js
@@ -39,7 +39,7 @@ describe('rejectEggFromBasket action', () => {
                                         };
 
     const dispatch = expect.createSpy();
-  const getState = () => ({routeSpec: {level: 0, mission: 0, challenge: 0}, trial: 0, trials: [{}], authoring: [[[{}]]] });
+  const getState = () => ({routeSpec: {level: 0, mission: 0, challenge: 0}, trial: 0, trials: [{}], authoring: {definitions: {}, "levelHierarchy": [[[]]]} });
 
     actions.rejectEggFromBasket(rejectEggArgs)(dispatch, getState);
     expect(dispatch.calls[0].arguments).toEqual([rejectEggAction]);

--- a/test/actions/egg-rejected.js
+++ b/test/actions/egg-rejected.js
@@ -39,7 +39,10 @@ describe('rejectEggFromBasket action', () => {
                                         };
 
     const dispatch = expect.createSpy();
-  const getState = () => ({routeSpec: {level: 0, mission: 0, challenge: 0}, trial: 0, trials: [{}], authoring: {challenges: {}, "levelHierarchy": [[[]]]} });
+  const getState = () => ({routeSpec: {level: 0, mission: 0, challenge: 0}, trial: 0, trials: [{}], authoring: {
+    challenges: {}, 
+    "application": {"levels": [{"missions": [{"challenges": []}]}]}
+  }});
 
     actions.rejectEggFromBasket(rejectEggArgs)(dispatch, getState);
     expect(dispatch.calls[0].arguments).toEqual([rejectEggAction]);

--- a/test/actions/egg-rejected.js
+++ b/test/actions/egg-rejected.js
@@ -39,7 +39,7 @@ describe('rejectEggFromBasket action', () => {
                                         };
 
     const dispatch = expect.createSpy();
-  const getState = () => ({routeSpec: {level: 0, mission: 0, challenge: 0}, trial: 0, trials: [{}], authoring: {definitions: {}, "levelHierarchy": [[[]]]} });
+  const getState = () => ({routeSpec: {level: 0, mission: 0, challenge: 0}, trial: 0, trials: [{}], authoring: {challenges: {}, "levelHierarchy": [[[]]]} });
 
     actions.rejectEggFromBasket(rejectEggArgs)(dispatch, getState);
     expect(dispatch.calls[0].arguments).toEqual([rejectEggAction]);

--- a/test/actions/navigate-to-challenge.js
+++ b/test/actions/navigate-to-challenge.js
@@ -32,19 +32,23 @@ describe('navigateToChallenge action', () => {
       let defaultState = reducer(undefined, {});
       let initialState = defaultState.merge({
         routeSpec: {level: 0, mission: 0, challenge: 0},
-        authoring: 
-        [
-          [
-            [],
-            [{}, {}, {
+        authoring: {
+          "definitions": {
+            "test": {
               template: "GenomePlayground",
               "initialDrake": {
                 "alleles": "a:T,b:T",
                 "sex": 1
               }
-            }]
-          ]
-        ]
+            }, "empty": {}},
+          "levelHierarchy": 
+            [
+              [
+                [],
+                ["empty", "empty", "test"]
+              ]
+            ]
+        }
       });
 
       let nextState = reducer(initialState, navigateToChallenge({level: 0, mission: 1, challenge: 2}));

--- a/test/actions/navigate-to-challenge.js
+++ b/test/actions/navigate-to-challenge.js
@@ -45,7 +45,7 @@ describe('navigateToChallenge action', () => {
             [
               [
                 [],
-                ["empty", "empty", "test"]
+                [{"challengeId": "empty"}, {"challengeId": "empty"}, {"challengeId": "test"}]
               ]
             ]
         }

--- a/test/actions/navigate-to-challenge.js
+++ b/test/actions/navigate-to-challenge.js
@@ -41,13 +41,20 @@ describe('navigateToChallenge action', () => {
                 "sex": 1
               }
             }, "empty": {}},
-          "levelHierarchy": 
-            [
-              [
-                [],
-                [{"challengeId": "empty"}, {"challengeId": "empty"}, {"challengeId": "test"}]
-              ]
+          "application": {
+            "levels": [
+              {
+                "missions": [
+                  {
+                    "challenges": []
+                  },
+                  {
+                    "challenges": [{"id": "empty"}, {"id": "empty"}, {"id": "test"}]
+                  }
+                ]
+              }
             ]
+          }
         }
       });
 

--- a/test/actions/navigate-to-challenge.js
+++ b/test/actions/navigate-to-challenge.js
@@ -33,7 +33,7 @@ describe('navigateToChallenge action', () => {
       let initialState = defaultState.merge({
         routeSpec: {level: 0, mission: 0, challenge: 0},
         authoring: {
-          "definitions": {
+          "challenges": {
             "test": {
               template: "GenomePlayground",
               "initialDrake": {

--- a/test/actions/navigate-to-current-route.js
+++ b/test/actions/navigate-to-current-route.js
@@ -42,7 +42,7 @@ describe('navigateToCurrentRoute action', () => {
     routeSpec: {level: 0, mission: 0, challenge: 0}, 
     authoring: {
       "definitions": {"empty": {}}, 
-      "levelHierarchy": [[["empty"],["empty", "empty", "empty"]]] 
+      "levelHierarchy": [[[{"challengeId": "empty"}],[{"challengeId": "empty"}, {"challengeId": "empty"}, {"challengeId": "empty"}]]] 
     }
   });
 
@@ -75,7 +75,7 @@ describe('navigateToCurrentRoute action', () => {
             [
               [
                 [],
-                ["empty", "empty", "test"]
+                [{"challengeId": "empty"}, {"challengeId": "empty"}, {"challengeId": "test"}]
               ]
             ]
         }

--- a/test/actions/navigate-to-current-route.js
+++ b/test/actions/navigate-to-current-route.js
@@ -42,7 +42,20 @@ describe('navigateToCurrentRoute action', () => {
     routeSpec: {level: 0, mission: 0, challenge: 0}, 
     authoring: {
       "challenges": {"empty": {}}, 
-      "levelHierarchy": [[[{"challengeId": "empty"}],[{"challengeId": "empty"}, {"challengeId": "empty"}, {"challengeId": "empty"}]]] 
+      "application": {
+        "levels": [
+          {
+            "missions": [
+              {
+                "challenges": []
+              },
+              {
+                "challenges": [{"id": "empty"}, {"id": "empty"}, {"id": "empty"}]
+              }
+            ]
+          }
+        ]
+      }
     }
   });
 
@@ -71,13 +84,20 @@ describe('navigateToCurrentRoute action', () => {
                 "sex": 1
               }
             }, "empty": {}},
-          "levelHierarchy": 
-            [
-              [
-                [],
-                [{"challengeId": "empty"}, {"challengeId": "empty"}, {"challengeId": "test"}]
-              ]
+          "application": {
+            "levels": [
+              {
+                "missions": [
+                  {
+                    "challenges": []
+                  },
+                  {
+                    "challenges": [{"id": "empty"}, {"id": "empty"}, {"id": "test"}]
+                  }
+                ]
+              }
             ]
+          }
         }
       });
 

--- a/test/actions/navigate-to-current-route.js
+++ b/test/actions/navigate-to-current-route.js
@@ -41,7 +41,7 @@ describe('navigateToCurrentRoute action', () => {
   const getState = () => ({
     routeSpec: {level: 0, mission: 0, challenge: 0}, 
     authoring: {
-      "definitions": {"empty": {}}, 
+      "challenges": {"empty": {}}, 
       "levelHierarchy": [[[{"challengeId": "empty"}],[{"challengeId": "empty"}, {"challengeId": "empty"}, {"challengeId": "empty"}]]] 
     }
   });
@@ -63,7 +63,7 @@ describe('navigateToCurrentRoute action', () => {
       let initialState = defaultState.merge({
         routeSpec: {level: 0, mission: 0, challenge: 0},
         authoring: {
-          "definitions": {
+          "challenges": {
             "test": {
               template: "GenomePlayground",
               "initialDrake": {

--- a/test/actions/navigate-to-current-route.js
+++ b/test/actions/navigate-to-current-route.js
@@ -38,7 +38,13 @@ describe('navigateToCurrentRoute action', () => {
         };
 
   const dispatch = expect.createSpy();
-  const getState = () => ({routeSpec: {level: 0, mission: 0, challenge: 0}, authoring: [[[{}],[{},{},{}]]] });
+  const getState = () => ({
+    routeSpec: {level: 0, mission: 0, challenge: 0}, 
+    authoring: {
+      "definitions": {"empty": {}}, 
+      "levelHierarchy": [[["empty"],["empty", "empty", "empty"]]] 
+    }
+  });
 
   it("should dispatch a navigateToCurrentRoute action when a valid challenge is specified", () => {
     navigateToCurrentRoute({level: validLevel, mission: validMission, challenge: validChallenge})(dispatch, getState);
@@ -56,19 +62,23 @@ describe('navigateToCurrentRoute action', () => {
       let defaultState = reducer(undefined, {});
       let initialState = defaultState.merge({
         routeSpec: {level: 0, mission: 0, challenge: 0},
-        authoring: 
-        [
-          [
-            [],
-            [{}, {}, {
+        authoring: {
+          "definitions": {
+            "test": {
               template: "GenomePlayground",
               "initialDrake": {
                 "alleles": "a:T,b:T",
                 "sex": 1
               }
-            }]
-          ]
-        ]
+            }, "empty": {}},
+          "levelHierarchy": 
+            [
+              [
+                [],
+                ["empty", "empty", "test"]
+              ]
+            ]
+        }
       });
 
       let nextState = reducer(initialState, currentRouteAction);

--- a/test/actions/submit-drake.js
+++ b/test/actions/submit-drake.js
@@ -58,7 +58,7 @@ const correctCharacteristics = {
           }
         ],
         trial: 0, trials: [{}],
-        authoring: {challenges: {"test": {visibleGenes: "wings, arms"}}, "levelHierarchy": [[[{"challengeId": "test"}]]]}
+        authoring: {challenges: {"test": {visibleGenes: "wings, arms"}}, "application": {"levels": [{"missions": [{"challenges": [{"id": "test"}]}]}]}}
       });
 
 

--- a/test/actions/submit-drake.js
+++ b/test/actions/submit-drake.js
@@ -58,7 +58,7 @@ const correctCharacteristics = {
           }
         ],
         trial: 0, trials: [{}],
-        authoring: [[[{visibleGenes: "wings, arms"}]]]
+        authoring: {definitions: {"test": {visibleGenes: "wings, arms"}}, "levelHierarchy": [[["test"]]]}
       });
 
 

--- a/test/actions/submit-drake.js
+++ b/test/actions/submit-drake.js
@@ -58,7 +58,7 @@ const correctCharacteristics = {
           }
         ],
         trial: 0, trials: [{}],
-        authoring: {definitions: {"test": {visibleGenes: "wings, arms"}}, "levelHierarchy": [[[{"challengeId": "test"}]]]}
+        authoring: {challenges: {"test": {visibleGenes: "wings, arms"}}, "levelHierarchy": [[[{"challengeId": "test"}]]]}
       });
 
 

--- a/test/actions/submit-drake.js
+++ b/test/actions/submit-drake.js
@@ -58,7 +58,7 @@ const correctCharacteristics = {
           }
         ],
         trial: 0, trials: [{}],
-        authoring: {definitions: {"test": {visibleGenes: "wings, arms"}}, "levelHierarchy": [[["test"]]]}
+        authoring: {definitions: {"test": {visibleGenes: "wings, arms"}}, "levelHierarchy": [[[{"challengeId": "test"}]]]}
       });
 
 

--- a/test/templates/egg-game.js
+++ b/test/templates/egg-game.js
@@ -84,7 +84,7 @@ describe('loading authored state into template', () => {
           "targetDrakes": [{},{},{}]
         },
         "empty": {}},
-        "levelHierarchy": [[[{"challengeId": "empty"}, {"challengeId": "test"}]]]
+        "application": {"levels": [{"missions": [{"challenges": [{"id": "empty"}, {"id": "test"}]}]}]}
       }, ["alleles"]);
 
     let defaultState = reducer(undefined, {});

--- a/test/templates/egg-game.js
+++ b/test/templates/egg-game.js
@@ -69,7 +69,7 @@ describe('authoredDrakesToDrakeArray()', () => {
 describe('loading authored state into template', () => {
   describe('in the EggGame II template', () => {
     let authoring = GeneticsUtils.convertDashAllelesObjectToABAlleles({
-      definitions: {
+      challenges: {
         "test": {
           "template": "EggGame",
           "challengeType": "match-target",

--- a/test/templates/egg-game.js
+++ b/test/templates/egg-game.js
@@ -68,27 +68,24 @@ describe('authoredDrakesToDrakeArray()', () => {
 
 describe('loading authored state into template', () => {
   describe('in the EggGame II template', () => {
-    let authoring = GeneticsUtils.convertDashAllelesObjectToABAlleles(
-      [
-        [
-          [
-            {},
-            {
-              "template": "EggGame",
-              "challengeType": "match-target",
-              "mother":{
-                "alleles": "W-W, T-T",
-                "sex": 1
-              },
-              "father": {
-                "alleles": "w-w, T-T",
-                "sex": 1
-              },
-              "targetDrakes": [{},{},{}]
-            }
-          ]
-        ]
-      ], ["alleles"]);
+    let authoring = GeneticsUtils.convertDashAllelesObjectToABAlleles({
+      definitions: {
+        "test": {
+          "template": "EggGame",
+          "challengeType": "match-target",
+          "mother":{
+            "alleles": "W-W, T-T",
+            "sex": 1
+          },
+          "father": {
+            "alleles": "w-w, T-T",
+            "sex": 1
+          },
+          "targetDrakes": [{},{},{}]
+        },
+        "empty": {}},
+        "levelHierarchy": [[["empty", "test"]]]
+      }, ["alleles"]);
 
     let defaultState = reducer(undefined, {});
     let initialState = defaultState.merge({

--- a/test/templates/egg-game.js
+++ b/test/templates/egg-game.js
@@ -84,7 +84,7 @@ describe('loading authored state into template', () => {
           "targetDrakes": [{},{},{}]
         },
         "empty": {}},
-        "levelHierarchy": [[["empty", "test"]]]
+        "levelHierarchy": [[[{"challengeId": "empty"}, {"challengeId": "test"}]]]
       }, ["alleles"]);
 
     let defaultState = reducer(undefined, {});

--- a/test/templates/genome-challenge.js
+++ b/test/templates/genome-challenge.js
@@ -40,7 +40,7 @@ describe('authoredDrakesToDrakeArray()', () => {
 describe('loading authored state into template', () => {
   describe('in the GenomeChallenge template', () => {
     let authoring = GeneticsUtils.convertDashAllelesObjectToABAlleles({
-      "definitions": {
+      "challenges": {
         "test": {
           "template": "GenomeChallenge",
           "initialDrake":{
@@ -111,7 +111,7 @@ describe('loading authored state into template', () => {
   describe('with linked genes', () => {
     describe('in the GenomeChallenge template', () => {
       let authoring = GeneticsUtils.convertDashAllelesObjectToABAlleles({
-      "definitions": {
+      "challenges": {
         "test": {
           "template": "GenomeChallenge",
           "initialDrake": {
@@ -163,7 +163,7 @@ describe('loading authored state into template', () => {
   describe('with randomized trials', () => {
     describe('in the GenomeChallenge template', () => {
       let authoring = GeneticsUtils.convertDashAllelesObjectToABAlleles({
-      "definitions": {
+      "challenges": {
         "test": {
           "template": "GenomeChallenge",
           "randomizeTrials": true,

--- a/test/templates/genome-challenge.js
+++ b/test/templates/genome-challenge.js
@@ -56,7 +56,7 @@ describe('loading authored state into template', () => {
             "sex": 1
           }]
         }, "empty": {}},
-      "levelHierarchy": [[[{"challengeId": "empty"}, {"challengeId": "test"}]]]
+      "application": {"levels": [{"missions": [{"challenges": [{"id": "empty"}, {"id": "test"}]}]}]}
     }, ["alleles"]);
 
     let defaultState = reducer(undefined, {});
@@ -131,7 +131,7 @@ describe('loading authored state into template', () => {
             "genes": "tail, horns"
           }
         }, "empty": {}},
-      "levelHierarchy": [[[{"challengeId": "empty"}, {"challengeId": "test"}]]]
+      "application": {"levels": [{"missions": [{"challenges": [{"id": "empty"}, {"id": "test"}]}]}]}
     }, ["alleles"]);
 
       let defaultState = reducer(undefined, {});
@@ -173,7 +173,7 @@ describe('loading authored state into template', () => {
           },
           "targetDrakes": [{}, {}, {}, {}, {}, {}, {}, {}]
         }, "empty": {}},
-      "levelHierarchy": [[[{"challengeId": "empty"}, {"challengeId": "test"}]]]
+      "application": {"levels": [{"missions": [{"challenges": [{"id": "empty"}, {"id": "test"}]}]}]}
     }, ["alleles"]);
 
       let defaultState = reducer(undefined, {});

--- a/test/templates/genome-challenge.js
+++ b/test/templates/genome-challenge.js
@@ -56,7 +56,7 @@ describe('loading authored state into template', () => {
             "sex": 1
           }]
         }, "empty": {}},
-      "levelHierarchy": [[["empty", "test"]]]
+      "levelHierarchy": [[[{"challengeId": "empty"}, {"challengeId": "test"}]]]
     }, ["alleles"]);
 
     let defaultState = reducer(undefined, {});
@@ -131,7 +131,7 @@ describe('loading authored state into template', () => {
             "genes": "tail, horns"
           }
         }, "empty": {}},
-      "levelHierarchy": [[["empty", "test"]]]
+      "levelHierarchy": [[[{"challengeId": "empty"}, {"challengeId": "test"}]]]
     }, ["alleles"]);
 
       let defaultState = reducer(undefined, {});
@@ -173,7 +173,7 @@ describe('loading authored state into template', () => {
           },
           "targetDrakes": [{}, {}, {}, {}, {}, {}, {}, {}]
         }, "empty": {}},
-      "levelHierarchy": [[["empty", "test"]]]
+      "levelHierarchy": [[[{"challengeId": "empty"}, {"challengeId": "test"}]]]
     }, ["alleles"]);
 
       let defaultState = reducer(undefined, {});

--- a/test/templates/genome-challenge.js
+++ b/test/templates/genome-challenge.js
@@ -39,29 +39,25 @@ describe('authoredDrakesToDrakeArray()', () => {
 
 describe('loading authored state into template', () => {
   describe('in the GenomeChallenge template', () => {
-    let authoring = GeneticsUtils.convertDashAllelesObjectToABAlleles(
-      [
-        [
-          [
-            {},
-            {
-              "template": "GenomeChallenge",
-              "initialDrake":{
-                "alleles": "W-w, D-D, Bog-Bog, rh-rh",
-                "sex": 0
-              },
-              "targetDrakes": [{
-                "alleles": "W-W",
-                "sex": 1
-              },
-              {
-                "alleles": "w-w",
-                "sex": 1
-              }]
-            }
-          ]
-        ]
-      ], ["alleles"]);
+    let authoring = GeneticsUtils.convertDashAllelesObjectToABAlleles({
+      "definitions": {
+        "test": {
+          "template": "GenomeChallenge",
+          "initialDrake":{
+            "alleles": "W-w, D-D, Bog-Bog, rh-rh",
+            "sex": 0
+          },
+          "targetDrakes": [{
+            "alleles": "W-W",
+            "sex": 1
+          },
+          {
+            "alleles": "w-w",
+            "sex": 1
+          }]
+        }, "empty": {}},
+      "levelHierarchy": [[["empty", "test"]]]
+    }, ["alleles"]);
 
     let defaultState = reducer(undefined, {});
     let initialState = defaultState.merge({
@@ -114,33 +110,29 @@ describe('loading authored state into template', () => {
 
   describe('with linked genes', () => {
     describe('in the GenomeChallenge template', () => {
-      let authoring = GeneticsUtils.convertDashAllelesObjectToABAlleles(
-        [
-          [
-            [
-              {},
-              {
-                "template": "GenomeChallenge",
-                "initialDrake": {
-                  "alleles": "W-w",
-                  "sex": 1
-                },
-                "targetDrakes": [{
-                  "alleles": "W-W",
-                  "sex": 1
-                },
-                {
-                  "alleles": "w-w",
-                  "sex": 1
-                }],
-                "linkedGenes": {
-                  "drakes": [0, 1],
-                  "genes": "tail, horns"
-                }
-              }
-            ]
-          ]
-        ], ["alleles"]);
+      let authoring = GeneticsUtils.convertDashAllelesObjectToABAlleles({
+      "definitions": {
+        "test": {
+          "template": "GenomeChallenge",
+          "initialDrake": {
+            "alleles": "W-w",
+            "sex": 1
+          },
+          "targetDrakes": [{
+            "alleles": "W-W",
+            "sex": 1
+          },
+          {
+            "alleles": "w-w",
+            "sex": 1
+          }],
+          "linkedGenes": {
+            "drakes": [0, 1],
+            "genes": "tail, horns"
+          }
+        }, "empty": {}},
+      "levelHierarchy": [[["empty", "test"]]]
+    }, ["alleles"]);
 
       let defaultState = reducer(undefined, {});
       let initialState = defaultState.merge({
@@ -170,23 +162,19 @@ describe('loading authored state into template', () => {
 
   describe('with randomized trials', () => {
     describe('in the GenomeChallenge template', () => {
-      let authoring = GeneticsUtils.convertDashAllelesObjectToABAlleles(
-        [
-          [
-            [
-              {},
-              {
-                "template": "GenomeChallenge",
-                "randomizeTrials": true,
-                "initialDrake": {
-                  "alleles": "W-w",
-                  "sex": 1
-                },
-                "targetDrakes": [{}, {}, {}, {}, {}, {}, {}, {}]
-              }
-            ]
-          ]
-        ], ["alleles"]);
+      let authoring = GeneticsUtils.convertDashAllelesObjectToABAlleles({
+      "definitions": {
+        "test": {
+          "template": "GenomeChallenge",
+          "randomizeTrials": true,
+          "initialDrake": {
+            "alleles": "W-w",
+            "sex": 1
+          },
+          "targetDrakes": [{}, {}, {}, {}, {}, {}, {}, {}]
+        }, "empty": {}},
+      "levelHierarchy": [[["empty", "test"]]]
+    }, ["alleles"]);
 
       let defaultState = reducer(undefined, {});
       let initialState = defaultState.merge({


### PR DESCRIPTION
Updated the authoring doc per this story:

https://www.pivotaltracker.com/story/show/142096149

The structure is now broken into level definitions and a level hierarchy. Additionally, at the suggestion of @kswenson, I use objects instead of strings in the level hierarchy so that we could move application-specific logic into the hierarchy and make the levels more reusable. The idea is that we could move more applications into a single authoring document, but I didn't have the opportunity to do that, and want to prioritize other tasks.

The downside of using objects instead of strings is that it makes the authoring document a little more challenging for non-engineers to modify. What do you think?