### PR TITLE
Color levels and randomization changes

### DIFF
--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -307,8 +307,7 @@ export function submitDrake(targetDrakeIndex, userDrakeIndex, correct, incorrect
           levelCount = AuthoringUtils.getLevelCount(authoring),
           missionCount = AuthoringUtils.getMissionCount(authoring, state.routeSpec.level),
           challengeCount = AuthoringUtils.getChallengeCount(authoring, state.routeSpec.level, state.routeSpec.mission),
-          trials = state.trials,
-          trialCount = trials.length;
+          trialCount = state.numTrials;
     let challengeComplete = false,
         missionComplete = false,
         // levelComplete = false,

--- a/src/code/components/gamete-pen.js
+++ b/src/code/components/gamete-pen.js
@@ -2,7 +2,7 @@ import React, {PropTypes} from 'react';
 import { assign, map } from 'lodash';
 import { toClass } from 'recompose';
 import Dimensions from 'react-dimensions';
-import FVGameteImageView from '../fv-components/fv-gamete-image';
+import GameteImageView from './gamete-image';
 
 /**
  * @param {number} rows - Option number of rows. If defined, it will be fixed at that. Otherwise, it
@@ -18,7 +18,7 @@ export function getGameteLocation(layout, index) {
             top: layout.yMargin + row * layout.effectiveHeight };
 }
 
-const GametePenView = ({id, sex, gametes, idPrefix='gamete-', gameteSize=1.0, showChromosomes=true, containerWidth, containerHeight, rows, columns, tightenRows=0, tightenColumns=0, selectedIndex, selectedColor='#FF6666', onClick, onReportLayoutConstants}) => {
+const GametePenView = ({id, sex, GameteImageClass=GameteImageView, gametes, idPrefix='gamete-', gameteSize=1.0, showChromosomes=true, containerWidth, containerHeight, rows, columns, tightenRows=0, tightenColumns=0, selectedIndex, selectedColor='#FF6666', onClick, onReportLayoutConstants}) => {
 
   function handleGameteClick(evt, gameteID) {
     const prefixIndex = gameteID.indexOf(idPrefix),
@@ -92,8 +92,8 @@ const GametePenView = ({id, sex, gametes, idPrefix='gamete-', gameteSize=1.0, sh
               gameteDisplayStyle = assign({}, gameteDefaultDisplayStyle,
                                           isSelected ? { fillColor: selectedColor } : null);
         return gamete != null
-                ? <FVGameteImageView isEgg={isEgg} chromosomes={chromosomes} key={index}
-                                    id={idPrefix + index} className={className}
+                ? <GameteImageClass isEgg={isEgg} chromosomes={chromosomes} key={index}
+                                    id={idPrefix + index} className={className} isSelected={isSelected}
                                     style={eltStyle} displayStyle={gameteDisplayStyle}
                                     onClick={handleGameteClick}/>
                 : null;

--- a/src/code/containers/fv-challenge-container.js
+++ b/src/code/containers/fv-challenge-container.js
@@ -15,7 +15,7 @@ class FVChallengeContainer extends Component {
 
   render() {
     const { template, style, ...otherProps } = this.props,
-          { challengeType, interactionType, routeSpec, trial, trials, correct } = this.props;
+          { challengeType, interactionType, routeSpec, trial, numTrials, correct } = this.props;
 
     if (!template) return null;
 
@@ -31,7 +31,7 @@ class FVChallengeContainer extends Component {
         <div id="mission-wrapper">
           <Template {...otherProps} />
         </div>
-        <BottomHUDView level={routeSpec.level + 1} trial={trial + 1} trialCount={trials ? trials.length : 1}
+        <BottomHUDView level={routeSpec.level + 1} trial={trial + 1} trialCount={numTrials}
                        currScore={correct} maxScore={maxScore}/>
       </div>
     );
@@ -44,6 +44,7 @@ class FVChallengeContainer extends Component {
     interactionType: PropTypes.string,
     trial: PropTypes.number,
     trials: PropTypes.array,
+    numTrials: PropTypes.number,
     containerWidth: PropTypes.number,
     containerHeight: PropTypes.number,
     routeSpec: PropTypes.object,
@@ -66,6 +67,7 @@ function mapStateToProps (state) {
       baskets: state.baskets,
       trial: state.trial,
       trials: state.trials,
+      numTrials: state.numTrials,
       routeSpec: state.routeSpec,
       correct: state.correct,
       errors: state.errors,

--- a/src/code/containers/navigation.js
+++ b/src/code/containers/navigation.js
@@ -57,6 +57,8 @@ class Navigation extends Component {
           {navigateButton(10, 1, 1)}
           {navigateButton(11, 1, 1)}
           {navigateButton(12, 1, 1)}
+          {navigateButton(13, 1, 1)}
+          {navigateButton(14, 1, 1)}
         </div>
       </div>
     );

--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -114,6 +114,7 @@ export function loadStateFromAuthoring(state, authoring, progress={}) {
         baskets = processAuthoredBaskets(authoredChallenge, state),
         showUserDrake = (authoredChallenge.showUserDrake != null) ? authoredChallenge.showUserDrake : false,
         trials = authoredChallenge.targetDrakes,
+        numTrials = authoredChallenge.numTrials || (trials ? trials.length : 1),
         trialOrder = createTrialOrder(trial, trials, state.trialOrder, authoredChallenge.randomizeTrials),
         drakes = processAuthoredDrakes(authoredChallenge, trialOrder[trial], template),
         gametes = processAuthoredGametes(authoredChallenge, drakes, state);
@@ -137,6 +138,7 @@ export function loadStateFromAuthoring(state, authoring, progress={}) {
     drakes,
     trial,
     trials,
+    numTrials,
     trialOrder,
     challenges,
     correct: 0,
@@ -153,7 +155,7 @@ export function loadStateFromAuthoring(state, authoring, progress={}) {
 export function loadNextTrial(state, authoring, progress) {
   let trial = state.trial;
   if (state.trialSuccess){
-    trial = (state.trial < state.trials.length) ? (trial+1) : 0;
+    trial = (state.trial < state.numTrials) ? (trial+1) : 0;
   }
   let nextState = state.merge({
     trial: trial

--- a/src/code/reducers/index.js
+++ b/src/code/reducers/index.js
@@ -115,7 +115,7 @@ export default function reducer(state, action) {
     case actionTypes.ADVANCED_TRIAL: {
       if (state.trialSuccess){
         let progress = updateProgress(state, true);
-        if (state.trial < state.trials.length - 1) {
+        if (state.trial < state.numTrials - 1) {
           return loadNextTrial(state, action.authoring, progress);
         }
         else {

--- a/src/code/templates/fv-genome-challenge.js
+++ b/src/code/templates/fv-genome-challenge.js
@@ -253,7 +253,7 @@ export default class FVGenomeChallenge extends React.Component {
       initialDrake: state.drakes[0],
       targetDrake: state.drakes[1],
       goalMoves: state.goalMoves,
-      trials: state.trials ? state.trials.length : null,
+      trials: state.numTrials,
       trial: state.trial
     };
   }

--- a/src/code/templates/genome-challenge.js
+++ b/src/code/templates/genome-challenge.js
@@ -14,7 +14,7 @@ export default class GenomeChallengeTemplate extends Component {
 
   render() {
     const { drakes, instructions, onChromosomeAlleleChange, onSexChange, onDrakeSubmission,
-            userChangeableGenes, visibleGenes, hiddenAlleles, showUserDrake, userDrakeHidden, trial, trials } = this.props,
+            userChangeableGenes, visibleGenes, hiddenAlleles, showUserDrake, userDrakeHidden, trial, numTrials } = this.props,
           userDrakeDef = drakes[userDrakeIndex],
           targetDrakeDef = drakes[targetDrakeIndex],
           userDrake   = new BioLogica.Organism(BioLogica.Species.Drake, userDrakeDef.alleleString, userDrakeDef.sex),
@@ -45,7 +45,7 @@ export default class GenomeChallengeTemplate extends Component {
           <div id="target-drake-label" className="column-label">Target Drake</div>
           <OrganismGlowView id="target-drake" org={ targetDrake } />
           <FeedbackView id='trial-feedback' className='feedback-view'
-                                text={["TRIAL", `${trial+1} of ${trials.length}`]}/>
+                                text={["TRIAL", `${trial+1} of ${numTrials}`]}/>
           <FeedbackView id='goal-feedback' className='feedback-view'
                                 text={[`GOAL is ${this.props.goalMoves} MOVES`,
                                         `Your moves: ${this.props.moves}`]}/>
@@ -72,6 +72,7 @@ export default class GenomeChallengeTemplate extends Component {
     hiddenAlleles: PropTypes.array.isRequired,
     trial: PropTypes.number.isRequired,
     trials: PropTypes.array.isRequired,
+    numTrials: PropTypes.number.isRequired,
     moves: PropTypes.number.isRequired,
     goalMoves: PropTypes.number.isRequired,
     showUserDrake: PropTypes.bool,
@@ -101,7 +102,7 @@ export default class GenomeChallengeTemplate extends Component {
       initialDrake: state.drakes[0],
       targetDrake: state.drakes[1],
       goalMoves: state.goalMoves,
-      trials: state.trials.length,
+      trials: state.numTrials,
       trial: state.trial
     };
   }

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -637,19 +637,19 @@
       "showUserDrake": true,
       "initialDrake": [
         {
-          "alleles": "M-m, Bog-, D-, rh-rh",
+          "alleles": "M-m, A1-A1, Bog-, D-, rh-rh",
         },
         {
-          "alleles": "c-c, Bog-, D-, rh-rh",
+          "alleles": "c-c, A1-a, Bog-, D-, rh-rh",
         },
         {
-          "alleles": "B-b, Bog-, D-, rh-rh",
+          "alleles": "B-b, a-A1, Bog-, D-, rh-rh",
         },
         {
-          "alleles": "m-m, Bog-, D-, rh-rh",
+          "alleles": "m-m, a-a, Bog-, D-, rh-rh",
         },
         {
-          "alleles": "C-c, Bog-, D-, rh-rh",
+          "alleles": "C-c, A1-A1, Bog-, D-, rh-rh",
         }
       ],
       "targetDrakes": [
@@ -670,7 +670,6 @@
         }
       ],
       "userChangeableGenes": "metallic, color, black",
-      "visibleGenes": "forelimbs, hindlimbs, wings, armor, horns",
       "linkedGenes": {
         "drakes": [0, 1],
         "genes": "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, nose, bogbreath"

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -717,6 +717,7 @@
           "alleles": "m-m, c-c, B-B",
         }
       ],
+      "numTrials": 3,
       "userChangeableGenes": "metallic, color, black",
       "visibleGenes": "forelimbs, hindlimbs, wings, armor, horns",
       "linkedGenes": {

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -628,6 +628,102 @@
         "genes": "metallic, wings, forelimbs, hindlimbs, tail, color, black, dilute, nose, bogbreath"
       }
     },
+    "allele-targetMatch-visible-simpleColors": {
+      "container": "FVContainer",
+      "template": "FVGenomeChallenge",
+      "challengeType": "match-target",
+      "randomizeTrials": true,
+      "instructions": "Match the target drake!",
+      "showUserDrake": true,
+      "initialDrake": [
+        {
+          "alleles": "M-m, Bog-, D-, rh-rh",
+        },
+        {
+          "alleles": "c-c, Bog-, D-, rh-rh",
+        },
+        {
+          "alleles": "B-b, Bog-, D-, rh-rh",
+        },
+        {
+          "alleles": "m-m, Bog-, D-, rh-rh",
+        },
+        {
+          "alleles": "C-c, Bog-, D-, rh-rh",
+        }
+      ],
+      "targetDrakes": [
+        {
+          "alleles": "m-m, C-C, B-B",
+        },
+        {
+          "alleles": "M-m, C-C, B-B",
+        },
+        {
+          "alleles": "m-m, C-C, b-b",
+        },
+        {
+          "alleles": "M-m, C-C, B-B",
+        },
+        {
+          "alleles": "m-m, c-c, B-B",
+        }
+      ],
+      "userChangeableGenes": "metallic, color, black",
+      "visibleGenes": "forelimbs, hindlimbs, wings, armor, horns",
+      "linkedGenes": {
+        "drakes": [0, 1],
+        "genes": "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, nose, bogbreath"
+      }
+    },
+    "allele-targetMatch-hidden-simpleColors": {
+      "container": "FVContainer",
+      "template": "FVGenomeChallenge",
+      "challengeType": "match-target",
+      "randomizeTrials": true,
+      "showUserDrake": false,
+      "instructions": "Match the target drake!",
+      "initialDrake": [
+        {
+          "alleles": "M-m, Bog-, D-, rh-rh",
+        },
+        {
+          "alleles": "c-c, Bog-, D-, rh-rh",
+        },
+        {
+          "alleles": "B-b, Bog-, D-, rh-rh",
+        },
+        {
+          "alleles": "m-m, Bog-, D-, rh-rh",
+        },
+        {
+          "alleles": "C-c, Bog-, D-, rh-rh",
+        }
+      ],
+      "targetDrakes": [
+        {
+          "alleles": "m-m, C-C, B-B",
+        },
+        {
+          "alleles": "M-m, C-C, B-B",
+        },
+        {
+          "alleles": "m-m, C-C, b-b",
+        },
+        {
+          "alleles": "M-m, C-C, B-B",
+        },
+        {
+          "alleles": "m-m, c-c, B-B",
+        }
+      ],
+      "userChangeableGenes": "metallic, color, black",
+      "visibleGenes": "forelimbs, hindlimbs, wings, armor, horns",
+      "linkedGenes": {
+        "drakes": [0, 1],
+        "genes": "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, nose, bogbreath"
+      }
+    },
     "allele-targetMatch-hidden-armorHorns": {
       "comment": "*** Level 2, Mission 3.2: Genome Challenge (armor intro, user drake hidden) ***",
       "container": "FVContainer",
@@ -875,6 +971,36 @@
         ]
       },
 
+      {
+        "name": "Level 13",
+        "missions": [
+          {
+            "name": "Mission 1.1",
+            "challenges": [
+              {
+                "name": "Challenge 1.1.1",
+                "id": "allele-targetMatch-visible-simpleColors"
+              }
+            ]
+          }
+        ]
+      },
+
+      {
+        "name": "Level 14",
+        "missions": [
+          {
+            "name": "Mission 1.1",
+            "challenges": [
+              {
+                "name": "Challenge 1.1.1",
+                "id": "allele-targetMatch-hidden-simpleColors"
+              }
+            ]
+          }
+        ]
+      },
+      
     ]
   }
 }

--- a/src/stylus/fablevision/fv-gene-label.styl
+++ b/src/stylus/fablevision/fv-gene-label.styl
@@ -34,16 +34,22 @@
   flex-direction: row
 
 .geniblocks.fv-gene-label.allele.noneditable
+  &.m
+    z-index: 8
   &.w
-    z-index: 6
+    z-index: 7
   &.h
+    z-index: 6
+  &.c
     z-index: 5
-  &.fl
+  &.b
     z-index: 4
-  &.hl
+  &.fl
     z-index: 3
-  &.a
+  &.hl
     z-index: 2
+  &.a
+    z-index: 1
 
 .fv-layout
 
@@ -112,14 +118,14 @@
     .fv-gene-label-text
       margin-top: -21px
 
-  .h
+  .w
     .line
-      margin-top: 1px
-      width: 21px 
+      margin-top: -7px
+      width: 25px 
     #mountNode
-      margin-top: 20px
+      margin-top: -17px
     .fv-gene-label-text
-      margin-top: 6px
+      margin-top: -21px
 
   .a 
     .line
@@ -129,6 +135,44 @@
       margin-top: 31px
     .fv-gene-label-text
       margin-top: 19px
+
+  .c 
+    .line
+      margin-top: -7px
+      width: 25px 
+    #mountNode
+      margin-top: -17px
+    .fv-gene-label-text
+      margin-top: 19px
+
+  .b
+    .line
+      margin-top: 3px
+      width: 25px 
+    #mountNode
+      margin-top: 7px
+    .fv-gene-label-text
+      margin-top: 19px
+
+  .ltl .w .line
+    transform: rotate(-35deg)
+    left: -30px
+    top: 12px
+
+  .rtl .w .line
+    transform: rotate(35deg)
+    right: -29px
+    top: 12px
+
+  .ltl .c .line
+    transform: rotate(-35deg)
+    left: -30px
+    top: 12px
+
+  .rtl .c .line
+    transform: rotate(35deg)
+    right: -29px
+    top: 12px
 
   .ltl .fl .line
     transform: rotate(-35deg)
@@ -140,14 +184,6 @@
     right: -29px
     top: 12px
 
-  .ltl .h .line
-    transform: rotate(15deg)
-    top: 15px
-
-  .rtl .h .line
-    transform: rotate(-15deg)
-    top: 15px
-
   .ltl .a .line
     transform: rotate(42deg)
     top: 15px
@@ -155,5 +191,15 @@
 
   .rtl .a .line
     transform: rotate(-42deg)
+    top: 15px
+    right: -30px
+
+  .ltl .b .line
+    transform: rotate(25deg)
+    top: 15px
+    left: -30px
+
+  .rtl .b .line
+    transform: rotate(-25deg)
     top: 15px
     right: -30px

--- a/src/stylus/fablevision/fv-gene-label.styl
+++ b/src/stylus/fablevision/fv-gene-label.styl
@@ -152,7 +152,7 @@
     #mountNode
       margin-top: 7px
     .fv-gene-label-text
-      margin-top: 19px
+      margin-top: 10px
 
   .ltl .w .line
     transform: rotate(-35deg)

--- a/test/templates/egg-game.js
+++ b/test/templates/egg-game.js
@@ -127,6 +127,7 @@ describe('loading authored state into template', () => {
           initialDrakes: drakes, 
           "goalMoves": nextState.goalMoves,
           "trials": [ {}, {}, {} ],
+          "numTrials": 3,
           "trialOrder": [0,1,2]
         }));
     });

--- a/test/templates/genome-challenge.js
+++ b/test/templates/genome-challenge.js
@@ -43,6 +43,7 @@ describe('loading authored state into template', () => {
       "challenges": {
         "test": {
           "template": "GenomeChallenge",
+          "numTrials": 1,
           "initialDrake":{
             "alleles": "W-w, D-D, Bog-Bog, rh-rh",
             "sex": 0
@@ -95,6 +96,7 @@ describe('loading authored state into template', () => {
               "sex": 1
             }
           ],
+          "numTrials": 1,
           "trialOrder": [0,1]
         }));
     });


### PR DESCRIPTION
Hi @sfentress! I added two new levels which allow students to play with color in a Genome Challenge. Those changes were small, but the level spec required some more involved updates I'd appreciate your feedback on.

For the first new level, students have to match 5 target drakes over 5 trials - one each of 5 colors, in a random order. For the second level, students match 3 drakes, picking out of the 5 different colors at random. To accomplish this, I added a new `numTrials` field to the authoring doc and state, which allows you to specify any number of trials, and then choose a random subset of them (3 out of a possible 5, in this case). It actually simplified some pieces of code throughout the project.

Let me know what you think!