### PR TITLE
Fix gulp.watch issues

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,11 +1,11 @@
-var src = './src',
-    bower = './bower_components',
-    node = './node_modules',
-    examples = './examples',
-    publicRoot  = './public',
-    publicExamples  = './public/examples',
-    publicGeniverse = './public/gv2',
-    dist = './dist';
+var src = 'src',
+    bower = 'bower_components',
+    node = 'node_modules',
+    examples = 'examples',
+    publicRoot  = 'public',
+    publicExamples  = 'public/examples',
+    publicGeniverse = 'public/gv2',
+    dist = 'dist';
 
 module.exports = {
   geniverseJS: {

--- a/gulp/tasks/default.js
+++ b/gulp/tasks/default.js
@@ -1,17 +1,21 @@
 var gulp = require('gulp');
 var config = require('../config');
+// cwd is required for new/deleted files to be detected (http://stackoverflow.com/a/34346524)
+var gazeOptions = { cwd: './' };
 
 gulp.task('watch', function() {
-    gulp.watch(config.geniblocksJS.watch,   ['geni-js']);
-    gulp.watch(config.geniblocksCSS.watch,  ['geniblocks-css']);
-    gulp.watch(config.geniverseRsrc.watch,  ['geniverse-rsrc']);
-    gulp.watch(config.examples.watch,       ['examples', 'examples-css']);
-    gulp.watch(config.examplesJS.watch,     ['examples-js']);
+  gulp.watch(config.geniblocksJS.watch, gazeOptions, ['geni-js']);
+  gulp.watch(config.geniblocksCSS.watch, gazeOptions, ['geniblocks-css']);
+  gulp.watch(config.geniverseRsrc.watch, gazeOptions, ['geniverse-rsrc']);
+  gulp.watch(config.examples.watch, gazeOptions, ['examples', 'examples-css']);
+  gulp.watch(config.examplesJS.watch, gazeOptions, ['examples-js']);
 });
 
 gulp.task('watch-fast', function() {
-    gulp.watch(config.geniblocksJS.watch,   ['geniverse-js-dev']);
-    gulp.watch(config.geniblocksCSS.watch,  ['geniblocks-css']);
+  gulp.watch(config.geniblocksJS.watch, gazeOptions,  ['geniverse-js-dev']);
+  gulp.watch(config.geniblocksCSS.watch, gazeOptions, ['geniblocks-css']);
+  // while potentially desirable, resource task is too slow/problematic for 'watch-fast'
+  //gulp.watch(config.geniverseRsrc.watch, gazeOptions, ['geniverse-rsrc']);
 });
 
 gulp.task('build-all', ['geni-js', 'geniblocks-css', 'geniverse-rsrc',


### PR DESCRIPTION
- New/deleted files now trigger rebuilds (add `{ cwd: './' }` argument) [#142103931]
- ~~`watch-fast` task now watches `resources` directory~~

Having `watch-fast` watch the `resources` directory turned out to be problematic because the resources task copies the entire resources folder which is slow and triggers excessive numbers of reloads, so it has been removed from this PR.