### PR TITLE
Moving dialog boxes to center of screen

### DIFF
--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -389,7 +389,6 @@ export function submitDrake(targetDrakeIndex, userDrakeIndex, correct, incorrect
             label: "~BUTTON.NEXT_TRIAL",
             action: "advanceTrial"
           },
-          top: "600px"
         };
       }
     } else {
@@ -400,7 +399,6 @@ export function submitDrake(targetDrakeIndex, userDrakeIndex, correct, incorrect
           label: "~BUTTON.TRY_AGAIN",
           action: incorrectAction || "dismissModalDialog"
         },
-        top: "600px"
       };
     }
     dispatch(showModalDialog(dialog));
@@ -486,7 +484,6 @@ export function submitEggForBasket(eggDrakeIndex, basketIndex, isCorrect, isChal
           action: "rejectEggFromBasket",
           args: { eggDrakeIndex, basketIndex, isChallengeComplete }
         },
-        top: "475px"
       };
       setTimeout(function() {
         dispatch(showModalDialog(dialog));

--- a/test/actions/submit-drake.js
+++ b/test/actions/submit-drake.js
@@ -158,7 +158,7 @@ describe('submitDrake action', () => {
         },
         leftButton: undefined,
         showAward: false,
-        top: "600px"
+        top: undefined
       });
     });
 


### PR DESCRIPTION
A small fix if you wouldn't mind taking a look @kswenson! Trudi noticed that dialog boxes aren't centered on the screen, and may move off entirely on smaller screens. 

I realized the issue is that the dialog boxes have a static offset from the top which isn't scaled, because it's not in the challenge container. I removed the offsets, so now the default `50%` is used. The fix looks fine, but there's a comment in the code that made me want a second pair of eyes:

```
// we use some pseudo random coords so nested modals
// don't sit right on top of each other.
````

I don't want these modals to get covered up, but in this case I'm fairly sure that won't happen.