### PR TITLE
Remove gating temporarily

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "examples": "live-server public --open=examples",
     "gv2": "live-server public --open=gv2",
     "pretest": "npm run lint",
+    "start": "gulp",
     "test": "mocha --compilers js:babel-core/register --recursive --require ./test/setup.js",
     "test:watch": "npm run test -- --watch"
   }

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ use the GeniBlocks library this way.
 
     npm install           # or 'yarn'
     bower install
-    gulp                  # or its alias 'npm run build:watch'
+    npm start             # or 'gulp'
 
 or to build without watching:
 

--- a/src/code/reducers/helpers/gems-helper.js
+++ b/src/code/reducers/helpers/gems-helper.js
@@ -36,6 +36,9 @@ export function getMissionGems(level, mission, challengeCount, gems) {
   return challengeScore;
 }
 
+// FIXME: Without gating, we have to count black NONE gems as passing, as otherwise
+// it will keep showing dialog for missions a user has started.
 export function isPassingGem(score) {
-  return score <= scoreValues.BRONZE;
+  // return score <= scoreValues.BRONZE;
+  return score <= scoreValues.NONE;
 }

--- a/src/code/utilities/progress-utils.js
+++ b/src/code/utilities/progress-utils.js
@@ -60,12 +60,18 @@ export default class AuthoringUtils {
 
   /**
    * Returns true if the given mission is beyond the current mission, and is therefore inaccesible.
+   *
+   * FIXME: Unlocking all missions was requested as a TEMPORARY feature, to remove gating
+   * entirely for the Fall 2017 teachers until we add a feature to put this under teacher
+   * control. The smallest temporary way to do this, and make it easy to revert, is to simply
+   * return `false` here.
    */
   static isMissionLocked(gems, authoring, level, mission) {
-    let currChallengeRoute = this.getCurrentChallengeFromGems(authoring, gems);
+    // let currChallengeRoute = this.getCurrentChallengeFromGems(authoring, gems);
 
-    return level > currChallengeRoute.level
-        || (level === currChallengeRoute.level && mission > currChallengeRoute.mission);
+    // return level > currChallengeRoute.level
+    //     || (level === currChallengeRoute.level && mission > currChallengeRoute.mission);
+    return false;
   }
 
 }


### PR DESCRIPTION
@ekosmin This is a one-line change, returning `false` from the function `isMissionLocked`. It seems to work fine, but wanted to check if you have thoughts about doing it this way.

I think in a few months we'll want to have this function back the way it was (perhaps alongside a Firebase property settable from the teacher dashboard), so I wanted to leave it easy to revert.