### PR TITLE
Support dragging a drake to the stable (#142262279)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "mustache": "^2.3.0",
     "react": "^15.4.1",
     "react-dimensions": "^1.3.0",
+    "react-dnd": "^2.2.4",
+    "react-dnd-html5-backend": "^2.2.4",
     "react-dom": "^15.4.1",
     "react-motion": "^0.4.7",
     "react-overlays": "^0.6.10",

--- a/src/code/components/custom-drag-layer.js
+++ b/src/code/components/custom-drag-layer.js
@@ -1,0 +1,127 @@
+/*
+ * Example of using a React DnD custom drag layer for rendering
+ * Custom drag layer is required for IE11 and for touch devices
+ * that don't support HTML5 drag/drop API.
+ *
+ * The current state of React DnD backend support is somewhat muddled.
+ * The default/only backend that is officially supported is the
+ * HTML5Backend, which utilizes the HTML5 drag/drop API. Unfortunately,
+ * the HTML5 drag/drop API is only partially supported on IE11 and
+ * completely unsupported on most mobile browsers. To support IE11,
+ * one must use a custom drag layer because IE11 doesn't support the
+ * dragImage API. This module demonstrates how to use a custom drag
+ * layer. Support of touch devices is trickier.
+ *
+ * The officially recommended way of supporting touch devices is to use the
+ * third-party https://www.npmjs.com/package/react-dnd-touch-backend, which
+ * utilizes touch events rather than drag/drop events. This seems to work
+ * reasonably well on touch devices. This touch backend has a mode which
+ * purports to support mouse events as well, but reading the Github issues
+ * for the project suggests that the mouse support is reportedly buggy and
+ * the ReadMe recommends against using its mouse event support. As a result,
+ * the state of the art seems to be to dynamically choose between the
+ * built-in HTML5Backend and the TouchBackend based on a run-time test
+ * for whether one is running on a touch device or not. Unfortunately,
+ * testing for touch devices isn't always straightforward, and the
+ * profusion of devices which support both mouse and touch events
+ * makes the notion of choosing between the two problematic. So the
+ * result is that devices that support both mouse and touch may end
+ * up working with the mouse but not touch (if the HTML5Backend is chosen)
+ * or working with touch but behaving erratically with the mouse (if the
+ * TouchBackend is chosen), and it's not always easy to predict which.
+ *
+ * There are a couple of other possibilities for enabling touch support.
+ * https://www.npmjs.com/package/react-dnd-multi-backend purports to
+ * support dynamically switching between the HTML5Backend and the
+ * TouchBackend depending on the events received.
+ * https://www.npmjs.com/package/react-dnd-html5-touch-backend purports to
+ * fold touch events into the drag/drop-like events which are then tied
+ * to the HTML5Backend analogously to the HTML5 drag/drop events.
+ * https://github.com/Bernardo-Castilho/dragdroptouch is a library which
+ * maps touch events to drag/drop events, which might be sufficient to
+ * make the HTML5Backend work on touch devices.
+ */
+import React, { PropTypes } from 'react';
+import { DragLayer } from 'react-dnd';
+import { DRAG_ITEM_TYPE_ORGANISM } from './drag-organism';
+import OrganismView from './organism';
+
+const layerStyles = {
+  position: 'fixed',
+  pointerEvents: 'none',
+  zIndex: 100,
+  left: 0,
+  top: 0,
+  width: '100%',
+  height: '100%',
+  opacity: 0.5
+};
+
+function getItemStyles(props) {
+  const { currentOffset, item } = props;
+  if (!currentOffset) {
+    return {
+      display: 'none'
+    };
+  }
+
+  const { x, y } = currentOffset,
+        scale = item.scale,
+        // not sure where this offset comes from
+        xOffset = 34,
+        // we must account for scale factor
+        xScaled = x / scale - xOffset,
+        yScaled = y / scale;
+  const transform = `translate(${xScaled}px, ${yScaled}px)`;
+  return {
+    transform: transform,
+    WebkitTransform: transform
+  };
+}
+
+class CustomDragLayer extends React.Component {
+  renderItem(type, item) {
+    switch (type) {
+    case DRAG_ITEM_TYPE_ORGANISM:
+      return (
+        <OrganismView {...item} />
+      );
+    }
+  }
+
+  render() {
+    const { item, itemType, isDragging } = this.props;
+    if (!isDragging) {
+      return null;
+    }
+
+    return (
+      <div style={layerStyles}>
+        <div style={getItemStyles(this.props)}>
+          {this.renderItem(itemType, item)}
+        </div>
+      </div>
+    );
+  }
+}
+
+CustomDragLayer.propTypes = {
+  item: PropTypes.object,
+  itemType: PropTypes.string,
+  currentOffset: PropTypes.shape({
+    x: PropTypes.number.isRequired,
+    y: PropTypes.number.isRequired
+  }),
+  isDragging: PropTypes.bool.isRequired
+};
+
+function collect(monitor) {
+  return {
+    item: monitor.getItem(),
+    itemType: monitor.getItemType(),
+    currentOffset: monitor.getSourceClientOffset(),
+    isDragging: monitor.isDragging()
+  };
+}
+
+export default DragLayer(collect)(CustomDragLayer);

--- a/src/code/components/drag-organism.js
+++ b/src/code/components/drag-organism.js
@@ -1,0 +1,91 @@
+/*
+ * React DnD DragSource wrapper for an OrganismView.
+ * Supports rendering via HTML5 dragImage (useCustomDragLayer=false)
+ * or custom drag layer (useCustomDragLayer=true).
+ * Custom drag layer is required for IE11 and for touch devices
+ * that don't support HTML5 drag/drop API.
+ */
+import React, { Component, PropTypes } from 'react';
+import { DragSource } from 'react-dnd';
+import { getEmptyImage } from 'react-dnd-html5-backend';
+import OrganismView, { getDrakeImageUrl } from './organism';
+
+export const DRAG_ITEM_TYPE_ORGANISM = 'organism';
+
+const dragOrganismSource = {
+  beginDrag(props) {
+    // make all props available for now
+    return props;
+  }
+};
+
+// collecting function gathers properties passed to dragged component
+function collect(connect, monitor) {
+  return {
+    connectDragSource: connect.dragSource(),
+    connectDragPreview: connect.dragPreview(),
+    isDragging: monitor.isDragging()
+  };
+}
+
+class DragOrganismView extends Component {
+
+  static propTypes = {
+    org: PropTypes.object,
+    width: PropTypes.number,
+    scale: PropTypes.number,
+    useCustomDragLayer: PropTypes.bool,
+    connectDragSource: PropTypes.func.isRequired,
+    connectDragPreview: PropTypes.func.isRequired,
+    isDragging: PropTypes.bool.isRequired
+  }
+
+  componentDidMount() {
+    // cf. https://github.com/react-dnd/react-dnd/blob/master/examples/02%20Drag%20Around/Custom%20Drag%20Layer/DraggableBox.js
+    // Use empty image as a drag preview so browsers don't draw it
+    // and we can draw whatever we want on the custom drag layer instead.
+    const { useCustomDragLayer, connectDragPreview } = this.props;
+    if (useCustomDragLayer) {
+      connectDragPreview(getEmptyImage(), {
+        // IE fallback: specify that we'd rather screenshot the node
+        // when it already knows it's being dragged so we can hide it with CSS.
+        captureDraggingState: true
+      });
+    }
+  }
+
+  updateDragImage() {
+    const { org, width, scale, connectDragPreview } = this.props,
+          size = width || 200,
+          scaledSize = size * (scale || 1),
+          canvas = document.createElement('canvas'),
+          ctx = canvas.getContext('2d'),
+          img = new Image();
+    img.onload = () => {
+      canvas.width = scaledSize;
+      canvas.height = scaledSize;
+      ctx.drawImage(img, 0, 0, scaledSize, scaledSize);
+      connectDragPreview(canvas);
+    };
+    img.src = getDrakeImageUrl(org);
+  }
+
+  render() {
+    const { connectDragSource, isDragging, useCustomDragLayer, ...otherProps } = this.props,
+          dragStyle = { opacity: isDragging ? 0.5 : 1, cursor: 'move' };
+
+    if (!useCustomDragLayer)
+      this.updateDragImage();
+
+    return connectDragSource(
+      <div>
+        <OrganismView style={dragStyle} {...otherProps} />
+      </div>
+    );
+  }
+}
+
+export default DragSource(
+                DRAG_ITEM_TYPE_ORGANISM,
+                dragOrganismSource,
+                collect)(DragOrganismView);

--- a/src/code/components/organism.js
+++ b/src/code/components/organism.js
@@ -1,8 +1,12 @@
 import React, {PropTypes} from 'react';
 
+export function getDrakeImageUrl(org) {
+  const baseUrl = "https://geniverse-resources.concord.org/resources/drakes/images/";
+  return org ? baseUrl + org.getImageName() : null;
+}
+
 const OrganismView = ({org, id, className="", width=200, flipped=false, style={}, onClick, wrapper }) => {
-  const baseUrl = "https://geniverse-resources.concord.org/resources/drakes/images/",
-        url     = org ? baseUrl + org.getImageName() : null,
+  const url = getDrakeImageUrl(org),
         // The goal here was to have the onMouseDown handler select the organism,
         // so that mousedown-drag will both select the organism and begin the
         // drag. This works on Chrome and Safari, but on Firefox it disables

--- a/src/code/containers/challenge-container-selector.js
+++ b/src/code/containers/challenge-container-selector.js
@@ -1,4 +1,6 @@
 import React, { Component, PropTypes } from 'react';
+import { DragDropContext } from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
 import { connect } from 'react-redux';
 import { navigateToCurrentRoute, navigateToChallenge } from '../actions';
 import ChallengeContainer from './challenge-container';
@@ -93,5 +95,6 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-const ConnectedChallengeContainerSelector = connect(mapStateToProps, mapDispatchToProps)(ChallengeContainerSelector);
+const DragDropChallengeContainerSelector = DragDropContext(HTML5Backend)(ChallengeContainerSelector),
+      ConnectedChallengeContainerSelector = connect(mapStateToProps, mapDispatchToProps)(DragDropChallengeContainerSelector);
 export default ConnectedChallengeContainerSelector;

--- a/src/code/containers/fv-challenge-container.js
+++ b/src/code/containers/fv-challenge-container.js
@@ -71,7 +71,10 @@ function mapStateToProps (state) {
       errors: state.errors,
       moves: state.moves,
       goalMoves: state.goalMoves,
-      userDrakeHidden: state.userDrakeHidden
+      userDrakeHidden: state.userDrakeHidden,
+      // drag/drop experiment option for enabling custom drag layer rather
+      // than HTML5 drag/drop dragImage
+      useCustomDragLayer: true
     };
   }
 

--- a/src/code/fv-components/fv-drop-stable.js
+++ b/src/code/fv-components/fv-drop-stable.js
@@ -1,0 +1,97 @@
+/*
+ * React DnD DropTarget wrapper for FVStableView
+ */
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+import FVStableView from './fv-stable';
+import { DropTarget } from 'react-dnd';
+import { DRAG_ITEM_TYPE_ORGANISM } from '../components/drag-organism';
+
+/**
+ * Specifies the drop target contract.
+ * All methods are optional.
+ */
+const stableTarget = {
+  canDrop(/* props, monitor */) {
+    // You can disallow drop based on props or item
+    //const item = monitor.getItem();
+    return true;
+  },
+
+  drop(props, monitor) {
+    if (monitor.didDrop()) {
+      // If you want, you can check whether some nested
+      // target already handled drop
+      return;
+    }
+
+    // Obtain the dragged item
+    //const item = monitor.getItem();
+
+    // You can do something with it
+    if (props.onDropDrake)
+      props.onDropDrake();
+
+    // You can also do nothing and return a drop result,
+    // which will be available as monitor.getDropResult()
+    // in the drag source's endDrag() method
+    return { moved: true };
+  }
+};
+
+/**
+ * Specifies which props to inject into your component.
+ */
+function collect(connect, monitor) {
+  return {
+    // Call this function inside render()
+    // to let React DnD handle the drag events:
+    connectDropTarget: connect.dropTarget(),
+    // You can ask the monitor about the current drag state:
+    isOver: monitor.isOver(),
+    isOverCurrent: monitor.isOver({ shallow: true }),
+    canDrop: monitor.canDrop(),
+    itemType: monitor.getItemType()
+  };
+}
+
+class FVDropStableView extends React.Component {
+
+  static propTypes = {
+    isOver: PropTypes.bool,
+    isOverCurrent: PropTypes.bool,
+    canDrop: PropTypes.bool,
+    connectDropTarget: PropTypes.func,
+    className: PropTypes.string
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (!this.props.isOver && nextProps.isOver) {
+      // You can use this as enter handler
+    }
+
+    if (this.props.isOver && !nextProps.isOver) {
+      // You can use this as leave handler
+    }
+
+    if (this.props.isOverCurrent && !nextProps.isOverCurrent) {
+      // You can be more specific and track enter/leave
+      // shallowly, not including nested targets
+    }
+  }
+
+  render() {
+    // These props are injected by React DnD,
+    // as defined by your `collect` function above:
+    const { className, isOver, canDrop, connectDropTarget, ...others } = this.props,
+          classes = classNames(className, { 'drag-droppable': canDrop,
+                                            'drag-over': canDrop && isOver });
+    return connectDropTarget(
+      <div>
+        <FVStableView className={classes} {...others} />
+      </div>
+    );
+  }
+}
+
+export default DropTarget(DRAG_ITEM_TYPE_ORGANISM, stableTarget, collect)(FVDropStableView);

--- a/src/code/fv-components/fv-stable.js
+++ b/src/code/fv-components/fv-stable.js
@@ -1,6 +1,7 @@
 import React, {PropTypes} from 'react';
 import FVStableCounter from './stable-counter';
 import OrganismView from '../components/organism';
+import classNames from 'classnames';
 
 /**
  * @param {number} rows - Option number of rows. If defined, it will be fixed at that. Otherwise, it
@@ -8,7 +9,7 @@ import OrganismView from '../components/organism';
  * @param {number} tightenRows - If given, will shrink the vertical height of the stable by this amount
  *                        per row, crowding the org images as needed.
  */
-const FVStableView = ({orgs, idPrefix='organism-', height=218, onClick}) => {
+const FVStableView = ({className, orgs, idPrefix='organism-', height=218, onClick}) => {
 
   function handleClick(id, org) {
     const prefixIndex = id.indexOf(idPrefix),
@@ -24,9 +25,10 @@ const FVStableView = ({orgs, idPrefix='organism-', height=218, onClick}) => {
           </div>
         );
       });
+  const classes = classNames('geniblocks fv-stable', className);
 
   return (
-    <div className="geniblocks fv-stable">
+    <div className={classes}>
       <FVStableCounter count={orgs.length} maxCount={5}/>
       <div className="stable-drakes">
         { stableDrakeViews }
@@ -36,6 +38,7 @@ const FVStableView = ({orgs, idPrefix='organism-', height=218, onClick}) => {
 };
 
 FVStableView.propTypes = {
+  className: PropTypes.string,
   orgs: PropTypes.arrayOf(PropTypes.object).isRequired,
   idPrefix: PropTypes.string,
   height: PropTypes.number,

--- a/src/stylus/fablevision/fv-drop-stable.styl
+++ b/src/stylus/fablevision/fv-drop-stable.styl
@@ -1,0 +1,12 @@
+/*
+ * Example demonstration of drag feedback.
+ * - yellow border while drag is in progress, indicating potential drop target
+ * - green border while drag is over stable, indicating active drop target
+ * A better UI would potentially use separate background images or otherwise
+ * show the drop target state in a more pleasing manner.
+ */
+.fv-stable.drag-droppable
+  border: 10px solid yellow
+
+  &.drag-over
+    border-color: #0F0

--- a/yarn.lock
+++ b/yarn.lock
@@ -173,7 +173,7 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-asap@~2.0.3:
+asap@^2.0.3, asap@~2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.5.tgz#522765b50c3510490e52d7dcfe085ef9ba96958f"
 
@@ -1572,6 +1572,19 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+disposables@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/disposables/-/disposables-1.0.1.tgz#064727a25b54f502bd82b89aa2dfb8df9f1b39e3"
+
+dnd-core@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-2.2.4.tgz#a05d49220fb2b05d08b99a00177c01c9a1c445ad"
+  dependencies:
+    asap "^2.0.3"
+    invariant "^2.0.0"
+    lodash "^4.2.0"
+    redux "^3.2.0"
+
 doctrine@^1.2.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -2715,7 +2728,7 @@ interpret@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.1.tgz#d579fb7f693b858004947af39fa0db49f795602c"
 
-invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.1:
+invariant@^2.0.0, invariant@^2.1.0, invariant@^2.2.0, invariant@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -3931,6 +3944,22 @@ react-dimensions@^1.3.0:
   dependencies:
     element-resize-event "^2.0.4"
 
+react-dnd-html5-backend@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-2.2.4.tgz#6c4a704efaa35cf568f40376ed82b8a3eb3c26df"
+  dependencies:
+    lodash "^4.2.0"
+
+react-dnd@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-2.2.4.tgz#8982d557cc620b1f201a8b6ebda894b622af903f"
+  dependencies:
+    disposables "^1.0.1"
+    dnd-core "^2.2.4"
+    hoist-non-react-statics "^1.2.0"
+    invariant "^2.1.0"
+    lodash "^4.2.0"
+
 react-dom@^15.4.1:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.1.tgz#d54c913261aaedb17adc20410d029dcc18a1344a"
@@ -4122,7 +4151,7 @@ redux-thunk@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.1.0.tgz#c724bfee75dbe352da2e3ba9bc14302badd89a98"
 
-redux@^3.5.2, redux@^3.6.0:
+redux@^3.2.0, redux@^3.5.2, redux@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.6.0.tgz#887c2b3d0b9bd86eca2be70571c27654c19e188d"
   dependencies:


### PR DESCRIPTION
- add DragDropContext to ChallengeContainerSelector
- add DragOrganismView to support dragging of drakes
- add FVDropStableView to support dropping of drakes in the stable
- add CustomDragLayer for IE11/touch backend support
- outline stable in yellow when drag is in progress (for demonstration only)
- outline stable in green when drag is over stable (for demonstration only)

This PR depends on the [`scaleToFit` PR#108](https://github.com/concord-consortium/geniblocks/pull/108) and should be rebased once that PR is merged.

This PR was not originally intended for merging at this point. It was part of an investigation to determine what would be involved to support drag/drop in GV2 given the scaling that we are doing as well as the platform support issues of the React-DnD library. The demonstration pieces have been removed, however, so that what remains is the necessary infrastructure for supporting drag/drop as well as some example components for making drakes draggable and stables droppable. These serve as examples of how to enable drag/drop in other challenges, e.g. draggable eggs and droppable baskets in the egg sorting challenges.

The brief results of the investigation are that:
- supporting drag/drop in a scaled div is reasonably straightforward
- supporting drag/drop on IE11 or touch devices requires a custom drag layer (demonstrated here)
- supporting drag/drop on touch devices additionally requires use of a third-party backend

The following discussion is largely copied from `custom-drag-layer.js`:
The current state of React DnD backend support is somewhat muddled. The default/only backend that is officially supported is the `HTML5Backend`, which utilizes the HTML5 drag/drop API. Unfortunately, the HTML5 drag/drop API is only partially supported on IE11 and completely unsupported on most mobile browsers. To support IE11, one must use a custom drag layer because IE11 doesn't support the dragImage API. This module demonstrates how to use a custom drag layer. Support of touch devices is trickier.

The officially recommended way of supporting touch devices is to use the third-party [TouchBackend](https://www.npmjs.com/package/react-dnd-touch-backend), which utilizes touch events rather than drag/drop events. This apparently works reasonably well on touch devices. The `TouchBackend` has a mode which purports to support mouse events as well, but the mouse support is reportedly buggy and the ReadMe recommends against using it. As a result, the state of the art seems to be to dynamically choose between the built-in `HTML5Backend` and the `TouchBackend` based on a run-time test for whether one is running on a touch device or not. Unfortunately, testing for touch devices isn't always straightforward, and the profusion of devices which support both mouse and touch events makes the notion of choosing between the two problematic. So the result is that devices that support both mouse and touch may end up working with the mouse but not touch (if the `HTML5Backend` is chosen) or working with touch but behaving erratically with the mouse (if the `TouchBackend` is chosen), and it's not always easy to predict which.

 There are a couple of other possibilities for enabling touch support which I did not have time to investigate:
 * [react-dnd-multi-backend](https://www.npmjs.com/package/react-dnd-multi-backend) purports to support dynamically switching between the `HTML5Backend` and the `TouchBackend` depending on the events received.
 * [react-dnd-html5-touch-backend](https://www.npmjs.com/package/react-dnd-html5-touch-backend) purports to fold touch events into the drag/drop-like events which are then tied to the `HTML5Backend` analogously to the HTML5 drag/drop events.
 * [dragdroptouch](https://github.com/Bernardo-Castilho/dragdroptouch) is a library which maps touch events to drag/drop events, which in theory could be sufficient to make the `HTML5Backend` work on touch devices.