### PR TITLE
ITS Updates

### DIFF
--- a/src/code/app.js
+++ b/src/code/app.js
@@ -77,6 +77,9 @@ initializeITSSocket(guideServer, guideProtocol, store);
 const sessionID = uuid.v4(),
       userNameBase = urlParams.baseUser || "gv2-user";
 loggingMetadata.userName = `${userNameBase}-${sessionID.split("-")[0]}`;
+loggingMetadata.classInfo = urlParams.class_info_url;
+loggingMetadata.studentId = urlParams.domain_uid;
+loggingMetadata.externalId = urlParams.externalId;
 // start the session before syncing history, which triggers navigation
 store.dispatch(startSession(sessionID));
 

--- a/src/code/containers/fv-challenge-container.js
+++ b/src/code/containers/fv-challenge-container.js
@@ -93,7 +93,7 @@ function mapDispatchToProps(dispatch) {
     onSelectGameteInPool: (sex, index) => dispatch(selectGameteInPool(sex, index)),
     onFertilize: (gamete1, gamete2) => dispatch(fertilize(gamete1, gamete2)),
     onHatch: () => dispatch(hatch()),
-    onResetGametes: () => dispatch(resetGametes()),
+    onResetGametes: (incrementMoves) => dispatch(resetGametes(incrementMoves)),
     onResetGametePools: () => dispatch(resetGametePools()),
     onKeepOffspring: (index, keptDrakesIndices, maxDrakes, shouldKeepSourceDrake) => dispatch(keepOffspring(index, keptDrakesIndices, maxDrakes, shouldKeepSourceDrake)),
     onChangeBasketSelection: (selectedIndices) => dispatch(changeBasketSelection(selectedIndices)),

--- a/src/code/middleware/its-log.js
+++ b/src/code/middleware/its-log.js
@@ -170,6 +170,9 @@ function createLogEntry(loggingMetadata, action, nextState){
   const message =
     {
       username: loggingMetadata.userName,
+      classInfo: loggingMetadata.classInfo,
+      studentId: loggingMetadata.studentId,
+      externalId: loggingMetadata.externalId,
       session: session,
       time: Date.now(),
       sequence: sequence,

--- a/src/code/modules/gametes.js
+++ b/src/code/modules/gametes.js
@@ -109,9 +109,10 @@ export function addGameteChromosome(index, name, side) {
   };
 }
 
-export function resetGametes() {
+export function resetGametes(incrementMoves=false) {
   return {
-    type: GAMETES_RESET
+    type: GAMETES_RESET,
+    incrementMoves
   };
 }
 

--- a/src/code/templates/fv-egg-game.js
+++ b/src/code/templates/fv-egg-game.js
@@ -929,7 +929,7 @@ export default class FVEggGame extends Component {
   render() {
     const { challengeType, interactionType, scale, showUserDrake, trial, drakes, gametes,
             userChangeableGenes, visibleGenes, userDrakeHidden, onChromosomeAlleleChange,
-            onFertilize, onHatch, onResetGametes, onKeepOffspring, onDrakeSubmission } = this.props,
+            onFertilize, onHatch, onResetGametes, onKeepOffspring, onDrakeSubmission, moves } = this.props,
           { currentGametes } = gametes,
           { animatingGametes } = this.state,
           firstTargetDrakeIndex = 3, // 0: mother, 1: father, 2: child, 3-5: targets
@@ -987,8 +987,13 @@ export default class FVEggGame extends Component {
       }
     };
     const handleReset = function() {
+      if (moves >= 1) {
+        // Treat reset and submit the same after a mistake has been made
+        handleSubmit();
+        return;
+      }
       resetAnimationEvents({ showStaticGametes: true, showHatchAnimation: showUserDrake });
-      onResetGametes();
+      onResetGametes(true);
     };
 
     function getGameteChromosomeMap(parent, gamete, side) {
@@ -1241,7 +1246,8 @@ export default class FVEggGame extends Component {
     onHatch: PropTypes.func,
     onResetGametes: PropTypes.func,
     onKeepOffspring: PropTypes.func,
-    onDrakeSubmission: PropTypes.func
+    onDrakeSubmission: PropTypes.func,
+    moves: PropTypes.number
   }
 
   static authoredGametesToGametePools = function(authoredChallenge, drakes, trial) {

--- a/test/actions/submit-egg.js
+++ b/test/actions/submit-egg.js
@@ -1,62 +1,138 @@
 import expect from 'expect';
 import * as actions from '../../src/code/actions';
 
-const types = actions.actionTypes;
+const types = actions.actionTypes,
+      submittedCharacteristics = {
+        armor: "Five armor",
+        color:"Steel",
+        forelimbs:"Forelimbs",
+        health: "Healthy",
+        hindlimbs: "No hindlimbs",
+        horns: "Horns",
+        liveliness: "Alive",
+        "nose spike": "No nose spike",
+        tail: "Long tail",
+        wings: "Wings"
+      },
+      submittedAlleles = "a:T,b:T,a:M,b:M,a:W,b:w,a:h,b:h,a:C,b:C,a:B,b:B,a:Fl,b:Fl,a:hl,b:hl,a:A1,b:A1,a:D,a:Bog,a:rh",
+      acceptedAllelesCorrect = ["a:W", "b:W"],
+      acceptedAllelesIncorrect = ["a:w,b:w"],
+      submittedBasketLabel = "test basket";
+
+function assertMatchingPhenotype(actionPhenotype, targetCharacteristics) {
+  Object.keys(actionPhenotype).forEach((trait) => {
+    expect(actionPhenotype[trait]).toEqual(targetCharacteristics[trait]);
+  });
+}
 
 describe('submitEggForBasket action', () => {
   describe('when the egg is submitted correctly', () => {
-    const eggDrakeIndex = 0, basketIndex = 0, isCorrect = true,
-          submitEggAction = {
-                              type: types.EGG_SUBMITTED,
-                              eggDrakeIndex,
-                              basketIndex,
-                              isCorrect,
-                              incrementMoves: false,
-                              meta: {
-                                "itsLog": {
-                                  "actor": "USER",
-                                  "action": "SUBMITTED",
-                                  "target": "EGG"
-                                }
-                              }
-                            };
+    const eggDrakeIndex = 0, basketIndex = 0, isCorrect = true;
 
     const dispatch = expect.createSpy();
-    const getState = () => ({routeSpec: {mission: 0, challenge: 0, trial: 0}, trials: [{}], authoring: [[[{}]]]});
+    const getState = () => ({
+      routeSpec: {level: 0, mission: 0, challenge: 0},
+      drakes: [
+        {
+          phenotype: {characteristics: submittedCharacteristics},
+          alleleString: submittedAlleles,
+          sex: 0
+        }
+      ],
+      baskets: [
+        {
+          alleles: acceptedAllelesCorrect,
+          label: submittedBasketLabel
+        }
+      ],
+      trials: [{}], 
+      authoring: {
+        challenges: {"test": {visibleGenes: "wings, arms"}}, 
+        "application": {"levels": [{"missions": [{"challenges": [{"id": "test"}]}]}]}
+      }
+    });
 
     actions.submitEggForBasket(eggDrakeIndex, basketIndex, isCorrect)(dispatch, getState);
 
     expect(dispatch).toHaveBeenCalled();
     it('should call dispatch with the correct _submitEggForBasket action', () => {
-      expect(dispatch.calls[0].arguments).toEqual([submitEggAction]);
+      var submitEggAction = dispatch.calls[0].arguments[0];
+      expect(submitEggAction).toEqual({
+        type: types.EGG_SUBMITTED,
+        species: BioLogica.Species.Drake.name,
+        submittedPhenotype: submitEggAction.submittedPhenotype, // phenotype checked below
+        submittedGenotype: submittedAlleles,
+        submittedSex: 0,
+        acceptedGenotypes: acceptedAllelesCorrect,
+        acceptedSexes: [BioLogica.FEMALE, BioLogica.MALE],
+        basketLabel: submittedBasketLabel,
+        visibleGenes: ["wings", "arms"],
+        isCorrect,
+        incrementMoves: false,
+        meta: {
+          "itsLog": {
+            "actor": "USER",
+            "action": "SUBMITTED",
+            "target": "EGG"
+          }
+        }
+      });
+      assertMatchingPhenotype(submitEggAction.submittedPhenotype, submittedCharacteristics);
     });
   });
 
   describe('when the egg is submitted incorrectly', () => {
-    const eggDrakeIndex = 0, basketIndex = 0, isCorrect = false,
-          submitEggAction = {
-                              type: types.EGG_SUBMITTED,
-                              eggDrakeIndex,
-                              basketIndex,
-                              isCorrect,
-                              incrementMoves: true,
-                              meta: {
-                                "itsLog": {
-                                  "actor": "USER",
-                                  "action": "SUBMITTED",
-                                  "target": "EGG"
-                                }
-                              }
-                            };
+    const eggDrakeIndex = 0, basketIndex = 0, isCorrect = false;
 
     const dispatch = expect.createSpy();
-    const getState = () => ({routeSpec: {mission: 0, challenge: 0, trial: 0}, trials: [{}], authoring: [[[{}]]]});
+    const getState = () => ({
+      routeSpec: {level: 0, mission: 0, challenge: 0},
+      drakes: [
+        {
+          phenotype: {characteristics: submittedCharacteristics},
+          alleleString: submittedAlleles,
+          sex: 0
+        }
+      ],
+      baskets: [
+        {
+          alleles: acceptedAllelesIncorrect,
+          label: submittedBasketLabel
+        }
+      ],
+      trials: [{}], 
+      authoring: {
+        challenges: {"test": {visibleGenes: "wings, arms"}}, 
+        "application": {"levels": [{"missions": [{"challenges": [{"id": "test"}]}]}]}
+      }
+    });
 
     actions.submitEggForBasket(eggDrakeIndex, basketIndex, isCorrect)(dispatch, getState);
 
     expect(dispatch).toHaveBeenCalled();
     it('should call dispatch with the correct _submitEggForBasket action', () => {
-      expect(dispatch.calls[0].arguments).toEqual([submitEggAction]);
+      var submitEggAction = dispatch.calls[0].arguments[0];
+      expect(submitEggAction).toEqual({
+        type: types.EGG_SUBMITTED,
+        species: BioLogica.Species.Drake.name,
+        submittedPhenotype: submitEggAction.submittedPhenotype, // phenotype checked below
+        submittedGenotype: submittedAlleles,
+        submittedSex: 0,
+        acceptedGenotypes: acceptedAllelesIncorrect,
+        acceptedSexes: [BioLogica.FEMALE, BioLogica.MALE],
+        basketLabel: submittedBasketLabel,
+        visibleGenes: ["wings", "arms"],
+        isCorrect,
+        incrementMoves: true,
+        meta: {
+          "itsLog": {
+            "actor": "USER",
+            "action": "SUBMITTED",
+            "target": "EGG"
+          }
+        }
+      });
+      assertMatchingPhenotype(submitEggAction.submittedPhenotype, submittedCharacteristics);
     });
   });
 });

--- a/test/modules/gametes.js
+++ b/test/modules/gametes.js
@@ -98,7 +98,8 @@ describe("gametes module", () => {
   describe("resetGametes action", () => {
     it("should create an action to reset the gametes", () => {
       expect(resetGametes()).toEqual({
-        type: GAMETES_RESET
+        type: GAMETES_RESET,
+        incrementMoves: false
       });
     });
   });


### PR DESCRIPTION
A handful of different ITS updates:
* Adding information to `submitEgg` action for the egg sorting game
* Adding integration with the Portal. If launched from an activity there, the student and classroom IDs are now pulled out of the URL.
* ITS now hints after a student has bred two drakes without completing a challenge. Functionally, this means that after a single reset, the 'reset' and 'submit' buttons to the same thing

Turns out implementing the last bullet point was simpler than expected- I gave `resetGametes` a flag to optionally increment the number of moves, and check `moves` when the 'reset' button is hit.