### PR TITLE
Changing initial drake generation to make sure it does not match the target drake

### DIFF
--- a/src/code/utilities/trial-generator.js
+++ b/src/code/utilities/trial-generator.js
@@ -11,10 +11,27 @@ export function generateTrialDrakes(trialDef, trial=0) {
 
     let initialDrakeAlleles = generateComboDrakeAlleles(trialDef.baseDrake, trialDef.initialDrakeCombos, trial),
         targetDrakeAlleles  = generateComboDrakeAlleles(trialDef.baseDrake, trialDef.targetDrakeCombos,  trial),
-        initialDrake = {alleles: initialDrakeAlleles, sex: 0},
-        targetDrake = {alleles: targetDrakeAlleles, sex: 0};
+        initialDrake = new BioLogica.Organism(BioLogica.Species.Drake, initialDrakeAlleles),
+        targetDrake = new BioLogica.Organism(BioLogica.Species.Drake, targetDrakeAlleles);
 
-    return [initialDrake, targetDrake];
+    for (let numTrials = 0; numTrials < 100; numTrials++) {
+      if (arePhenotypesEqual(initialDrake, targetDrake)) {
+        initialDrakeAlleles = generateComboDrakeAlleles(trialDef.baseDrake, trialDef.initialDrakeCombos, trial);
+        initialDrake = new BioLogica.Organism(BioLogica.Species.Drake, initialDrakeAlleles);
+      } else {
+        break;
+      }
+    }
+    if (arePhenotypesEqual(initialDrake, targetDrake)) {
+      console.log("Failed to produce different initial and target drakes");
+    }
+
+    let initialDrakeSex = Math.trunc(2 * Math.random()),
+        targetDrakeSex = Math.trunc(2 * Math.random()),
+        initialDrakeObj = {alleles: initialDrakeAlleles, sex: initialDrakeSex},
+        targetDrakeObj = {alleles: targetDrakeAlleles, sex: targetDrakeSex};
+
+    return [initialDrakeObj, targetDrakeObj];
   }
   if (trialDef.type === RANDOMIZE_ORDER) {
     if (trialDef.drakes) {
@@ -32,6 +49,16 @@ export function generateTrialDrakes(trialDef, trial=0) {
     }
   }
   return [];
+}
+
+function arePhenotypesEqual(drake1, drake2) {
+  let areEqual = true;
+  Object.keys(drake1.phenotype.characteristics).forEach((trait) => {
+    if (drake1.phenotype.characteristics[trait] !== drake2.phenotype.characteristics[trait]) {
+      return areEqual = false;
+    }
+  });
+  return areEqual;
 }
 
 function generateComboDrakeAlleles(base, combos, trial) {

--- a/src/code/utilities/trial-generator.js
+++ b/src/code/utilities/trial-generator.js
@@ -52,13 +52,7 @@ export function generateTrialDrakes(trialDef, trial=0) {
 }
 
 function arePhenotypesEqual(drake1, drake2) {
-  let areEqual = true;
-  Object.keys(drake1.phenotype.characteristics).forEach((trait) => {
-    if (drake1.phenotype.characteristics[trait] !== drake2.phenotype.characteristics[trait]) {
-      return areEqual = false;
-    }
-  });
-  return areEqual;
+  return drake1.getImageName() === drake2.getImageName();
 }
 
 function generateComboDrakeAlleles(base, combos, trial) {

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -532,24 +532,22 @@
       "challengeType": "match-target",
       "instructions": "Match the target drake!",
       "showUserDrake": true,
-      "randomizeTrials": true,
-      "initialDrake": {
-        "alleles": "Bog-, D-, rh-rh",
-        "sex": 1
+      "trialGenerator": {
+        "type": "all-combinations",
+        "baseDrake": "M-M, T-T, h-h, A1-A1, C-C, B-B, D-D, rh-rh, Bog-Bog",
+        "initialDrakeCombos": [
+          ["W-W",   "W-w",   "w-W",   "w-w"],
+          ["Fl-Fl", "Fl-fl", "fl-Fl", "fl-fl"],
+          ["Hl-Hl", "Hl-hl", "hl-Hl", "hl-hl"]
+        ],
+        "targetDrakeCombos": [
+          ["W-W",   "w-w"],
+          ["Fl-Fl", "fl-fl"],
+          ["Hl-Hl", "hl-hl"]
+        ]
       },
-      "targetDrakes": [{
-        "alleles": "",
-        "sex": 0
-      },
-      {
-        "alleles": "",
-        "sex": 1
-      }],
-      "userChangeableGenes": "wings, forelimbs, hindlimbs",
-      "linkedGenes": {
-        "drakes": [0, 1],
-        "genes": "metallic, tail, horns, color, black, dilute, armor, nose, bogbreath"
-      }
+      "targetDrakes": [{},{}],
+      "userChangeableGenes": "wings, forelimbs, hindlimbs"
     },
     "allele-targetMatch-hidden-simpleDom": {
       "comment": "*** Level 2, Mission 1.2: Genome Challenge (basics intro, user drake hidden) ***",

--- a/test/utilities/trial-generator.js
+++ b/test/utilities/trial-generator.js
@@ -27,6 +27,42 @@ describe('generateTrialDrakes() -- all-combinations', () => {
       expect(GeneticsUtils.isValidAlleleString(drakes[1].alleles)).toBe(true);
     }
   });
+
+  it('should generate different drakes if possible', () => {
+    const spec = GeneticsUtils.convertDashAllelesObjectToABAlleles({
+                  "type": "all-combinations",
+                  "baseDrake": "T-T, W-W, Fl-Fl, Hl-Hl, h-h, A1-A1, C-C, B-B, D-D, rh-rh, Bog-Bog",
+                  "initialDrakeCombos": [
+                    ["M-M",  "m-m"]
+                  ],
+                  "targetDrakeCombos": [
+                    ["M-M",   "m-m"]
+                  ]
+                }, ["baseDrake", "initialDrakeCombos", "targetDrakeCombos"]);
+    // stochastic test, so try several times
+    for (let tries = 0; tries < 10; tries++) {
+      let drakes = generateTrialDrakes(spec, 0);
+      // just compare alleles for this test, but actual code ensures diff phenotypes
+      assert.notEqual(drakes[0].alleles, drakes[1].alleles);
+    }
+  });
+
+  it('should fail gracefully if impossible to generate different drakes', () => {
+    const spec = GeneticsUtils.convertDashAllelesObjectToABAlleles({
+                  "type": "all-combinations",
+                  "baseDrake": "T-T, W-W, Fl-Fl, Hl-Hl, h-h, A1-A1, C-C, B-B, D-D, rh-rh, Bog-Bog",
+                  "initialDrakeCombos": [
+                    ["M-M"]
+                  ],
+                  "targetDrakeCombos": [
+                    ["M-M"]
+                  ]
+                }, ["baseDrake", "initialDrakeCombos", "targetDrakeCombos"]);
+    let drakes = generateTrialDrakes(spec, 0);
+    expect(drakes.length).toBe(2);
+    expect(GeneticsUtils.isValidAlleleString(drakes[0].alleles)).toBe(true);
+    expect(GeneticsUtils.isValidAlleleString(drakes[1].alleles)).toBe(true);
+  });
 });
 
 describe('generateTrialDrakes() -- randomize-order', () => {


### PR DESCRIPTION
For early genome challenges, it was possible for the target drake to match the initial drake exactly. To fix this, I changed the `trialGenerator` for one of the levels, and tweaked the `all-combinations` generation code. Now, it tries up to 100 times to generate 2 drakes with different phenotypes.

I'll admit, the randomization schemes have never been totally clear to me- I'm not sure who worked on each one. Does this seem like a reasonable change? As for the other genome challenges, I believe they avoid duplicates by more specifically outlining each trial.