### PR TITLE
Gulp fails loudly

### DIFF
--- a/gulp/tasks/geniblocks-js-task.js
+++ b/gulp/tasks/geniblocks-js-task.js
@@ -14,6 +14,7 @@ var errorHandler = function (error) {
   console.log(error.toString());
   beep();
   this.emit('end');
+  process.exit(1);
 };
 
 // build stand-alone geniverse application, which pulls in

--- a/src/code/app.js
+++ b/src/code/app.js
@@ -1,6 +1,6 @@
 import 'babel-polyfill';
 
-import React from 'react';
+import React from 'doesnt-exist';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 import { createStore, applyMiddleware } from 'redux';

--- a/src/code/app.js
+++ b/src/code/app.js
@@ -1,6 +1,6 @@
 import 'babel-polyfill';
 
-import React from 'doesnt-exist';
+import React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 import { createStore, applyMiddleware } from 'redux';


### PR DESCRIPTION
This makes Travis not deploy branches if `geniverse.js` fails to build.

This can be seen in the failing Travis build here

https://travis-ci.org/concord-consortium/geniblocks/builds/244612757

and the successful Travis build here

https://travis-ci.org/concord-consortium/geniblocks/builds/244618535