### PR TITLE
Slow submissions

### DIFF
--- a/src/code/components/clutch-view.js
+++ b/src/code/components/clutch-view.js
@@ -20,15 +20,7 @@ const ClutchView = React.createClass({
   },
 
   getInitialState() {
-    return { page : 0 };
-  },
-
-  handleClick(id, org) {
-    const prefixIndex = id.indexOf(this.props.idPrefix),
-          indexOnPage = Number(id.substr(prefixIndex + this.props.idPrefix.length)),
-          index = ((this.state.page-1) * 8) + indexOnPage;
-
-    if (this.props.onClick) this.props.onClick(index, id, org);
+    return { page : 0, tempDisabled: false };
   },
 
   handlePageBackward() {
@@ -52,13 +44,32 @@ const ClutchView = React.createClass({
   },
 
   render() {
+    const handleClick = (id, org) => {
+      let _this = this;
+      if (!_this.state.tempDisabled) {
+        const prefixIndex = id.indexOf(_this.props.idPrefix),
+              indexOnPage = Number(id.substr(prefixIndex + _this.props.idPrefix.length)),
+              index = ((_this.state.page-1) * 8) + indexOnPage;
+
+        if (_this.props.onClick) {
+          _this.props.onClick(index, id, org);
+        }
+
+        // Disable clicks for a bit to avoid mass submissions
+        _this.setState({tempDisabled: true});
+        setTimeout(function() {
+          _this.setState({tempDisabled: false});
+        }, 2000);
+      }
+    };
+
     let displayStyle = {size: 136, top: -153, marginLeft: -12},
         firstDrake = (this.state.page - 1) * 8,
         pageDrakes = this.props.orgs.slice(firstDrake, firstDrake + 8),
         stableDrakeViews = pageDrakes.map((org, index) => {
           return (
             <div key={index} className="stable-drake-overlay" style={{width: 116}}>
-              <FVEggHatchView organism = {org} id={this.props.idPrefix + index} onClick={this.handleClick} eggStyle={{left: -477, top: -424}} displayStyle={displayStyle}/>
+              <FVEggHatchView organism = {org} id={this.props.idPrefix + index} onClick={handleClick} eggStyle={{left: -477, top: -424}} displayStyle={displayStyle}/>
             </div>
           );
         });

--- a/src/code/fv-components/breed-button.js
+++ b/src/code/fv-components/breed-button.js
@@ -2,22 +2,36 @@ import React, {PropTypes} from 'react';
 import classNames from 'classnames';
 import t from '../utilities/translate';
 
-const BreedButtonView = ({onClick, disabled}) => {
-
-  function handleClick() {
-    onClick();
+export default class BreedButtonView extends React.Component {
+  static propTypes = {
+    onClick: PropTypes.func.isRequired,
+    disabled: PropTypes.bool
   }
 
-  return (
-    <div className={classNames('breed-button', { 'disabled': disabled})} onClick={handleClick}>
-      <div className="button-label breed-button-label unselectable">{ t("~FV_EGG_GAME.BREED_BUTTON") }</div>
-    </div>
-  );
-};
+  constructor(props) {
+    super(props);
+    this.state = {
+      tempDisabled: false
+    };
+  }
 
-BreedButtonView.propTypes = {
-  onClick: PropTypes.func.isRequired,
-  disabled: PropTypes.bool
-};
+  render() {
+    let _this = this;
+    const handleClick = () => {
+      if (!_this.state.tempDisabled) {
+        _this.props.onClick();
+        _this.setState({tempDisabled: true});
+        // Disable the button for a bit to avoid mass breeding
+        setTimeout(function() {
+          _this.setState({tempDisabled: false});
+        }, 500);
+      }
+    };
 
-export default BreedButtonView;
+    return (
+      <div className={classNames('breed-button', { 'disabled': this.props.disabled})} onClick={handleClick}>
+        <div className="button-label breed-button-label unselectable">{ t("~FV_EGG_GAME.BREED_BUTTON") }</div>
+      </div>
+    );
+  }
+}

--- a/src/code/templates/fv-genome-challenge.js
+++ b/src/code/templates/fv-genome-challenge.js
@@ -18,26 +18,40 @@ const userDrakeIndex   = 0,
 /*
  * HatchDrakeButton
  */
-const HatchDrakeButton = ({label, onClick, disabled}) => {
-
-  function handleClick() {
-    onClick();
+class HatchDrakeButton extends React.Component {
+  static propTypes = {
+    label: PropTypes.string.isRequired,
+    onClick: PropTypes.func.isRequired,
   }
 
-  return (
-    <div className={classNames('hatch-drake-button', {disabled})} onClick={handleClick}>
-      <div className="button-label hatch-drake-button-label unselectable">
-        {label}
-      </div>
-    </div>
-  );
-};
+  constructor(props) {
+    super(props);
+    this.state = {
+      disabled: false
+    };
+  }
 
-HatchDrakeButton.propTypes = {
-  label: PropTypes.string.isRequired,
-  onClick: PropTypes.func.isRequired,
-  disabled: PropTypes.bool
-};
+  render() {
+    let _this = this;
+    const handleClick = () => {
+      if (!_this.state.disabled) {
+        _this.props.onClick();
+        _this.setState({disabled: true});
+        setTimeout(function() {
+          _this.setState({disabled: false});
+        }, 1000);
+      }
+    };
+
+    return (
+      <div className={classNames('hatch-drake-button', {disabled: _this.state.disabled})} onClick={handleClick}>
+        <div className="button-label hatch-drake-button-label unselectable">
+          {_this.props.label}
+        </div>
+      </div>
+    );
+  }
+}
 
 /*
  * YourDrakeView

--- a/src/code/templates/fv-genome-challenge.js
+++ b/src/code/templates/fv-genome-challenge.js
@@ -37,6 +37,7 @@ class HatchDrakeButton extends React.Component {
       if (!_this.state.disabled) {
         _this.props.onClick();
         _this.setState({disabled: true});
+        // Disable the button for a second to avoid mass submissions
         setTimeout(function() {
           _this.setState({disabled: false});
         }, 1000);


### PR DESCRIPTION
There were a few places where you could repeatedly submit drakes, overwhelm the ITS feedback, and get all the messages to concat into a dialog that scrolled off the screen. This PR adds short timeouts that disable submissions. Perhaps it would be worth putting this into some kind of HOC in the future