### PR TITLE
Gem is awarded if challenges are completed out of order

### DIFF
--- a/src/code/reducers/gems.js
+++ b/src/code/reducers/gems.js
@@ -21,6 +21,11 @@ export default function gems(state = initialState, challengeErrors, routeSpec, a
             state = state.setIn([currLevel, mission], []);
           }
         }
+        for (let challenge = 0; challenge <= currChallenge; challenge++) {
+          if (isNaN(state[currLevel][currMission][challenge])) {
+            state = state.setIn([currLevel, currMission, challenge], null);
+          }
+        }
 
         let gem = getGemFromChallengeErrors(challengeErrors);
         state = state.setIn([currLevel, currMission, currChallenge], gem);


### PR DESCRIPTION
A previous commit allowed missions to be completed out of order by removing undefined mission arrays, which break Firebase storage. This commit allows challenges to be completed out of order, by setting incomplete challenges to null to allow storage in Firebase.