### PR TITLE
Fixing #143585545: click area of baskets is incorrect

### DIFF
--- a/src/code/components/basket-set.js
+++ b/src/code/components/basket-set.js
@@ -47,9 +47,10 @@ class BasketView extends React.Component {
     }
 
     return (
-      <div className={classes} id={id} key={id} style={{ position: 'relative' }} onClick={this.handleClick}>
+      <div className={classes} id={id} key={id} style={{ position: 'relative' }}>
         <div className='basket-image' ref='domNode'>
           <div className='basket-label unselectable'>{basket.label}</div>
+          <div className='basket-hover' onClick={this.handleClick}></div>
         </div>
         {eggsDiv()}
       </div>

--- a/src/stylus/fablevision/fv-egg-sort-game.styl
+++ b/src/stylus/fablevision/fv-egg-sort-game.styl
@@ -54,20 +54,27 @@
               height: 503px
               background-size: contain
               position: absolute
+              .basket-label
+                width: 133px
+                height: 135px
+                left: 203px
+                top: 352px
+                font-family: 'Yanone Kaffeesatz'
+                position: absolute
+                text-align: center
+                display: flex
+                flex-direction: column
+                justify-content: center
             &.selected .basket-image
               background-image: url('../resources/fablevision/layout-d/basket.png')
-              cursor: pointer
-            .basket-label
-              width: 133px
-              height: 135px
-              left: 203px
-              top: 352px
-              font-family: 'Yanone Kaffeesatz'
-              position: absolute
-              text-align: center
-              display: flex
-              flex-direction: column
-              justify-content: center
+              .basket-hover
+                width: 250px
+                height: 200px
+                position: absolute
+                left: 130px
+                top: 300px
+                cursor: pointer
+                z-index: 3
 
       #left-section
         width: 1156px


### PR DESCRIPTION
Another small fix- placing a separate div over the baskets so their click regions don't overlap as they did previously