### PR TITLE
Eliminate redundant Object.assign() polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "axios": "^0.15.3",
     "babel-polyfill": "^6.20.0",
     "classnames": "^2.2.5",
-    "es6-object-assign": "^1.0.3",
     "lodash": "^4.17.3",
     "mustache": "^2.3.0",
     "react": "^15.4.1",

--- a/src/code/app.js
+++ b/src/code/app.js
@@ -1,5 +1,3 @@
-// Polyfill, modifying the global Object
-require('es6-object-assign').polyfill();
 import 'babel-polyfill';
 
 import React from 'react';

--- a/src/code/geniblocks.js
+++ b/src/code/geniblocks.js
@@ -4,9 +4,6 @@
  * for description of some of the details involved in mixing ES6 export with require().
  */
 
-// Polyfill, modifying the global Object
-require('es6-object-assign').polyfill();
-
 // components
 export { default as AlleleFiltersView } from './components/allele-filters';
 export { default as AlleleView } from './components/allele';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1774,10 +1774,6 @@ es6-map@^0.1.3:
     es6-symbol "~3.1.0"
     event-emitter "~0.3.4"
 
-es6-object-assign@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.0.3.tgz#40a192e0fda5ee44ee8cf6f5b5d9b47cd0f69b14"
-
 es6-promise@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-2.3.0.tgz#96edb9f2fdb01995822b263dd8aadab6748181bc"


### PR DESCRIPTION
`babel-polyfill`, which was added after `es6-object-assign`, includes its own polyfill for Object.assign().