### PR TITLE
Mission Control

### DIFF
--- a/src/code/action-types.js
+++ b/src/code/action-types.js
@@ -3,6 +3,7 @@ const actionTypes = {
   AUTHORING_CHANGED: "Authoring changed",
   LOADED_CHALLENGE_FROM_AUTHORING: "Loaded challenge from authoring",
   NAVIGATED: "Navigated",
+  NAVIGATED_HOME: "Navigated home",
   CHALLENGE_COMPLETED: "Challenge completed",
   CHALLENGE_RETRIED: "Challenge retried",
   BRED: "Bred",

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -128,27 +128,12 @@ export function navigateToNextChallenge() {
         nextChallenge = currentChallenge+1,
         challengeCountInMission = AuthoringUtils.getChallengeCount(authoring, currentLevel, currentMission);
     if (challengeCountInMission <= nextChallenge) {
-      let missionCountInLevel = AuthoringUtils.getMissionCount(authoring, currentLevel);
-      // there are not enough challenges...if the next mission exists, navigate to it
-      if (currentMission + 1 < missionCountInLevel) {
-        nextMission++;
-      } else {
-        let levelCount = AuthoringUtils.getLevelCount(authoring);
-        // otherwise, check if the next level exists
-        if (currentLevel + 1 < levelCount) {
-          nextLevel++;
-        } else {
-          // if no next level exists, loop around
-          nextLevel = 0;
-        }
-        nextMission = 0;
-      }
-      nextChallenge = 0;
+      dispatch(navigateToHome());
 
       if (endMissionUrl) {
         dispatch(navigateToStartPage(endMissionUrl));
-        return;
       }
+      return;
     }
     dispatch(navigateToChallenge({level: nextLevel, mission: nextMission, challenge: nextChallenge}));
   };

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -78,9 +78,10 @@ export function navigateToChallenge(routeSpec) {
   };
 }
 
