### PR TITLE
Adding moves counter to genome challenge and clutch game templates

### DIFF
--- a/src/code/containers/fv-challenge-container.js
+++ b/src/code/containers/fv-challenge-container.js
@@ -35,7 +35,8 @@ class FVChallengeContainer extends Component {
           <Template {...otherProps} />
         </div>
         <BottomHUDView level={routeSpec.level + 1} trial={trial + 1} trialCount={numTrials}
-                       currScore={correct} maxScore={maxScore}/>
+                       currScore={correct} maxScore={maxScore} currMoves={this.props.moves} 
+                       goalMoves={this.props.goalMoves}/>
         <NotificationContainer />
         <ModalMessageContainer />
       </div>
@@ -53,7 +54,9 @@ class FVChallengeContainer extends Component {
     containerWidth: PropTypes.number,
     containerHeight: PropTypes.number,
     routeSpec: PropTypes.object,
-    correct: PropTypes.number
+    correct: PropTypes.number,
+    moves: PropTypes.number,
+    goalMoves: PropTypes.number
   }
 }
 

--- a/src/code/fv-components/bottom-hud.js
+++ b/src/code/fv-components/bottom-hud.js
@@ -4,8 +4,9 @@ import LevelIndicatorView from './level-indicator';
 import CountView from './counter';
 import t from '../utilities/translate';
 
