### PR TITLE
Implement css version of FV drop down styling images

### DIFF
--- a/src/code/fv-components/fv-chromosome-image.js
+++ b/src/code/fv-components/fv-chromosome-image.js
@@ -27,6 +27,22 @@ const FVChromosomeImageView = ({small=false, empty=false, chromosomeDescriptor, 
     return null;
   }
 
+  function chromosomeDescriptorText(chromosomeDescriptor) {
+    if (!chromosomeDescriptor) {
+      return null;
+    } else if (chromosomeDescriptor.side === 'y') {
+      return <div className="chromosome-label label-y">Y</div>;
+    } else if (chromosomeDescriptor.side.startsWith('x')) {
+      return <div className="chromosome-label label-x">X</div>;
+    } else if (chromosomeDescriptor.name === '1') {
+      return <div className="chromosome-label label-1">1</div>;
+    } else if (chromosomeDescriptor.name === '2') {
+      return <div className="chromosome-label label-2">2</div>;
+    }
+    // Default case, no name for empty chromosomes
+    return null;
+  }
+
   let stripes = null;
 
   if (chromosomeDescriptor && !empty) {
@@ -43,7 +59,8 @@ const FVChromosomeImageView = ({small=false, empty=false, chromosomeDescriptor, 
     };
   }
   return (
-    <div className={classNames('fv-chromosome-image', chromosomeDescriptorToClass(chromosomeDescriptor), { 'empty': empty, 'small': small})} style={positionStyling}>
+    <div className={classNames('fv-chromosome-image', chromosomeDescriptorToClass(chromosomeDescriptor), { 'empty': empty, 'small': small })} style={positionStyling}>
+      {chromosomeDescriptorText(chromosomeDescriptor)}
       {stripes}
     </div>
   );

--- a/src/code/fv-components/fv-gene-label.js
+++ b/src/code/fv-components/fv-gene-label.js
@@ -12,7 +12,6 @@ const Form = React.createClass({
 
     // render :: a -> ReactElement
     render: function () {
-      let self = this;
       return <SimpleSelect
         onValueChange={this.props.handleChange}
         options={this.props.options}
@@ -22,13 +21,13 @@ const Form = React.createClass({
         defaultValue={this.props.defaultOption}
         renderValue={function(item){
           return <div className="fv-gene-option-value">
-                    <div>{item.label}</div>
-                </div>
+            <div>{item.label}</div>
+          </div>;
           }}
         renderOption={function (item) {
           return <div className="fv-gene-option">
-                    <div>{item.label}</div>
-                </div>
+            <div>{item.label}</div>
+          </div>;
           }}
       ></SimpleSelect>;
     },

--- a/src/code/fv-components/fv-gene-label.js
+++ b/src/code/fv-components/fv-gene-label.js
@@ -11,8 +11,26 @@ const Form = React.createClass({
     },
 
     // render :: a -> ReactElement
-    render: function(){
-        return <SimpleSelect defaultValue={this.props.defaultOption} onValueChange={this.props.handleChange} options = {this.props.options} hideResetButton={true} editable={false} disabled={false}></SimpleSelect>;
+    render: function () {
+      let self = this;
+      return <SimpleSelect
+        onValueChange={this.props.handleChange}
+        options={this.props.options}
+        hideResetButton={true}
+        editable={false}
+        disabled={false}
+        defaultValue={this.props.defaultOption}
+        renderValue={function(item){
+          return <div className="fv-gene-option-value">
+                    <div>{item.label}</div>
+                </div>
+          }}
+        renderOption={function (item) {
+          return <div className="fv-gene-option">
+                    <div>{item.label}</div>
+                </div>
+          }}
+      ></SimpleSelect>;
     },
 
     componentDidMount: function() {
@@ -54,11 +72,11 @@ const FVGeneLabelView = ({species, editable, allele, hiddenAlleles=[], onAlleleC
 
       label = stripe ? null : (
         <div id='mountNode'>
-            <Form defaultOption={{label: alleleName, value: allele}} options={alleleOptions} handleChange={onAlleleChange}/> 
+            <Form defaultOption={{label: alleleName, value: allele}} options={alleleOptions} handleChange={onAlleleChange}/>
         </div>
       );
     }
-          
+
     return (
       <div className={"geniblocks fv-gene-label allele noneditable " + normalizedAllele} key={allele} style={style}>
         {line}

--- a/src/code/fv-components/fv-gene-label.js
+++ b/src/code/fv-components/fv-gene-label.js
@@ -10,8 +10,8 @@ const Form = React.createClass({
       handleChange: PropTypes.func
     },
 
-    // render :: a -> ReactElement
-    render: function () {
+  render: function () {
+    let currentValue = "";
       return <SimpleSelect
         onValueChange={this.props.handleChange}
         options={this.props.options}
@@ -19,13 +19,15 @@ const Form = React.createClass({
         editable={false}
         disabled={false}
         defaultValue={this.props.defaultOption}
-        renderValue={function(item){
+        renderValue={function (item) {
+          currentValue = item.label;
           return <div className="fv-gene-option-value">
             <div>{item.label}</div>
           </div>;
           }}
         renderOption={function (item) {
           return <div className="fv-gene-option">
+            {item.label === currentValue && <div className="selected">&nbsp;</div>}
             <div>{item.label}</div>
           </div>;
           }}

--- a/src/code/fv-components/fv-gene-label.js
+++ b/src/code/fv-components/fv-gene-label.js
@@ -11,7 +11,7 @@ const Form = React.createClass({
     },
 
   render: function () {
-    let currentValue = "";
+    let self = this;
       return <SimpleSelect
         onValueChange={this.props.handleChange}
         options={this.props.options}
@@ -20,20 +20,19 @@ const Form = React.createClass({
         disabled={false}
         defaultValue={this.props.defaultOption}
         renderValue={function (item) {
-          currentValue = item.label;
+          self.currentValue = item.label;
           return <div className="fv-gene-option-value">
             <div>{item.label}</div>
           </div>;
-          }}
+        }}
         renderOption={function (item) {
           return <div className="fv-gene-option">
-            {item.label === currentValue && <div className="selected">&nbsp;</div>}
+            {item.label === self.currentValue && <div className="selected">&nbsp;</div>}
             <div>{item.label}</div>
           </div>;
           }}
       ></SimpleSelect>;
     },
-
     componentDidMount: function() {
       document.querySelectorAll("input").forEach(input => input.setAttribute('readonly', true));
     }
@@ -69,11 +68,14 @@ const FVGeneLabelView = ({species, editable, allele, hiddenAlleles=[], onAlleleC
             alleleNames = visibleAlleles.map(a => species.alleleLabelMap[a]),
             alleleOptions = alleleNames.map((name, i) => (
                               {label:name, value:visibleAlleles[i]}
-                            ));
+            ));
+
+      let sortedAlleleOptions = alleleOptions.filter(a => a.value !== allele);
+      sortedAlleleOptions.unshift({ label: alleleName, value: allele });
 
       label = stripe ? null : (
         <div id='mountNode'>
-            <Form defaultOption={{label: alleleName, value: allele}} options={alleleOptions} handleChange={onAlleleChange}/>
+            <Form defaultOption={{label: alleleName, value: allele}} options={sortedAlleleOptions} handleChange={onAlleleChange}/>
         </div>
       );
     }

--- a/src/resources/images/arrow.svg
+++ b/src/resources/images/arrow.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;">
+    <g transform="matrix(1,0,0,0.714286,0,4.57143)">
+        <path d="M2,2L30,2L16,30L2,2Z" style="fill:white;stroke:white;stroke-width:1.15px;"/>
+    </g>
+</svg>

--- a/src/stylus/challenges.styl
+++ b/src/stylus/challenges.styl
@@ -6,7 +6,7 @@
  */
 $layoutWidth = 1920px
 $layoutHeight = 1080px
-$layoutMinWidth = 1200px
+$layoutMinWidth = 1024px
 $layoutMinHeight = 700px
 
 html
@@ -20,6 +20,7 @@ html
 
 body
   margin: 0
+  background-color: black
 
 .challenge-container
   background-color: black

--- a/src/stylus/fablevision/fv-chromosome.styl
+++ b/src/stylus/fablevision/fv-chromosome.styl
@@ -41,3 +41,18 @@
       width: 20px
       background-image: url('../resources/fablevision/layout-c/chromosome_half_dark.png')
 
+.chromosome-label
+  position: relative
+  left: 6px
+  top: 18px
+  font-family: "Yanone Kaffeesatz"
+  font-size: 0.9rem
+  color: #333
+  &.label-x
+    top: 54px
+  &.label-y
+    top: 24px
+  &.label-1
+    top: 48px
+  &.label-2
+    top: 48px

--- a/src/stylus/fablevision/fv-gene-label.styl
+++ b/src/stylus/fablevision/fv-gene-label.styl
@@ -13,24 +13,75 @@
 .rtl .fv-gene-option-value
   padding-left: 30px;
 
-.fv-layout-a #mountNode .react-selectize-control
-  background: #4C1FB6
-  border:2px solid #EAE1FE
-.fv-layout-b #mountNode .react-selectize-control
-  background: #CF670A
-  border:2px solid #F7E88D
-.fv-layout-c #mountNode .react-selectize-control
-  background: #084875
-  border:2px solid #0BEBFF
-.fv-layout-e #mountNode .react-selectize-control
-  background: #084875
-  border:2px solid #0BEBFF
-.fv-layout-h #mountNode .react-selectize-control
-  background: #CF670A
-  border:2px solid #F7E88D
-.fv-layout-i #mountNode .react-selectize-control
-  background: #CF670A
-  border:2px solid #F7E88D
+layout-a-background = #4c1fb6
+layout-a-highlight = #eae1fe
+
+layout-b-h-i-background = #cf670a
+layout-b-h-i-highlight = #f7e88d
+
+layout-c-e-background = #084875
+layout-c-e-highlight = #0bebff
+
+.fv-layout-a
+  #mountNode .react-selectize-control
+    background: layout-a-background
+    border:2px solid layout-a-highlight
+  .fv-gene-option
+    background: layout-a-background
+  .dropdown-menu
+    border-color: layout-a-highlight !important;
+    .option-wrapper
+      background: layout-a-highlight;
+.fv-layout-b
+  #mountNode .react-selectize-control
+    background: layout-b-h-i-background
+    border:2px solid layout-b-highlight
+  .fv-gene-option
+    background: layout-b-h-i-background
+  .dropdown-menu
+    border-color: layout-b-h-i-highlight !important;
+    .option-wrapper
+      background: layout-b-h-i-highlight;
+.fv-layout-c
+  #mountNode .react-selectize-control
+    background: layout-c-e-background
+    border:2px solid layout-c-e-highlight
+  .fv-gene-option
+    background: layout-c-e-background
+  .dropdown-menu
+    border-color: layout-c-e-highlight !important;
+    .option-wrapper
+      background: layout-c-e-highlight;
+.fv-layout-e
+  #mountNode .react-selectize-control
+    background: layout-c-e-background
+    border:2px solid layout-c-e-highlight
+  .fv-gene-option
+    background: layout-c-e-background
+  .dropdown-menu
+    border-color: layout-c-e-highlight !important;
+    .option-wrapper
+      background: layout-c-e-highlight;
+.fv-layout-h
+  #mountNode .react-selectize-control
+    background: layout-b-h-i-background
+    border:2px solid layout-b-h-i-highlight
+  .fv-gene-option
+    background: layout-b-h-i-background
+  .dropdown-menu
+    border-color: layout-b-h-i-highlight !important;
+    .option-wrapper
+      background: layout-b-h-i-highlight;
+.fv-layout-i
+  #mountNode .react-selectize-control
+    background: layout-b-h-i-background
+    border:2px solid layout-b-h-i-highlight
+  .fv-gene-option
+    background: layout-b-h-i-background
+  .dropdown-menu
+    border-color: layout-b-h-i-highlight !important;
+    .option-wrapper
+      background: layout-b-h-i-highlight;
 
 .react-selectize-toggle-button-container
   background: url('../resources/images/arrow.svg')
@@ -47,26 +98,42 @@
 .react-selectize-toggle-button
   display:none
 
+.dropdown-menu
+  border: 1px solid #666;
+  border-color: #333 !important;
+  background: black;
+  top:0px
+  border-radius: 12px !important
+  padding:1px
+  box-shadow: 0px 0px 15px #333;
+  .option-wrapper
+    padding:2px 1px 1px 1px;
+    background: #fff;
+    &.highlight
+      background: #fff !important;
+
 .fv-gene-option
   width:100%
   color:white
+  padding:6px 0px;
+  border-radius: 12px
+
   :hover
-    background-color:#555
+    border-radius: 12px;
+    background: #444 !important;
   div
     padding-left:16px;
-.fv-layout-a .fv-gene-option
-  background: #4C1FB6
-.fv-layout-b .fv-gene-option
-  background: #CF670A
-.fv-layout-c .fv-gene-option
-  background: #084875
-.fv-layout-e .fv-gene-option
-  background: #084875
-.fv-layout-h .fv-gene-option
-  background: #CF670A
-.fv-layout-i .fv-gene-option
-  background: #CF670A
-
+    font-size:1.1em !important
+  .selected
+    position:relative;
+    float:left;
+    margin-left:-2px;
+    color:#fff;
+    background: url('../resources/images/arrow.svg')
+    background-repeat: no-repeat
+    background-size:80%
+    transform: rotate(270deg)
+    background-position: center center
 .react-selectize.root-node
     position: relative;
     width: 158px;

--- a/src/stylus/fablevision/fv-gene-label.styl
+++ b/src/stylus/fablevision/fv-gene-label.styl
@@ -120,7 +120,7 @@ layout-c-e-highlight = #0bebff
 
   :hover
     border-radius: 12px;
-    background: #444 !important;
+    background: #444;
   div
     padding-left:16px;
     font-size:1.1em !important

--- a/src/stylus/fablevision/fv-gene-label.styl
+++ b/src/stylus/fablevision/fv-gene-label.styl
@@ -1,10 +1,71 @@
 .geniblocks.genome #mountNode .react-selectize-control
   display: flex
   flex-direction: row
-  height: 28px
+  height: 26px
+  border-radius:12px;
+  padding-left:10px;
+  background-repeat:no-repeat
+  background-size: 100% 100%
+  color:white
   input
     font-family: "Yanone Kaffeesatz";
     font-size: 1.5rem;
+.rtl .fv-gene-option-value
+  padding-left: 30px;
+
+.fv-layout-a #mountNode .react-selectize-control
+  background: #4C1FB6
+  border:2px solid #EAE1FE
+.fv-layout-b #mountNode .react-selectize-control
+  background: #CF670A
+  border:2px solid #F7E88D
+.fv-layout-c #mountNode .react-selectize-control
+  background: #084875
+  border:2px solid #0BEBFF
+.fv-layout-e #mountNode .react-selectize-control
+  background: #084875
+  border:2px solid #0BEBFF
+.fv-layout-h #mountNode .react-selectize-control
+  background: #CF670A
+  border:2px solid #F7E88D
+.fv-layout-i #mountNode .react-selectize-control
+  background: #CF670A
+  border:2px solid #F7E88D
+
+.react-selectize-toggle-button-container
+  background: url('../resources/images/arrow.svg')
+  background-repeat: no-repeat
+  background-size:60%
+  background-position: center center
+.ltl .react-selectize-toggle-button-container
+  border-left: 2px solid white
+.rtl .react-selectize-toggle-button-container
+  position:absolute
+  border-right: 2px solid white
+  left:0px;
+
+.react-selectize-toggle-button
+  display:none
+
+.fv-gene-option
+  width:100%
+  color:white
+  :hover
+    background-color:#555
+  div
+    padding-left:16px;
+.fv-layout-a .fv-gene-option
+  background: #4C1FB6
+.fv-layout-b .fv-gene-option
+  background: #CF670A
+.fv-layout-c .fv-gene-option
+  background: #084875
+.fv-layout-e .fv-gene-option
+  background: #084875
+.fv-layout-h .fv-gene-option
+  background: #CF670A
+.fv-layout-i .fv-gene-option
+  background: #CF670A
 
 .react-selectize.root-node
     position: relative;
@@ -13,7 +74,7 @@
       color: transparent
       text-shadow: 0 0 0 black;
 
-.geniblocks.genome 
+.geniblocks.genome
     #mountNode
       position: relative
       z-index: 1
@@ -121,7 +182,7 @@
   .fl .line
     width: 25px
 
-  .h 
+  .h
     .line
       width: 21px
     #mountNode
@@ -130,7 +191,7 @@
   .fl
     .line
       margin-top: -7px
-      width: 25px 
+      width: 25px
     #mountNode
       margin-top: 25px
     .fv-gene-label-text
@@ -139,25 +200,25 @@
   .w
     .line
       margin-top: -7px
-      width: 25px 
+      width: 25px
     #mountNode
       margin-top: -23px
     .fv-gene-label-text
       margin-top: -24px
 
-  .a 
+  .a
     .line
       margin-top: 6px
-      width: 25px 
+      width: 25px
     #mountNode
       margin-top: 31px
     .fv-gene-label-text
       margin-top: 19px
 
-  .c 
+  .c
     .line
       margin-top: -7px
-      width: 25px 
+      width: 25px
     #mountNode
       margin-top: -17px
     .fv-gene-label-text
@@ -166,7 +227,7 @@
   .b
     .line
       margin-top: 3px
-      width: 25px 
+      width: 25px
     #mountNode
       margin-top: 7px
     .fv-gene-label-text


### PR DESCRIPTION
I used css instead of the supplied images to improve rendering and flexibility of layout of drop downs, especially the switch from arrows on the right to left depending on which side the label is positioned. I did not see any samples showing hover highlights for option selection so I improvised with a general grey background, though that can be changed fairly easily.

I wasn't sure how to get to a layout that used the brown background - do any of the current challenges use that layout?

The React Selectize SimpleSelect control did not seem to allow the option to resize the svg arrow that was included in the control so I added a simple arrow.