-export function navigateToHome() {
+export function navigateToHome(showMissionEndDialog=false) {
   return {
-    type: actionTypes.NAVIGATED_HOME
+    type: actionTypes.NAVIGATED_HOME,
+    showMissionEndDialog
   };
 }
 
@@ -128,7 +129,7 @@ export function navigateToNextChallenge() {
         nextChallenge = currentChallenge+1,
         challengeCountInMission = AuthoringUtils.getChallengeCount(authoring, currentLevel, currentMission);
     if (challengeCountInMission <= nextChallenge) {
-      dispatch(navigateToHome());
+      dispatch(navigateToHome(true));
 
       if (endMissionUrl) {
         dispatch(navigateToStartPage(endMissionUrl));

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -120,6 +120,20 @@ function navigateToStartPage(url) {
   };
 }
 
+export function continueFromVictory() {
+  return (dispatch, getState) => {
+    const { routeSpec, authoring, gems } = getState(),
+          currentMission = routeSpec.level + "" + routeSpec.mission,
+          nextMissionSpec = AuthoringUtils.getCurrentMissionFromGems(authoring, gems),
+          nextMission = nextMissionSpec.level + "" + nextMissionSpec.mission;
+    if (currentMission !== nextMission) {
+      dispatch(navigateToHome(true));
+    } else {
+      dispatch(toggleMap(true));
+    }
+  };
+}
+
 export function navigateToNextChallenge() {
   return (dispatch, getState) => {
     const { routeSpec, authoring, endMissionUrl } = getState();
@@ -438,7 +452,7 @@ export function showCompleteChallengeDialog() {
       action: "retryCurrentChallenge"
     },
     rightButton = {
-      action: "navigateToNextChallenge"
+      action: "continueFromVictory"
     };
   return {
     type: actionTypes.MODAL_DIALOG_SHOWN,

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -78,6 +78,12 @@ export function navigateToChallenge(routeSpec) {
   };
 }
 
+export function navigateToHome() {
+  return {
+    type: actionTypes.NAVIGATED_HOME
+  };
+}
+
 function _retryCurrentChallenge() {
   return {
     type: actionTypes.CHALLENGE_RETRIED

--- a/src/code/components/notifications.js
+++ b/src/code/components/notifications.js
@@ -37,7 +37,7 @@ class Notifications extends React.Component {
           character = message.character || this.props.defaultCharacter,
           speaker = <div className={`fv-character ${character}`}></div>,
             // don't show close button if there's more narrative dialog
-          showCloseButton = (message.type && message.type !== "narrative") || !this.props.messages[1],
+          showCloseButton = !!this.props.closeButton && ((message.type && message.type !== "narrative") || !this.props.messages[1]),
           showNextButton = !!this.props.messages[1],
 
           messageView = <div className="notification">

--- a/src/code/components/notifications.js
+++ b/src/code/components/notifications.js
@@ -9,6 +9,7 @@ class Notifications extends React.Component {
   static propTypes = {
     messages: PropTypes.array,
     defaultCharacter: PropTypes.string,
+    closeButton: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
     onCloseButton: PropTypes.func,
     onAdvanceNotifications: PropTypes.func.isRequired,
     onCloseNotifications: PropTypes.func.isRequired

--- a/src/code/containers/challenge-container-selector.js
+++ b/src/code/containers/challenge-container-selector.js
@@ -71,7 +71,7 @@ class ChallengeContainerSelector extends Component {
         navigateToCurrentRoute({level: routeParams.level-1, mission: routeParams.mission-1, challenge: routeParams.challenge-1});
       }
     } else {
-      navigateToChallenge({level: 0, mission: 0, challenge: 0});
+      navigateToHome();
     }
   }
 

--- a/src/code/containers/challenge-container-selector.js
+++ b/src/code/containers/challenge-container-selector.js
@@ -41,6 +41,7 @@ class ChallengeContainerSelector extends Component {
       mission: PropTypes.number,
       challenge: PropTypes.number
     }),
+    currentRoom: PropTypes.string,
     // Potentially updated, incoming route parameters
     routeParams: PropTypes.shape({
       level: PropTypes.string,
@@ -58,7 +59,9 @@ class ChallengeContainerSelector extends Component {
     let routeParams = this.props.routeParams;
     if (routeParams.challengeId) {
       if (routeParams.challengeId === "home") {
-        navigateToHome();
+        if (this.props.currentRoom !== "home") {
+          navigateToHome();
+        }
         return;
       }
       routeParams = AuthoringUtils.challengeIdToRouteParams(authoring, routeParams.challengeId);
@@ -77,7 +80,9 @@ class ChallengeContainerSelector extends Component {
     let { routeParams } = newProps;
     if (routeParams.challengeId) {
       if (routeParams.challengeId === "home") {
-        navigateToHome();
+        if (newProps.currentRoom !== "home") {
+          navigateToHome();
+        }
         return;
       }
       routeParams = AuthoringUtils.challengeIdToRouteParams(authoring, routeParams.challengeId);
@@ -106,7 +111,8 @@ class ChallengeContainerSelector extends Component {
 function mapStateToProps (state) {
   return {
     authoring: state.authoring,
-    currentRouteSpec: state.routeSpec
+    currentRouteSpec: state.routeSpec,
+    currentRoom: state.location && state.location.id
   };
 }
 

--- a/src/code/containers/challenge-container-selector.js
+++ b/src/code/containers/challenge-container-selector.js
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 import { connect } from 'react-redux';
-import { navigateToCurrentRoute, navigateToChallenge, navigateToHome } from '../actions';
+import { navigateToCurrentRoute, navigateToHome } from '../actions';
 import ChallengeContainer from './challenge-container';
 import FVChallengeContainer from './fv-challenge-container';
 import AuthoringUtils from '../utilities/authoring-utils';
@@ -49,12 +49,12 @@ class ChallengeContainerSelector extends Component {
       challenge: PropTypes.string,
       challengeId: PropTypes.string
     }),
-    navigateToChallenge: PropTypes.func,
+    navigateToHome: PropTypes.func,
     navigateToCurrentRoute: PropTypes.func
   }
 
   componentWillMount() {
-    const { navigateToCurrentRoute, navigateToChallenge, navigateToHome, authoring } = this.props;
+    const { navigateToCurrentRoute, navigateToHome, authoring } = this.props;
     // the URL's challengeId is only used for initial routing, so prioritize the numeric route params
     let routeParams = this.props.routeParams;
     if (routeParams.challengeId) {
@@ -118,7 +118,6 @@ function mapStateToProps (state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    navigateToChallenge: (routeSpec) => dispatch(navigateToChallenge(routeSpec)),
     navigateToCurrentRoute: (routeSpec) => dispatch(navigateToCurrentRoute(routeSpec)),
     navigateToHome: () => dispatch(navigateToHome())
   };

--- a/src/code/containers/challenge-container-selector.js
+++ b/src/code/containers/challenge-container-selector.js
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 import { connect } from 'react-redux';
-import { navigateToCurrentRoute, navigateToChallenge } from '../actions';
+import { navigateToCurrentRoute, navigateToChallenge, navigateToHome } from '../actions';
 import ChallengeContainer from './challenge-container';
 import FVChallengeContainer from './fv-challenge-container';
 import AuthoringUtils from '../utilities/authoring-utils';
@@ -53,10 +53,14 @@ class ChallengeContainerSelector extends Component {
   }
 
   componentWillMount() {
-    const { navigateToCurrentRoute, navigateToChallenge, authoring } = this.props;
+    const { navigateToCurrentRoute, navigateToChallenge, navigateToHome, authoring } = this.props;
     // the URL's challengeId is only used for initial routing, so prioritize the numeric route params
     let routeParams = this.props.routeParams;
     if (routeParams.challengeId) {
+      if (routeParams.challengeId === "home") {
+        navigateToHome();
+        return;
+      }
       routeParams = AuthoringUtils.challengeIdToRouteParams(authoring, routeParams.challengeId);
     }
     if (isValidRouteParams(routeParams)) {
@@ -69,9 +73,13 @@ class ChallengeContainerSelector extends Component {
   }
 
   componentWillReceiveProps(newProps) {
-    const { currentRouteSpec, navigateToCurrentRoute, authoring } = newProps;
+    const { currentRouteSpec, navigateToCurrentRoute, navigateToHome, authoring } = newProps;
     let { routeParams } = newProps;
     if (routeParams.challengeId) {
+      if (routeParams.challengeId === "home") {
+        navigateToHome();
+        return;
+      }
       routeParams = AuthoringUtils.challengeIdToRouteParams(authoring, routeParams.challengeId);
     }
     if (hasChangedRouteParams(currentRouteSpec, routeParams)) {
@@ -81,12 +89,14 @@ class ChallengeContainerSelector extends Component {
 
   render() {
     const { authoring, currentRouteSpec, ...otherProps } = this.props;
-    if (!currentRouteSpec) {
-      return null;
+    let ContainerClass;
+    if (currentRouteSpec) {
+      const authoredChallenge = AuthoringUtils.getChallengeDefinition(authoring, currentRouteSpec),
+            containerName = authoredChallenge.container;
+      ContainerClass = mapContainerNameToContainer(containerName);
+    } else {
+      ContainerClass = FVChallengeContainer;
     }
-    const authoredChallenge = AuthoringUtils.getChallengeDefinition(authoring, currentRouteSpec),
-          containerName = authoredChallenge.container,
-          ContainerClass = mapContainerNameToContainer(containerName);
     return (
       <ContainerClass {...otherProps} />
     );
@@ -103,7 +113,8 @@ function mapStateToProps (state) {
 function mapDispatchToProps(dispatch) {
   return {
     navigateToChallenge: (routeSpec) => dispatch(navigateToChallenge(routeSpec)),
-    navigateToCurrentRoute: (routeSpec) => dispatch(navigateToCurrentRoute(routeSpec))
+    navigateToCurrentRoute: (routeSpec) => dispatch(navigateToCurrentRoute(routeSpec)),
+    navigateToHome: () => dispatch(navigateToHome())
   };
 }
 

--- a/src/code/containers/challenge-container.js
+++ b/src/code/containers/challenge-container.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import templates from '../templates';
-import { changeAllele, changeSex, submitDrake, navigateToNextChallenge,
+import { changeAllele, changeSex, submitDrake,
         keepOffspring, fertilize, hatch,
         changeBasketSelection, changeDrakeSelection, submitEggForBasket } from '../actions';
 import { addGameteChromosome, resetGametes,
@@ -60,7 +60,6 @@ function mapDispatchToProps(dispatch) {
       dispatch(changeSex(index, newSex, incrementMoves)),
     onDrakeSubmission: (targetDrakeIndex, userDrakeIndex, correct, incorrectAction, motherIndex, fatherIndex) =>
       dispatch(submitDrake(targetDrakeIndex, userDrakeIndex, correct, incorrectAction, motherIndex, fatherIndex)),
-    onNavigateNextChallenge: () => dispatch(navigateToNextChallenge()),
     onGameteChromosomeAdded: (index, name, side) => dispatch(addGameteChromosome(index, name, side)),
     onAddGametesToPool: (index, gametes) => dispatch(addGametesToPool(index, gametes)),
     onSelectGameteInPool: (sex, index) => dispatch(selectGameteInPool(sex, index)),

--- a/src/code/containers/fv-challenge-container.js
+++ b/src/code/containers/fv-challenge-container.js
@@ -34,7 +34,7 @@ class FVChallengeContainer extends Component {
         <div id="enter-challenge-hotspot" className="hotspot" onClick={ this.props.onEnterChallenge }/>
       );
     } else {
-      const Template = templates[this.props.template];
+      const Template = templates[template];
 
       bgClasses = classNames('mission-backdrop', Template.backgroundClasses,
                               challengeType, interactionType);

--- a/src/code/containers/fv-challenge-container.js
+++ b/src/code/containers/fv-challenge-container.js
@@ -8,7 +8,7 @@ import TopHUDView from '../fv-components/top-hud';
 import NotificationContainer from "./notification-container";
 import ModalMessageContainer from "./modal-message-container";
 
-import { changeAllele, changeSex, submitDrake, navigateToNextChallenge,
+import { changeAllele, changeSex, submitDrake,
         keepOffspring, fertilize, breedClutch, hatch,
         changeBasketSelection, changeDrakeSelection, submitEggForBasket,
         winZoomChallenge, toggleMap, enterChallengeFromRoom } from '../actions';
@@ -128,7 +128,6 @@ function mapDispatchToProps(dispatch) {
       dispatch(changeSex(index, newSex, incrementMoves)),
     onDrakeSubmission: (targetDrakeIndex, userDrakeIndex, correct, incorrectAction, motherIndex, fatherIndex) =>
       dispatch(submitDrake(targetDrakeIndex, userDrakeIndex, correct, incorrectAction, motherIndex, fatherIndex)),
-    onNavigateNextChallenge: () => dispatch(navigateToNextChallenge()),
     onGameteChromosomeAdded: (index, name, side) => dispatch(addGameteChromosome(index, name, side)),
     onAddGametesToPool: (index, gametes) => dispatch(addGametesToPool(index, gametes)),
     onSelectGameteInPool: (sex, index) => dispatch(selectGameteInPool(sex, index)),

--- a/src/code/containers/fv-challenge-container.js
+++ b/src/code/containers/fv-challenge-container.js
@@ -21,10 +21,6 @@ class FVChallengeContainer extends Component {
     const { template, style, location, showingRoom, ...otherProps } = this.props,
           { challengeType, interactionType, routeSpec, trial, numTrials, correct, challenges, showAward } = this.props;
 
-    if (!template) return null;
-
-    const Template = templates[this.props.template];
-
     let bgClasses,
         maxScore,
         goalMoves,
@@ -38,6 +34,8 @@ class FVChallengeContainer extends Component {
         <div id="enter-challenge-hotspot" className="hotspot" onClick={ this.props.onEnterChallenge }/>
       );
     } else {
+      const Template = templates[this.props.template];
+
       bgClasses = classNames('mission-backdrop', Template.backgroundClasses,
                               challengeType, interactionType);
       maxScore = Template.maxScore;

--- a/src/code/fv-components/bottom-hud.js
+++ b/src/code/fv-components/bottom-hud.js
@@ -25,10 +25,28 @@ const BottomHUDView = React.createClass({
     let {routeSpec, trial, trialCount, currScore, maxScore, currMoves, goalMoves, numChallenges, gems} = this.props,
         scoreView = maxScore ? <CountView countTitleText={t('~COUNTER.SCORE_LABEL')} className={'score-count'} currCount={currScore} maxCount={maxScore} /> : null,
         movesView = goalMoves > 0 ? <CountView countTitleText={t('~COUNTER.MOVES_LABEL')} className={'moves-count'} currCount={currMoves} maxCount={goalMoves} /> : null,
-        widgets;
+        showRouteWidgets = routeSpec !== null,
+        routeWidgets, challengeWidgets;
+
+    if (showRouteWidgets) {
+      let missionScreen = (
+        <div className="mission-screen">
+          <div className="mission-label mission-label-text">Mission</div>
+          <div className="mission-label mission-label-value">{routeSpec.mission + 1}</div>
+        </div>
+      );
+
+      routeWidgets = (
+        <div>
+          <LevelIndicatorView level={routeSpec.level + 1} />
+          {missionScreen}
+          <GemSetView level={routeSpec.level} mission={routeSpec.mission} challenge={routeSpec.challenge} challengeCount={numChallenges} gems={gems}/>
+        </div>
+      );
+    }
 
     if (this.props.showChallengeWidgets) {
-      widgets = (
+      challengeWidgets = (
         <div>
           <CountView countTitleText={t('~COUNTER.TRIAL_LABEL')} className={'trial-count'} currCount={trial} maxCount={trialCount} />
           {scoreView}
@@ -37,20 +55,13 @@ const BottomHUDView = React.createClass({
       );
     }
 
-    let missionScreen = (
-      <div className="mission-screen">
-        <div className="mission-label mission-label-text">Mission</div>
-        <div className="mission-label mission-label-value">{routeSpec.mission + 1}</div>
-      </div>
-    );
+
 
     return (
       <div id='fv-bottom-hud' className='fv-hud fv-bottom-hud' >
         <AvatarButtonView />
-        <LevelIndicatorView level={routeSpec.level + 1} />
-        {missionScreen}
-        <GemSetView level={routeSpec.level} mission={routeSpec.mission} challenge={routeSpec.challenge} challengeCount={numChallenges} gems={gems}/>
-        { widgets }
+        { routeWidgets }
+        { challengeWidgets }
       </div>
     );
   }

--- a/src/code/fv-components/navigation-dialog.js
+++ b/src/code/fv-components/navigation-dialog.js
@@ -16,8 +16,14 @@ export default class NavigationDialogView extends React.Component {
 
   constructor(props) {
     super(props);
+    let level = props.routeSpec && props.routeSpec.level;
+
+    if (typeof level !== "number") {
+      level = AuthoringUtils.getCurrentMissionFromGems(props.authoring, props.gems).level;
+    }
+
     this.state = {
-      level: props.routeSpec.level
+      level: level
     };
   }
 
@@ -25,13 +31,14 @@ export default class NavigationDialogView extends React.Component {
     let {gems, onNavigateToChallenge, onHideMap, authoring} = this.props;
 
     let gemSets = [];
+
     for (let mission = 0; mission < AuthoringUtils.getMissionCount(authoring, this.state.level); mission++) {
       gemSets.push(<div id={"gem-label-" + mission} className="gem-set-label">
                      {"Mission " + (this.state.level + 1) + "." + (mission + 1) + ":"}
                    </div>);
-      gemSets.push(<GemSetView level={this.state.level} mission={mission} 
-                               challengeCount={AuthoringUtils.getChallengeCount(authoring, this.state.level, mission)} 
-                               gems={gems} 
+      gemSets.push(<GemSetView level={this.state.level} mission={mission}
+                               challengeCount={AuthoringUtils.getChallengeCount(authoring, this.state.level, mission)}
+                               gems={gems}
                                onNavigateToChallenge={onNavigateToChallenge} />);
     }
 

--- a/src/code/middleware/router-history.js
+++ b/src/code/middleware/router-history.js
@@ -12,6 +12,8 @@ export default function routerMiddleware(history) {
   return () => next => action => {
     if (action.type === actionTypes.NAVIGATED && action.route) {
       history.push(action.route);
+    } else if (action.type === actionTypes.NAVIGATED_HOME) {
+      history.push("home");
     }
 
     return next(action);

--- a/src/code/modules/notifications.js
+++ b/src/code/modules/notifications.js
@@ -1,5 +1,6 @@
 import Immutable from 'seamless-immutable';
 import { GAMETES_RESET } from '../modules/gametes';
+import { LOCATION_CHANGE } from 'react-router-redux';
 import actionTypes from '../action-types';
 import t from '../utilities/translate';
 
@@ -51,6 +52,7 @@ export default function notifications(state = initialState, action) {
     case GUIDE_ALERT_RECEIVED:
     case actionTypes.MODAL_DIALOG_SHOWN:
     case actionTypes.MODAL_DIALOG_DISMISSED:
+    case LOCATION_CHANGE:
       return state;
     // For now, clear all messages every time the user does anything else
     default:

--- a/src/code/reducers/challenge-errors.js
+++ b/src/code/reducers/challenge-errors.js
@@ -14,6 +14,8 @@ export default function challengeErrors(state = initialState, moves, goalMoves, 
   switch(action.type) {
     case actionTypes.NAVIGATED:
       return 0;
+    case actionTypes.EGG_REJECTED:
+      return state + 1;
     default: {
       // for any action that increases moves, increase challengeErrors if we're above
       // goal moves. (Remembering that `moves` has already been set by previous reducers)

--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -216,7 +216,7 @@ export function loadHome(state, authoring, showMissionEndDialog) {
       }
     }
 
-    messages = dialog.map( (d) => ({type: notificationType.DIALOG, ...d}));
+    messages = dialog.map( (d) => ({type: notificationType.NARRATIVE, ...d}));
   }
 
   let authoredState = {

--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -196,7 +196,7 @@ export function loadStateFromAuthoring(state, authoring) {
   return state.merge(authoredState);
 }
 
-export function loadHome(state, authoring) {
+export function loadHome(state, authoring, showMissionEndDialog) {
   let room = "home",
       roomInfo = (authoring && authoring.rooms) ? authoring.rooms[room] : {},
       location = {id: room, ...roomInfo},
@@ -207,6 +207,15 @@ export function loadHome(state, authoring) {
   if (dialogDefs) {
     let whichDialog = started ? "middle" : "start",
         dialog = dialogDefs[whichDialog];
+
+    if (!started && showMissionEndDialog) {
+      let previousMission = AuthoringUtils.getPreviousMission(authoring, level, mission);
+      if (previousMission) {
+        let endDialog = authoring.application.levels[previousMission.level].missions[previousMission.mission].dialog["end"] || [];
+        dialog = endDialog.concat(dialog);
+      }
+    }
+
     messages = dialog.map( (d) => ({type: notificationType.DIALOG, ...d}));
   }
 

--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -152,7 +152,7 @@ export function loadStateFromAuthoring(state, authoring) {
 
   let messages = [],
       closeButton = null;
-  if (dialog) {
+  if (showingRoom && dialog) {
     messages = dialog.map( (d) => ({type: notificationType.NARRATIVE, ...d}));
     closeButton = {action: "enterChallengeFromRoom"};
   }

--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -199,11 +199,18 @@ export function loadStateFromAuthoring(state, authoring) {
 export function loadHome(state, authoring) {
   let room = "home",
       roomInfo = (authoring && authoring.rooms) ? authoring.rooms[room] : {},
-      location = {id: room, ...roomInfo};
+      location = {id: room, ...roomInfo},
+      { level, mission, started } = AuthoringUtils.getCurrentMissionFromGems(authoring, state.gems),
+      dialog = started ? [] : authoring.application.levels[level].missions[mission].dialog,
+      messages = dialog.map( (d) => ({type: notificationType.DIALOG, ...d}));
 
   let authoredState = {
     location,
-    showingRoom: true
+    showingRoom: true,
+    notifications: {
+      messages,
+      closeButton: false
+    }
   };
 
   // remove all undefined or null keys

--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -196,6 +196,22 @@ export function loadStateFromAuthoring(state, authoring) {
   return state.merge(authoredState);
 }
 
+export function loadHome(state, authoring) {
+  let room = "home",
+      roomInfo = (authoring && authoring.rooms) ? authoring.rooms[room] : {},
+      location = {id: room, ...roomInfo};
+
+  let authoredState = {
+    location,
+    showingRoom: true
+  };
+
+  // remove all undefined or null keys
+  Object.keys(authoredState).forEach((key) => (authoredState[key] == null) && delete authoredState[key]);
+
+  return state.merge(authoredState);
+}
+
 export function loadNextTrial(state, authoring) {
   let trial = state.trial;
   if (state.trialSuccess){

--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -201,8 +201,14 @@ export function loadHome(state, authoring) {
       roomInfo = (authoring && authoring.rooms) ? authoring.rooms[room] : {},
       location = {id: room, ...roomInfo},
       { level, mission, started } = AuthoringUtils.getCurrentMissionFromGems(authoring, state.gems),
-      dialog = started ? [] : authoring.application.levels[level].missions[mission].dialog,
-      messages = dialog.map( (d) => ({type: notificationType.DIALOG, ...d}));
+      dialogDefs = authoring.application.levels[level].missions[mission].dialog,
+      messages = [];
+
+  if (dialogDefs) {
+    let whichDialog = started ? "middle" : "start",
+        dialog = dialogDefs[whichDialog];
+    messages = dialog.map( (d) => ({type: notificationType.DIALOG, ...d}));
+  }
 
   let authoredState = {
     location,

--- a/src/code/reducers/index.js
+++ b/src/code/reducers/index.js
@@ -1,6 +1,6 @@
 import Immutable from 'seamless-immutable';
 import actionTypes from '../action-types';
-import { loadStateFromAuthoring, loadNextTrial } from './helpers/load-state-from-authoring';
+import { loadStateFromAuthoring, loadNextTrial, loadHome } from './helpers/load-state-from-authoring';
 import urlParams from '../utilities/url-params';
 
 // reducers
@@ -86,6 +86,12 @@ export default function reducer(state, action) {
         }
       }
       return state;
+    }
+    case actionTypes.NAVIGATED_HOME: {
+      state = state.merge({
+        routeSpec: null
+      });
+      return loadHome(state, state.authoring);
     }
     case actionTypes.NAVIGATED: {
       //TODO: it would be nice to merge this with the "routing" reducer into a module which controls the state's routeSpec

--- a/src/code/reducers/index.js
+++ b/src/code/reducers/index.js
@@ -91,7 +91,7 @@ export default function reducer(state, action) {
       state = state.merge({
         routeSpec: null
       });
-      return loadHome(state, state.authoring);
+      return loadHome(state, state.authoring, action.showMissionEndDialog);
     }
     case actionTypes.NAVIGATED: {
       //TODO: it would be nice to merge this with the "routing" reducer into a module which controls the state's routeSpec

--- a/src/code/reducers/modal-dialog.js
+++ b/src/code/reducers/modal-dialog.js
@@ -25,7 +25,8 @@ export default function modalDialog(state = initialState, action) {
     case actionTypes.TOGGLE_MAP:
       return state.merge({
         show: action.isVisible,
-        showMap: action.isVisible
+        showMap: action.isVisible,
+        showAward: false
       });
     case actionTypes.MODAL_DIALOG_DISMISSED:
       return initialState;

--- a/src/code/utilities/authoring-utils.js
+++ b/src/code/utilities/authoring-utils.js
@@ -57,6 +57,22 @@ export default class AuthoringUtils {
     return routeSpec;
   }
 
+  static getPreviousMission(authoring, level, mission) {
+    if (mission > 0) {
+      return {
+        level,
+        mission: mission - 1
+      };
+    } else if (level > 0) {
+      return {
+        level: level - 1,
+        mission: authoring.application.levels[level - 1].missions.length - 1
+      };
+    } else {
+      return null;
+    }
+  }
+
   /**
    * Returns an object representing the current level+mission the user is on,
    * and whether the user has completed at least one challenge in the mission.

--- a/src/code/utilities/authoring-utils.js
+++ b/src/code/utilities/authoring-utils.js
@@ -56,4 +56,28 @@ export default class AuthoringUtils {
     });
     return routeSpec;
   }
+
+  /**
+   * Returns an object representing the current level+mission the user is on,
+   * and whether the user has completed at least one challenge in the mission.
+   */
+  static getCurrentMissionFromGems(authoring, gems) {
+    for (let i = 0, ii = authoring.application.levels.length; i < ii; i++) {
+      let level = authoring.application.levels[i];
+      for (let j = 0, jj = level.missions.length; j < jj; j++) {
+        let mission = level.missions[j];
+        for (let k = 0, kk = mission.challenges.length; k < kk; k++) {
+          if (gems[i] && gems[i][j] && !isNaN(gems[i][j][k])) {
+            continue;
+          } else {
+            return {
+              level: i,
+              mission: j,
+              started: k > 0
+            };
+          }
+        }
+      }
+    }
+  }
 }

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -1022,6 +1022,28 @@
         "missions": [
           {
             "name": "Mission 1.1",
+            "dialog": [
+              {
+                "character": "HATCH",
+                "text": "Welcome, Cadet, to our underground hideout! I'm Professor Hatch, director of the Drake Breeder's Guild."
+              },
+              {
+                "character": "WEAVER",
+                "text": "And I'm Dr. Weaver, head of Mission Control here in the heart of our subterranean base."
+              },
+              {
+                "character": "HATCH",
+                "text": "Our country -- the Wyvern Republic -- depends on its dragons for defense, but they are under attack from the evil Kingdom of Darkwell, and in danger of going extinct! "
+              },
+              {
+                "character": "WEAVER",
+                "text": "You are training to be part of an elite team of scientists who will help us bring dragons back from the brink! We want to assemble a small dragon squad to stage a behind-enemy-lines strike on the Darkwellians to end the war."
+              },
+              {
+                "character": "HATCH",
+                "text": "Time is running out and we need to train you fast! Come with me to the Sim Room. Click your VenturePad to navigate around the base."
+              }
+            ],
             "challenges": [
               {
                 "name": "Challenge 1.1.1",
@@ -1051,6 +1073,24 @@
         "missions": [
           {
             "name": "Mission 2.1",
+            "dialog": [
+              {
+                "character": "HERRERA",
+                "text": "Attention, Cadet! I’m Colonel de Herrera, commander of the dragon pilots! We’re losing the war against Darkwell, so I will be leading the sneaky mission behind enemy lines!"
+              },
+              {
+                "character": "YEUNG",
+                "text": "Over the course of your service here with us, we will need your help understanding how to breed different types of drakes so that we can develop dragons that help Colonel de Herrera and his squad!"
+              },
+              {
+                "character": "HERRERA",
+                "text": "I hear you’ve been training in the Sim Room and show lots of promise! So let’s go back there and see if you can knock a few out of the park!"
+              },
+              {
+                "character": "YEUNG",
+                "text": "Open your VentureMap and head on over there with us. Quickly! We don’t have much time!"
+              }
+            ],
             "challenges": [
               {
                 "name": "Challenge 2.1.1",

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -1044,6 +1044,20 @@
                   "character": "HATCH",
                   "text": "Time is running out and we need to train you fast! Come with me to the Sim Room. Click your VenturePad to navigate around the base."
                 }
+              ],
+              "end": [
+                {
+                  "character": "HATCH",
+                  "text": "By completing this mission, you’ve earned the right to use one of our most valuable tools: the Chromoscope."
+                },
+                {
+                  "character": "WEAVER",
+                  "text": "The Chromoscope checks and displays chromosome alleles for each drake. It will be invaluable in your future missions!"
+                },
+                {
+                  "character": "HATCH",
+                  "text": "Speaking of which..."
+                }
               ]
             },
             "challenges": [
@@ -1098,6 +1112,32 @@
                 {
                   "character": "YEUNG",
                   "text": "Open your VentureMap and head on over to the Sim Room. Quickly! We don’t have much time!"
+                }
+              ],
+              "end": [
+                {
+                  "character": "HERRERA",
+                  "text": "Cadet, you’ve cleared a major hurdle and shown that you just might be able to help us save the day."
+                },
+                {
+                  "character": "YEUNG",
+                  "text": "Yes, you have mastered a key skill. You now know how to manipulate alleles. Since alleles are different versions of genes, you can now help us select the genes we need to breed the dragons necessary for defeating Darkwell."
+                },
+                {
+                  "character": "HERRERA",
+                  "text": "Well, let’s not celebrate yet. I’m getting word that Darkwellian spies have learned that there’s a new member of our team."
+                },
+                {
+                  "character": "YEUNG",
+                  "text": "That means you, Cadet."
+                },
+                {
+                  "character": "HERRERA",
+                  "text": "Right. And they’re trying to make life even more difficult for us now by stepping up their attacks on our remaining dragons!"
+                },
+                {
+                  "character": "YEUNG",
+                  "text": "Looks like this is going to be, um, down to the wire."
                 }
               ]
             },
@@ -1160,6 +1200,54 @@
           },
           {
             "name": "Mission 2.2",
+            "dialog": {
+              "start": [
+                {
+                  "character": "HERRERA",
+                  "text": "Listen up, Cadet! This is for your ears only! Aboveground, there’s a tunnel to this underground base, hidden in a cute, innocent-looking little cottage."
+                },
+                {
+                  "character": "NETANYA",
+                  "text": "That cottage is home to the Drake Breeders’ Guild. It houses a veterinary clinic and store, which I run. The money made by the store helps pay for the secret work we do down here."
+                },
+                {
+                  "character": "HERRERA",
+                  "text": "The Darkwellians have no idea that the Guild is just a front. The thing is, we suddenly need a lot more drakes than usual…"
+                },
+                {
+                  "character": "NETANYA",
+                  "text": "…And if a ton of drakes start coming and going from the cottage, the Darkwellians will get suspicious. So activate your VentureMap and come help us in the Hatchery."
+                }
+              ],
+              "middle": [
+                {
+                  "character": "NETANYA",
+                  "text": "Activate your VentureMap and come help us in the Hatchery."
+                }
+              ],
+              "end": [
+                {
+                  "character": "HERRERA",
+                  "text": "Oh no! I’m getting reports that Darkwell has found out about the secret messages we send via flying drakes to the Principality of Robinstone!"
+                },
+                {
+                  "character": "NETANYA",
+                  "text": "What? It must be those spies! If only we knew who they were!"
+                },
+                {
+                  "character": "HERRERA",
+                  "text": "Well, it gets even worse. They also know that the Kingdom of Bloomberg was going to grow crops for us. Darkwell is  going to kill two birds with one stone by polluting the skies."
+                },
+                {
+                  "character": "NETANYA",
+                  "text": "Now our drakes won’t be able to fly to Robinstone, and Bloomberg’s crops will  be ruined."
+                },
+                {
+                  "character": "HERRERA",
+                  "text": "Things are pretty grim, Cadet. We already had a couple of strikes against us, and we’re not gonna have many more chances at bat."
+                }
+              ]
+            },
             "challenges": [
               {
                 "name": "Challenge 2.2.1",

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -1,5 +1,8 @@
 {
   "rooms": {
+    "home": {
+      "name": "Mission Control"
+    },
     "simroom": {
       "name": "Sim Room",
       "defaultCharacter": "YEUNG"

--- a/src/resources/authoring/gv2.json
+++ b/src/resources/authoring/gv2.json
@@ -1022,28 +1022,30 @@
         "missions": [
           {
             "name": "Mission 1.1",
-            "dialog": [
-              {
-                "character": "HATCH",
-                "text": "Welcome, Cadet, to our underground hideout! I'm Professor Hatch, director of the Drake Breeder's Guild."
-              },
-              {
-                "character": "WEAVER",
-                "text": "And I'm Dr. Weaver, head of Mission Control here in the heart of our subterranean base."
-              },
-              {
-                "character": "HATCH",
-                "text": "Our country -- the Wyvern Republic -- depends on its dragons for defense, but they are under attack from the evil Kingdom of Darkwell, and in danger of going extinct! "
-              },
-              {
-                "character": "WEAVER",
-                "text": "You are training to be part of an elite team of scientists who will help us bring dragons back from the brink! We want to assemble a small dragon squad to stage a behind-enemy-lines strike on the Darkwellians to end the war."
-              },
-              {
-                "character": "HATCH",
-                "text": "Time is running out and we need to train you fast! Come with me to the Sim Room. Click your VenturePad to navigate around the base."
-              }
-            ],
+            "dialog": {
+              "start": [
+                {
+                  "character": "HATCH",
+                  "text": "Welcome, Cadet, to our underground hideout! I'm Professor Hatch, director of the Drake Breeder's Guild."
+                },
+                {
+                  "character": "WEAVER",
+                  "text": "And I'm Dr. Weaver, head of Mission Control here in the heart of our subterranean base."
+                },
+                {
+                  "character": "HATCH",
+                  "text": "Our country -- the Wyvern Republic -- depends on its dragons for defense, but they are under attack from the evil Kingdom of Darkwell, and in danger of going extinct! "
+                },
+                {
+                  "character": "WEAVER",
+                  "text": "You are training to be part of an elite team of scientists who will help us bring dragons back from the brink! We want to assemble a small dragon squad to stage a behind-enemy-lines strike on the Darkwellians to end the war."
+                },
+                {
+                  "character": "HATCH",
+                  "text": "Time is running out and we need to train you fast! Come with me to the Sim Room. Click your VenturePad to navigate around the base."
+                }
+              ]
+            },
             "challenges": [
               {
                 "name": "Challenge 1.1.1",
@@ -1073,24 +1075,32 @@
         "missions": [
           {
             "name": "Mission 2.1",
-            "dialog": [
-              {
-                "character": "HERRERA",
-                "text": "Attention, Cadet! I’m Colonel de Herrera, commander of the dragon pilots! We’re losing the war against Darkwell, so I will be leading the sneaky mission behind enemy lines!"
-              },
-              {
-                "character": "YEUNG",
-                "text": "Over the course of your service here with us, we will need your help understanding how to breed different types of drakes so that we can develop dragons that help Colonel de Herrera and his squad!"
-              },
-              {
-                "character": "HERRERA",
-                "text": "I hear you’ve been training in the Sim Room and show lots of promise! So let’s go back there and see if you can knock a few out of the park!"
-              },
-              {
-                "character": "YEUNG",
-                "text": "Open your VentureMap and head on over there with us. Quickly! We don’t have much time!"
-              }
-            ],
+            "dialog": {
+              "start": [
+                {
+                  "character": "HERRERA",
+                  "text": "Attention, Cadet! I’m Colonel de Herrera, commander of the dragon pilots! We’re losing the war against Darkwell, so I will be leading the sneaky mission behind enemy lines!"
+                },
+                {
+                  "character": "YEUNG",
+                  "text": "Over the course of your service here with us, we will need your help understanding how to breed different types of drakes so that we can develop dragons that help Colonel de Herrera and his squad!"
+                },
+                {
+                  "character": "HERRERA",
+                  "text": "I hear you’ve been training in the Sim Room and show lots of promise! So let’s go back there and see if you can knock a few out of the park!"
+                },
+                {
+                  "character": "YEUNG",
+                  "text": "Open your VentureMap and head on over there with us. Quickly! We don’t have much time!"
+                }
+              ],
+              "middle": [
+                {
+                  "character": "YEUNG",
+                  "text": "Open your VentureMap and head on over to the Sim Room. Quickly! We don’t have much time!"
+                }
+              ]
+            },
             "challenges": [
               {
                 "name": "Challenge 2.1.1",

--- a/src/stylus/fablevision/rooms.styl
+++ b/src/stylus/fablevision/rooms.styl
@@ -15,7 +15,7 @@
       left: 0
       height: 54%
       width: 100%
-  &.missioncontrol
+  &.home
     background-image: url('../resources/fablevision/rooms/missioncontrol.jpg')
   &.simroom
     background-image: url('../resources/fablevision/rooms/simroom.jpg')

--- a/src/stylus/notifications.styl
+++ b/src/stylus/notifications.styl
@@ -28,6 +28,12 @@
       font-size: 2rem
       color: black
       width: 1030px
+      -webkit-touch-callout: none
+      -webkit-user-select: none
+      -khtml-user-select: none
+      -moz-user-select: none
+      -ms-user-select: none
+      user-select: none
 
     .message-buttons
       padding-right: 112px

--- a/test/actions/egg-accepted.js
+++ b/test/actions/egg-accepted.js
@@ -32,7 +32,7 @@ describe('acceptEggInBasket action', () => {
                                             action: "retryCurrentChallenge"
                                           },
                                           rightButton: {
-                                            action: "navigateToNextChallenge"
+                                            action: "continueFromVictory"
                                           },
                                           showAward: true
                                         };

--- a/test/actions/egg-rejected.js
+++ b/test/actions/egg-rejected.js
@@ -64,7 +64,10 @@ describe('rejectEggFromBasket action', () => {
       const eggDrakeIndex = 0, basketIndex = 0,
             rejectEggAction = { type: types.EGG_REJECTED, eggDrakeIndex, basketIndex },
             nextState = reducer(initialState, rejectEggAction),
-            expectedState = initialState.set("errors", 1)
+            expectedState = initialState.merge({
+                                          errors:1,
+                                          challengeErrors: 1
+                                        })
                                         .setIn(["drakes", 0],
                                               { alleles: "a:T,b:T", sex: 0, basket: -1, isSelected: false });
       expect(nextState).toEqual(expectedState);

--- a/test/actions/egg-rejected.js
+++ b/test/actions/egg-rejected.js
@@ -32,7 +32,7 @@ describe('rejectEggFromBasket action', () => {
                                             action: "retryCurrentChallenge"
                                           },
                                           rightButton: {
-                                            action: "navigateToNextChallenge"
+                                            action: "continueFromVictory"
                                           },
                                           showAward: true
                                         };

--- a/test/actions/submit-drake.js
+++ b/test/actions/submit-drake.js
@@ -102,7 +102,7 @@ describe('submitDrake action', () => {
           action: "retryCurrentChallenge"
         },
         rightButton: {
-          action: "navigateToNextChallenge"
+          action: "continueFromVictory"
         },
         showAward: true
       });


### PR DESCRIPTION
This adds 

1. The Mission Control screen, visible at `/#home`
2. Loading mission control by default if you navigate to `/`
3. Start-mission dialog if you navigate to home and at at the start of a mission, with no challenges solved (counting blank gems as "solving" a mission)
4. Middle-mission dialog if you enter the mission control and you have > 1 gems in the mission (for most users, this will only accessible if they load the game with saved-state, because currently there is no way to navigate to the MC except by editing the url)
5. On the Victory screen, the Continue button will now either open the Navigation if there are more challenges in a mission, or go back to MC if there aren't
6. If they go back to the MC via the Victory screen, they are presented with End-mission dialog before the next missions start-dialog.

Sorry if the PR is a little jumbled. I've tried to make it streamlined, but there are a number of different things in the same PR.