-const BottomHUDView = ({level, trial, trialCount, currScore, maxScore}) => {
-  let scoreView = maxScore ? <CountView countTitleText={t('~COUNTER.SCORE_LABEL')} className={'score-count'} currCount={currScore} maxCount={maxScore} /> : null;
+const BottomHUDView = ({level, trial, trialCount, currScore, maxScore, currMoves, goalMoves}) => {
+  let scoreView = maxScore ? <CountView countTitleText={t('~COUNTER.SCORE_LABEL')} className={'score-count'} currCount={currScore} maxCount={maxScore} /> : null,
+      movesView = goalMoves > 0 ? <CountView countTitleText={t('~COUNTER.MOVES_LABEL')} className={'moves-count'} currCount={currMoves} maxCount={goalMoves} /> : null;
 
   return (
     <div id='fv-bottom-hud' className='fv-hud fv-bottom-hud' >
@@ -13,6 +14,7 @@ const BottomHUDView = ({level, trial, trialCount, currScore, maxScore}) => {
       <LevelIndicatorView level={level} />
       <CountView countTitleText={t('~COUNTER.TRIAL_LABEL')} className={'trial-count'} currCount={trial} maxCount={trialCount} />
       {scoreView}
+      {movesView}
     </div>
   );
 };
@@ -22,7 +24,9 @@ BottomHUDView.propTypes = {
   trial: PropTypes.number,
   trialCount: PropTypes.number,
   currScore: PropTypes.number,
-  maxScore: PropTypes.number
+  maxScore: PropTypes.number,
+  currMoves: PropTypes.number,
+  goalMoves: PropTypes.number
 };
 
 export default BottomHUDView;

--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -122,6 +122,8 @@ export function loadStateFromAuthoring(state, authoring, progress={}) {
   let goalMoves = null;
   if (template.calculateGoalMoves) {
     goalMoves = template.calculateGoalMoves(drakes);
+  } else if (authoredChallenge.goalMoves) {
+    goalMoves = authoredChallenge.goalMoves[trial];
   }
 
   return state.merge({

--- a/src/code/templates/clutch-game.js
+++ b/src/code/templates/clutch-game.js
@@ -213,10 +213,4 @@ export default class ClutchGame extends Component {
             authoredChallenge.targetDrakes[authoredTrialNumber]];
   }
 
-  static calculateGoalMoves = function() {
-    // each incorrect submission counts as one move
-    // the goal is to have no incorrect submissions
-    return 0;
-  }
-
 }

--- a/src/code/templates/fv-genome-challenge.js
+++ b/src/code/templates/fv-genome-challenge.js
@@ -115,7 +115,7 @@ class TargetDrakeView extends React.Component {
  */
 export default class FVGenomeChallenge extends React.Component {
 
-  static backgroundClasses = 'fv-layout fv-layout-a'
+  static backgroundClasses = 'fv-layout fv-layout-a';
 
   state = {
     hatchStarted: false

--- a/src/code/utilities/lang/en-us.js
+++ b/src/code/utilities/lang/en-us.js
@@ -59,6 +59,7 @@ export default {
 
   "~COUNTER.TRIAL_LABEL": "TRIAL",
   "~COUNTER.SCORE_LABEL": "SCORE",
+  "~COUNTER.MOVES_LABEL": "TARGET MOVES",
   "~COUNTER.n_OF_N": "${0}\xA0\xA0of\xA0\xA0${1}",
 
   // Messages from ITS

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -425,6 +425,7 @@
           "alleles": "m-m, w-w, B-B",
         }
       ],
+      "goalMoves": [1, 1, 1],
       "hiddenAlleles": "A2",
       "linkedGenes": {
         "drakes": [0, 1, 2],
@@ -464,13 +465,13 @@
           "sex": 1
         },
         {
-          "alleles": "M-M, w-w, B-B, H-H, a-a, C-C, T-T, fl-fl, Hl-Hl, D-D, rh-rh, Bog-Bog",
+          "alleles": "M-M, w-w, B-B, H-H, A1-a, C-C, T-T, fl-fl, Hl-Hl, D-D, rh-rh, Bog-Bog",
           "sex": 1
         }
       ],
       "father": [
         {
-          "alleles": "m-M, W-w, b-b, h-h, a-a, C-C, T-T, fl-fl, Hl-Hl, D-D, rh-rh, Bog-Bog",
+          "alleles": "m-M, W-w, b-b, h-h, A1-a, C-C, T-T, fl-fl, Hl-Hl, D-D, rh-rh, Bog-Bog",
           "sex": 0
         },
         {
@@ -478,13 +479,13 @@
           "sex": 0
         },
         {
-          "alleles": "M-M, w-w, b-B, H-H, a-a, c-C, T-T, fl-fl, Hl-Hl, D-D, rh-rh, Bog-Bog",
+          "alleles": "M-M, w-w, b-B, H-h, A1-a, c-C, T-T, fl-fl, Hl-Hl, D-D, rh-rh, Bog-Bog",
           "sex": 0
         }
       ],
       "targetDrakes": [
         {
-          "alleles": "m-m, w-w, B-B, H-H, A1-a, c-c",
+          "alleles": "m-m, w-w, B-B, H-H, A1-A1, c-c",
         },
         {
           "alleles": "m-m, w-w, B-B, H-H, a-a, C-c",
@@ -493,6 +494,7 @@
           "alleles": "m-m, W-W, b-b, h-h, A1-A1, c-c",
         }
       ],
+      "goalMoves": [6, 6, 6],
       "hiddenAlleles": "A2",
       "linkedGenes": {
         "drakes": [0, 1, 2],

--- a/src/stylus/fablevision/bottom-hud.styl
+++ b/src/stylus/fablevision/bottom-hud.styl
@@ -18,6 +18,13 @@
     position: absolute
     left: 1560px
     top: 38px
+  .geniblocks.moves-count
+    position: absolute
+    left: 1565px
+    top: 38px
+    width: 200px
+    .hud-text-area
+      width: 158px
 
 .next-trial-button
   position: absolute


### PR DESCRIPTION
Hi @sfentress! This is a smaller PR to add a moves counter to Genome Challenge and Clutch Breeding levels. Now, the number of `goalMoves` can be calculated on a per-template basis, or through the authoring document. 

Based on future discussions about randomness, we might need logic to dynamically compute minimum moves for complex situations, but I figured this was simplest for now. Let me know what you think!