### PR TITLE
Save past gems

### DIFF
--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -7,6 +7,7 @@ import ProgressUtils from './utilities/progress-utils';
 import { getUserQueryString } from './middleware/state-save';
 import { notificationType } from './modules/notifications';
 import { getGemFromChallengeErrors } from './reducers/helpers/gems-helper';
+import migrate from './migrations';
 
 export { actionTypes };
 
@@ -38,14 +39,15 @@ export function startSession(uuid) {
               ref = db.ref(userQueryString);
 
         ref.once("value", function(data) {
-          let loadedState = data.val();
-          if (loadedState) {
+          let loadedState = data.val(),
+              migratedState = migrate(loadedState);
+          if (migratedState) {
             dispatch({
               type: actionTypes.LOAD_SAVED_STATE,
-              gems: loadedState.gems
+              state: migratedState
             });
           }
-          
+
           const { location, routeSpec } = getState();
           if (location && location.id === "home") {
             dispatch(navigateToHome());
@@ -498,7 +500,7 @@ export function showNextTrialButton() {
 
 export function showNotification({message, closeButton}) {
   return showNotifications({
-    messages: [{text: message}], 
+    messages: [{text: message}],
     closeButton
   });
 }

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -1,3 +1,4 @@
+/* global firebase*/
 import actionTypes from './action-types';
 import { ITS_ACTORS, ITS_ACTIONS, ITS_TARGETS } from './its-constants';
 import GeneticsUtils from './utilities/genetics-utils';
@@ -33,8 +34,8 @@ export function startSession(uuid) {
       let userQueryString = getUserQueryString();
 
       if (userQueryString) {
-        const db = firebase.database(), //eslint-disable-line
-              ref = db.ref(userQueryString + "/state");
+        const db = firebase.database(),
+              ref = db.ref(userQueryString);
 
         ref.once("value", function(data) {
           let loadedState = data.val();

--- a/src/code/middleware/state-save.js
+++ b/src/code/middleware/state-save.js
@@ -5,7 +5,7 @@
 
   {
     state: < saveable state (i.e. gems) >,
-    stateVersion: 1,
+    stateVersion: n,
     stateMeta: {
       lastActionTime: t
       currentChallenge: {l, m, c}
@@ -43,8 +43,10 @@ export default () => store => next => action => {
     if (action.type !== actionTypes.LOAD_SAVED_STATE &&
           JSON.stringify(prevState.gems) !== JSON.stringify(nextState.gems)) {
       let gems = nextState.gems;
-      userDataUpdate.state = {gems};
-      userDataUpdate.stateVersion = stateVersionNumber;
+      userDataUpdate.state = {
+        gems,
+        stateVersion: stateVersionNumber
+      };
     }
     firebase.database().ref(userQueryString).update(userDataUpdate);
   }
@@ -71,7 +73,7 @@ export function getUserQueryString() {
   const classId = getClassId(),
         userId = getUserId();
 
-  return (classId && userId) ? authoringVersionNumber + "/userState/" + classId + "/" + userId : null;
+  return (classId && userId) ? authoringVersionNumber + "/userState/" + classId + "/" + userId + "/state" : null;
 }
 
 function getClassId() {

--- a/src/code/middleware/state-save.js
+++ b/src/code/middleware/state-save.js
@@ -17,10 +17,9 @@
 import urlParams from '../utilities/url-params';
 import actionTypes from '../action-types';
 import progressUtils from '../utilities/progress-utils';
+import { currentStateVersion } from '../migrations';
 
 export const authoringVersionNumber = 1;
-
-const stateVersionNumber = 1;
 const userQueryString = getUserQueryString();
 
 export default () => store => next => action => {
@@ -45,7 +44,7 @@ export default () => store => next => action => {
       let gems = nextState.gems;
       userDataUpdate.state = {
         gems,
-        stateVersion: stateVersionNumber
+        stateVersion: currentStateVersion
       };
     }
     firebase.database().ref(userQueryString).update(userDataUpdate);

--- a/src/code/migrations/02_convert_gems_to_array.js
+++ b/src/code/migrations/02_convert_gems_to_array.js
@@ -1,0 +1,26 @@
+const version = 2;
+
+export default function update(state) {
+  if (state.stateVersion < version) {
+    state.stateVersion = version;
+    return doUpdate(state);
+  }
+  return state;
+}
+
+// Previously: each mission had one number representing the last gem awarded.
+// Now: each mission has an array of all gems awarded for that mission.
+function doUpdate(state) {
+  if (state.gems) {
+    state.gems.forEach((level, i) => {
+      level.forEach((mission, j) => {
+        mission.forEach((gem, k) => {
+          if (!isNaN(gem)) {
+            state.gems[i][j][k] = [gem];
+          }
+        });
+      });
+    });
+  }
+  return state;
+}

--- a/src/code/migrations/index.js
+++ b/src/code/migrations/index.js
@@ -1,0 +1,23 @@
+import v02 from './02_convert_gems_to_array';
+
+const migrations = [
+  v02
+];
+
+export const currentStateVersion = 2;
+
+export default function migrate(state){
+  if (!state) {
+    return;
+  }
+
+  if (!state.stateVersion) {
+    // previously we were not saving stateVersion in the state itself,
+    // so those versions count as v 1.
+    state.stateVersion = 1;
+  }
+  migrations.forEach((update) => {
+    state = update(state);
+  });
+  return state;
+}

--- a/src/code/reducers/gems.js
+++ b/src/code/reducers/gems.js
@@ -8,8 +8,7 @@ const initialState = [];
  */
 export default function gems(state = initialState, challengeErrors, routeSpec, action) {
   switch(action.type) {
-    case actionTypes.CHALLENGE_COMPLETED:
-    case actionTypes.CHALLENGE_RETRIED: {
+    case actionTypes.CHALLENGE_COMPLETED: {
         let { level: currLevel, mission: currMission, challenge: currChallenge } = routeSpec;
         //XXX: Ultra-hack to make sure there are no undefined levels
         for (let level = 0; level <= 10; level++) {
@@ -21,15 +20,17 @@ export default function gems(state = initialState, challengeErrors, routeSpec, a
               state = state.setIn([level, mission], []);
             }
             for (let challenge = 0; challenge <= 10; challenge++) {
-              if (isNaN(state[level][mission][challenge])) {
-                state = state.setIn([level, mission, challenge], null);
+              if (!(state[level][mission][challenge])) {
+                state = state.setIn([level, mission, challenge], []);
               }
             }
           }
         }
-        
-        let gem = getGemFromChallengeErrors(challengeErrors);
-        state = state.setIn([currLevel, currMission, currChallenge], gem);
+
+        let gem = getGemFromChallengeErrors(challengeErrors),
+            gemArray = state[currLevel][currMission][currChallenge].concat(gem);
+
+        state = state.setIn([currLevel, currMission, currChallenge], gemArray);
 
         return state;
       }

--- a/src/code/reducers/gems.js
+++ b/src/code/reducers/gems.js
@@ -35,8 +35,8 @@ export default function gems(state = initialState, challengeErrors, routeSpec, a
         return state;
       }
     case actionTypes.LOAD_SAVED_STATE: {
-      if (action.gems && action.gems.length > 0) {
-        return action.gems;
+      if (action.state && action.state.gems) {
+        return action.state.gems;
       } else {
         return state;
       }

--- a/src/code/reducers/helpers/gems-helper.js
+++ b/src/code/reducers/helpers/gems-helper.js
@@ -21,7 +21,8 @@ export function getGemFromChallengeErrors(challengeErrors){
 
 export function getChallengeGem(level, mission, challenge, gems) {
   if (gems[level] && gems[level][mission] && gems[level][mission][challenge] != null) {
-    return gems[level][mission][challenge];
+    let gemArray = gems[level][mission][challenge];
+    return gemArray[gemArray.length-1];     // return last gem
   } else {
     return scoreValues.UNATTEMPTED;
   }
@@ -33,4 +34,8 @@ export function getMissionGems(level, mission, challengeCount, gems) {
     challengeScore.push(getChallengeGem(level, mission, i, gems));
   }
   return challengeScore;
+}
+
+export function isPassingGem(score) {
+  return score <= scoreValues.BRONZE;
 }

--- a/src/code/utilities/progress-utils.js
+++ b/src/code/utilities/progress-utils.js
@@ -1,11 +1,11 @@
-import { scoreValues } from '../reducers/helpers/gems-helper';
+import { getChallengeGem, isPassingGem } from '../reducers/helpers/gems-helper';
 
 export default class AuthoringUtils {
 
   /**
    * Returns an object representing the current level, mission and challenge the user is on,
-   * by returning the route spec first unattempted or failed challenge. If all challenges are complete, 
-   * returns the last challenge instead. Optionally, accepts a level number, to find the 
+   * by returning the route spec first unattempted or failed challenge. If all challenges are complete,
+   * returns the last challenge instead. Optionally, accepts a level number, to find the
    * current challenge on the given level instead.
    */
   static getCurrentChallengeFromGems(authoring, gems, levelNum) {
@@ -17,7 +17,7 @@ export default class AuthoringUtils {
       for (let j = 0, jj = level.missions.length; j < jj; j++) {
         let mission = level.missions[j];
         for (let k = 0, kk = mission.challenges.length; k < kk; k++) {
-          if (gems[i] && gems[i][j] && gems[i][j][k] != null && gems[i][j][k] !== scoreValues.NONE) {
+          if (isPassingGem(getChallengeGem(i, j, k, gems))) {
             continue;
           } else {
             return {
@@ -49,7 +49,8 @@ export default class AuthoringUtils {
         started = false;
     if (missionGems) {
       for (let i = 0; i < missionGems.length; i++) {
-        if (missionGems[i] != null) {
+        // we just care if there are any attempts, even failing ones
+        if (missionGems[i] && missionGems[i].length > 0) {
           started = true;
         }
       }
@@ -63,7 +64,7 @@ export default class AuthoringUtils {
   static isMissionLocked(gems, authoring, level, mission) {
     let currChallengeRoute = this.getCurrentChallengeFromGems(authoring, gems);
 
-    return level > currChallengeRoute.level 
+    return level > currChallengeRoute.level
         || (level === currChallengeRoute.level && mission > currChallengeRoute.mission);
   }
 

--- a/test/migrations/migrations.js
+++ b/test/migrations/migrations.js
@@ -1,0 +1,16 @@
+import expect from 'expect';
+import migrate from '../../src/code/migrations';
+
+describe("migrations", () => {
+  it("should set version number to most recent", () => {
+    let state = {gems: []},
+        nextState = migrate(state);
+    expect(nextState.stateVersion).toEqual(2);
+  });
+
+  it("should migrate gems to version 2", () => {
+    let state = {gems: [[[0]],[[1,2],[0,0]]]},
+        nextState = migrate(state);
+    expect(nextState.gems).toEqual([[[[0]]],[[[1],[2]],[[0],[0]]]]);
+  });
+});


### PR DESCRIPTION
This updates the `gems` state to contain arrays of gems for each challenge, instead of a single gem. This means that instead of just keeping the last earned gem, we can keep the gem history for each challenge. This allows us to display this history in the dashboard.

Since we are saving `gems` to Firebase, we need to add a migration for all users that have already saved gems, or those users will revert back to the begining.

In adding a migration, it seemed to simplify things to add `stateVersion` to the `state` object itself. That allows us to make a single request to FB to get our data, with the version.

The combination of this and #174 will make our Firebase user data into:

```
{
  state: {
    < saveable state (gems) >,
    stateVersion: 2
  },
  stateMeta: { 
    lastActionTime: t 
  },
  itsData: < set by ITS >
}
```

@ekosmin Could you take a look at this? If it looks good, I'll rebase it on top of #174.