### PR TITLE
Firebase State Saving

### DIFF
--- a/src/code/action-types.js
+++ b/src/code/action-types.js
@@ -26,7 +26,8 @@ const actionTypes = {
   NOTIFICATION_SHOWN: "Notification shown",
   ADVANCED_TRIAL: "Advanced to next trial",
   TOGGLE_MAP: "Map toggled",
-  ENTERED_CHALLENGE_FROM_ROOM: "Entered challenge from room"
+  ENTERED_CHALLENGE_FROM_ROOM: "Entered challenge from room",
+  LOAD_SAVED_STATE: "Loaded saved state"
 };
 
 export default actionTypes;

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -26,15 +26,18 @@ export function startSession(uuid) {
     dispatch(_startSession(uuid));
 
     // Attempt to load saved state from firebase
-    let db = firebase.database(),
-        ref = db.ref(getReturnUrlId());
+    if (typeof firebase !== "undefined") {
+      let db = firebase.database(), //eslint-disable-line
+          ref = db.ref(getReturnUrlId());
 
-    ref.once("value", function(data) {
-      dispatch({
-        type: actionTypes.LOAD_SAVED_STATE,
-        gems: data.val()
+      ref.once("value", function(data) {
+        dispatch({
+          type: actionTypes.LOAD_SAVED_STATE,
+          gems: data.val()
+        });
       });
-    });
+    }
+    
   };
 }
 

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -2,7 +2,7 @@ import actionTypes from './action-types';
 import { ITS_ACTORS, ITS_ACTIONS, ITS_TARGETS } from './its-constants';
 import GeneticsUtils from './utilities/genetics-utils';
 import AuthoringUtils from './utilities/authoring-utils';
-import { authoringVersionNumber, getUserQueryString } from './middleware/state-save';
+import { getUserQueryString } from './middleware/state-save';
 
 export { actionTypes };
 
@@ -36,7 +36,7 @@ export function startSession(uuid) {
         ref.once("value", function(data) {
           dispatch({
             type: actionTypes.LOAD_SAVED_STATE,
-            gems: data.val()
+            gems: data.val().gems
           });
         });
       }

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -22,27 +22,16 @@ function _startSession(uuid) {
 }
 
 export function startSession(uuid) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(_startSession(uuid));
 
     if (typeof firebase !== "undefined") {
-      // Store the authoring, if it is not already present
-      let db = firebase.database(), //eslint-disable-line
-          authoringRef = db.ref(authoringVersionNumber + "/authoring");
-
-        authoringRef.once("value", function(storedAuthoring) {
-          if (!storedAuthoring.val()) {
-            let authoringUpdate = { authoring: getState().authoring };
-
-            firebase.database().ref(authoringVersionNumber).update(authoringUpdate); //eslint-disable-line
-          }
-        });
-
       // Attempt to load saved state from firebase
       let userQueryString = getUserQueryString();
 
       if (userQueryString) {
-        const ref = db.ref(userQueryString + "/state");
+        const db = firebase.database(), //eslint-disable-line
+              ref = db.ref(userQueryString + "/state");
 
         ref.once("value", function(data) {
           dispatch({

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -2,10 +2,11 @@ import actionTypes from './action-types';
 import { ITS_ACTORS, ITS_ACTIONS, ITS_TARGETS } from './its-constants';
 import GeneticsUtils from './utilities/genetics-utils';
 import AuthoringUtils from './utilities/authoring-utils';
+import { getReturnUrlId } from './utilities/url-params';
 
 export { actionTypes };
 
-export function startSession(uuid) {
+function _startSession(uuid) {
   return {
     type: actionTypes.SESSION_STARTED,
     session: uuid,
@@ -17,6 +18,23 @@ export function startSession(uuid) {
         target: ITS_TARGETS.SESSION
       }
     }
+  };
+}
+
+export function startSession(uuid) {
+  return (dispatch) => {
+    dispatch(_startSession(uuid));
+
+    // Attempt to load saved state from firebase
+    let db = firebase.database(),
+        ref = db.ref(getReturnUrlId());
+
+    ref.once("value", function(data) {
+      dispatch({
+        type: actionTypes.LOAD_SAVED_STATE,
+        gems: data.val()
+      });
+    });
   };
 }
 

--- a/src/code/app.js
+++ b/src/code/app.js
@@ -19,6 +19,7 @@ import ChallengeContainerSelector from "./containers/challenge-container-selecto
 import loggerMiddleware from './middleware/gv-log';
 import itsMiddleware, { initializeITSSocket } from './middleware/its-log';
 import routerMiddleware from './middleware/router-history';
+import stateSaveMiddleware from './middleware/state-save';
 import soundsMiddleware from 'redux-sounds';
 import thunk from 'redux-thunk';
 
@@ -59,6 +60,7 @@ const createStoreWithMiddleware =
     loggerMiddleware(loggingMetadata),
     itsMiddleware(loggingMetadata),
     routerMiddleware(hashHistory),
+    stateSaveMiddleware(),
     loadedSoundsMiddleware
   )(createStore);
 

--- a/src/code/middleware/state-save.js
+++ b/src/code/middleware/state-save.js
@@ -1,4 +1,4 @@
-import { getClassId, getUserId } from '../utilities/url-params';
+import urlParams from '../utilities/url-params';
 
 export const authoringVersionNumber = 1;
 
@@ -29,4 +29,17 @@ export function getUserQueryString() {
         userId = getUserId();
 
   return (classId && userId) ? authoringVersionNumber + "/userState/" + classId + "/" + userId : null;
+}
+
+function getClassId() {
+  return convertUrlToFirebaseKey(urlParams.class_info_url);
+}
+
+function getUserId() {
+  return convertUrlToFirebaseKey(urlParams.domain) + urlParams.domain_uid;
+}
+
+function convertUrlToFirebaseKey(url) {
+  // Convert invalid Firebase characters (inluding periods) to their ASCII equivalents
+  return encodeURIComponent(url).replace(/\./g, "%2E");
 }

--- a/src/code/middleware/state-save.js
+++ b/src/code/middleware/state-save.js
@@ -1,17 +1,29 @@
 import actionTypes from '../action-types';
-import { getReturnUrlId } from '../utilities/url-params';
+import { getClassId, getUserId } from '../utilities/url-params';
+
+export const authoringVersionNumber = 1;
 
 export default () => store => next => action => {
-  let result = next(action),
-      nextState = store.getState();
+  let result = next(action);
 
   if (action.type === actionTypes.CHALLENGE_COMPLETED) {
-      let gems = nextState.gems, 
-          update = {};
+      let userQueryString = getUserQueryString();
 
-      update[getReturnUrlId()] = gems;
-      firebase.database().ref().update(update); //eslint-disable-line
+      if (userQueryString) {
+        let nextState = store.getState(),
+            gems = nextState.gems,
+            stateUpdate = {state: gems};
+          
+        firebase.database().ref(userQueryString).update(stateUpdate); //eslint-disable-line
+      }
     }
 
   return result;
 };
+
+export function getUserQueryString() {
+  const classId = getClassId(),
+        userId = getUserId();
+
+  return (classId && userId) ? authoringVersionNumber + "/userState/" + classId + "/" + userId : null;
+}

--- a/src/code/middleware/state-save.js
+++ b/src/code/middleware/state-save.js
@@ -1,0 +1,17 @@
+import actionTypes from '../action-types';
+import { getReturnUrlId } from '../utilities/url-params';
+
+export default () => store => next => action => {
+  let result = next(action),
+      nextState = store.getState();
+
+  if (action.type === actionTypes.CHALLENGE_COMPLETED) {
+      let gems = nextState.gems, 
+          update = {};
+
+      update[getReturnUrlId()] = gems;
+      firebase.database().ref().update(update);
+    }
+
+  return result;
+};

--- a/src/code/middleware/state-save.js
+++ b/src/code/middleware/state-save.js
@@ -15,7 +15,7 @@ export default () => store => next => action => {
 
       if (userQueryString) {
         let gems = nextState.gems,
-            stateUpdate = {state: gems, stateVersion: stateVersionNumber};
+            stateUpdate = {state: {gems}, stateVersion: stateVersionNumber};
           
         firebase.database().ref(userQueryString).update(stateUpdate); //eslint-disable-line
       }

--- a/src/code/middleware/state-save.js
+++ b/src/code/middleware/state-save.js
@@ -1,18 +1,21 @@
-import actionTypes from '../action-types';
 import { getClassId, getUserId } from '../utilities/url-params';
 
 export const authoringVersionNumber = 1;
 
-export default () => store => next => action => {
-  let result = next(action);
+const stateVersionNumber = 1;
 
-  if (action.type === actionTypes.CHALLENGE_COMPLETED) {
+export default () => store => next => action => {
+  let prevState = store.getState(),
+      result = next(action),
+      nextState = store.getState();
+
+  // Store updated gems if they have changed
+  if (JSON.stringify(prevState.gems) !== JSON.stringify(nextState.gems)) {
       let userQueryString = getUserQueryString();
 
       if (userQueryString) {
-        let nextState = store.getState(),
-            gems = nextState.gems,
-            stateUpdate = {state: gems};
+        let gems = nextState.gems,
+            stateUpdate = {state: gems, stateVersion: stateVersionNumber};
           
         firebase.database().ref(userQueryString).update(stateUpdate); //eslint-disable-line
       }

--- a/src/code/middleware/state-save.js
+++ b/src/code/middleware/state-save.js
@@ -10,7 +10,7 @@ export default () => store => next => action => {
           update = {};
 
       update[getReturnUrlId()] = gems;
-      firebase.database().ref().update(update);
+      firebase.database().ref().update(update); //eslint-disable-line
     }
 
   return result;

--- a/src/code/reducers/gems.js
+++ b/src/code/reducers/gems.js
@@ -23,6 +23,13 @@ export default function gems(state = initialState, challengeErrors, routeSpec, a
 
         return state;
       }
+    case actionTypes.LOAD_SAVED_STATE: {
+      if (action.gems && action.gems.length > 0) {
+        return action.gems;
+      } else {
+        return state;
+      }
+    }
     default:
       return state;
   }

--- a/src/code/utilities/url-params.js
+++ b/src/code/utilities/url-params.js
@@ -12,4 +12,12 @@ var urlParams;
        urlParams[decode(match[1])] = decode(match[2]);
 })();
 
+export function getReturnUrlId() {
+  //Extract the UID at the end of the returnUrl
+  let regex = /.*\/(\S+)/g,
+      matches = regex.exec(urlParams.returnUrl);
+
+  return matches[1];
+}
+
 export default urlParams;

--- a/src/code/utilities/url-params.js
+++ b/src/code/utilities/url-params.js
@@ -12,12 +12,16 @@ var urlParams;
        urlParams[decode(match[1])] = decode(match[2]);
 })();
 
-export function getReturnUrlId() {
-  //Extract the UID at the end of the returnUrl
-  let regex = /.*\/(\S+)/g,
-      matches = regex.exec(urlParams.returnUrl);
+export function getClassId() {
+  // Pull the class number out of the class info
+  let regex = /classes\/(\d*)/g,
+      matches = regex.exec(urlParams.class_info_url);
 
-  return matches[1];
+  return matches ? matches[1] : null;
+}
+
+export function getUserId() {
+  return urlParams.domain_uid;
 }
 
 export default urlParams;

--- a/src/code/utilities/url-params.js
+++ b/src/code/utilities/url-params.js
@@ -12,16 +12,4 @@ var urlParams;
        urlParams[decode(match[1])] = decode(match[2]);
 })();
 
-export function getClassId() {
-  // Pull the class number out of the class info
-  let regex = /classes\/(\d*)/g,
-      matches = regex.exec(urlParams.class_info_url);
-
-  return matches ? matches[1] : null;
-}
-
-export function getUserId() {
-  return urlParams.domain_uid;
-}
-
 export default urlParams;

--- a/src/index.html
+++ b/src/index.html
@@ -2,6 +2,19 @@
 <html>
   <head>
     <meta charset="UTF-8" />
+    <script src="https://www.gstatic.com/firebasejs/4.1.3/firebase.js"></script>
+    <script>
+      // Initialize Firebase
+      var config = {
+        apiKey: "AIzaSyCQyZqErr-WsvaZzATcmOgxxv1wcrNQXIo",
+        authDomain: "gvdemo-6f015.firebaseapp.com",
+        databaseURL: "https://gvdemo-6f015.firebaseio.com",
+        projectId: "gvdemo-6f015",
+        storageBucket: "",
+        messagingSenderId: "574673678327"
+      };
+      firebase.initializeApp(config);
+    </script>
     <script>
       var _rollbarConfig = {
           accessToken: "3d51512de4a0457d9d92c8e27aba8bbf",

--- a/test/actions/start-session.js
+++ b/test/actions/start-session.js
@@ -4,9 +4,13 @@ import * as actions from '../../src/code/actions';
 const types = actions.actionTypes;
 
 describe('startSession action', () => {
+  const dispatch = expect.createSpy(),
+        uuid = '123';
+
+  actions.startSession(uuid)(dispatch);
   it('should create an action to start a session', () => {
-    const uuid = '123';
-    expect(actions.startSession(uuid)).toEqual({
+    var startSessionAction = dispatch.calls[0].arguments[0];
+    expect(startSessionAction).toEqual({
       type: types.SESSION_STARTED,
       session: uuid,
       meta: {


### PR DESCRIPTION
I could have sworn I opened a PR for this yesterday, but I must not have pulled the trigger...in any case, here's what I've accomplished for state saving, with the [schema update suggested by Sam](https://gist.github.com/sfentress/b0b83103d2109ec287160511801c96e2). I didn't understand the `stateVersion` piece of the key so I left it out, but it might be worth talking over that more.

We interact with Firebase in two different places: 

1) When a session begins, we check if the user has any stored data. If so, we load it into the state. At this point, we also check if this version of the authoring document is stored in Firebase, and if not, we load it in.

2) When a challenge ends, a new piece of middleware updates the user's state in Firebase.

I'm sure there are more clever ways to have Firebase watch the `gem` state and update automatically, but this seems to get the job done. As for reviewing this PR, the first commit stores data in a flat map, so you may want to skip it, but I left it in for posterity. 