### PR TITLE
Save a timestamp of the last action to firebase

### DIFF
--- a/src/code/middleware/state-save.js
+++ b/src/code/middleware/state-save.js
@@ -3,16 +3,20 @@
 /**
  Our current user state:
 
- {
-   state: < saveable state (i.e. gems) >,
-   stateVersion: 1,
-   stateMeta: { lastActionTime: t },
-   itsData: < set by ITS >
- }
+  {
+    state: < saveable state (i.e. gems) >,
+    stateVersion: 1,
+    stateMeta: {
+      lastActionTime: t
+      currentChallenge: {l, m, c}
+    },
+    itsData: < set by ITS >
+  }
  */
 
 import urlParams from '../utilities/url-params';
 import actionTypes from '../action-types';
+import progressUtils from '../utilities/progress-utils';
 
 export const authoringVersionNumber = 1;
 
@@ -28,7 +32,11 @@ export default () => store => next => action => {
   // and update savable state (gems) if they have changed
   if (userQueryString) {
     let time = firebase.database.ServerValue.TIMESTAMP,
-        stateMeta = {lastActionTime: time},
+        currentChallenge = getCurrentChallenge(nextState),
+        stateMeta = {
+          lastActionTime: time,
+          currentChallenge
+        },
         userDataUpdate = {stateMeta: stateMeta};
 
     // Store updated gems if they have changed
@@ -42,6 +50,21 @@ export default () => store => next => action => {
   }
 
   return result;
+};
+
+const getCurrentChallenge = function(nextState) {
+  const {routeSpec, authoring, gems} = nextState;
+  if (!authoring) {
+    return null;
+  } else if (routeSpec && routeSpec.level !== undefined) {
+    return {
+      level: routeSpec.level,
+      mission: routeSpec.mission,
+      challenge: routeSpec.challenge
+    };
+  } else {
+    return progressUtils.getCurrentChallengeFromGems(authoring, gems);
+  }
 };
 
 export function getUserQueryString() {

--- a/src/code/middleware/state-save.js
+++ b/src/code/middleware/state-save.js
@@ -27,8 +27,8 @@ export default () => store => next => action => {
   // If we have a FB query string, update timestamp on every action,
   // and update savable state (gems) if they have changed
   if (userQueryString) {
-    let timeInSec = Math.floor(Date.now() / 1000),
-        stateMeta = {lastActionTime: timeInSec},
+    let time = firebase.database.ServerValue.TIMESTAMP,
+        stateMeta = {lastActionTime: time},
         userDataUpdate = {stateMeta: stateMeta};
 
     // Store updated gems if they have changed


### PR DESCRIPTION
Every action the user takes will now save a timestamp to Firebase, in
a new property `stateMeta`, designed to hold the data that does not make
up a user's loadable state.

This data will allow the Dashboard to show what users are currently
active.

@ekosmin could you please take a look at this when you get a chance?