### PR TITLE
In-challenge success message

### DIFF
--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -576,19 +576,21 @@ export function showNextTrialButton() {
   };
 }
 
-export function showNotification({message, closeButton, isRaised}) {
+export function showNotification({message, closeButton, arrowAsCloseButton, isRaised}) {
   const messageObj = typeof message === "string" ? {text: message} : message;
   return showNotifications({
     messages: [messageObj],
     closeButton,
+    arrowAsCloseButton,
     isRaised
   });
 }
 
-export function showNotifications({messages, closeButton, isRaised=false}) {
+export function showNotifications({messages, closeButton, arrowAsCloseButton=false, isRaised=false}) {
   return {
     type: actionTypes.NOTIFICATIONS_SHOWN,
     messages,
+    arrowAsCloseButton,
     closeButton,
     isRaised
   };
@@ -633,6 +635,7 @@ export function showInChallengeCompletionMessage() {
       closeButton: {
         action: "completeChallenge"
       },
+      arrowAsCloseButton: true,
       isRaised: true
     }));
   };

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -363,7 +363,7 @@ export function submitDrake(targetDrakeIndex, userDrakeIndex, correct, incorrect
 
     if (correct) {
       if (challengeComplete) {
-        dispatch(completeChallenge());
+        dispatch(showInChallengeCompletionMessage());
       } else {
         dispatch(showNotification({
           message: {
@@ -432,7 +432,7 @@ export function submitParents(motherIndex, fatherIndex, targetDrakeIndices, corr
 
     if (correct) {
       if (challengeComplete) {
-        dispatch(completeChallenge());
+        dispatch(showInChallengeCompletionMessage());
       } else {
         dispatch(showNotification({
           message: {
@@ -485,7 +485,7 @@ export function acceptEggInBasket(args) {
     dispatch(_acceptEggInBasket(args.eggDrakeIndex, args.basketIndex));
 
     if (args.isChallengeComplete) {
-      dispatch(completeChallenge());
+      dispatch(showInChallengeCompletionMessage());
     }
   };
 }
@@ -537,7 +537,7 @@ export function submitEggForBasket(eggDrakeIndex, basketIndex, isCorrect, isChal
       };
       if (isChallengeComplete) {
         dialog.closeButton = {
-          action: "completeChallenge"
+          action: "showInChallengeCompletionMessage"
         };
       } else {
         dialog.closeButton = {
@@ -612,6 +612,35 @@ export function advanceTrial() {
         target: ITS_TARGETS.TRIAL
       }
     }
+  };
+}
+
+export function showInChallengeCompletionMessage() {
+  return (dispatch, getState) => {
+
+    dispatch({
+      type: actionTypes.CHALLENGE_COMPLETED,
+      meta: {sound: 'receiveCoin'}
+    });
+
+    dispatch(showNotification({
+      message: {
+        text: "~ALERT.COMPLETED_CHALLENGE",
+        type: notificationType.NARRATIVE
+      },
+      closeButton: {
+        action: "completeChallenge"
+      }
+    }));
+
+    dispatch({
+      type: actionTypes.MODAL_DIALOG_SHOWN,
+      bigButtonText: "~BUTTON.CONTINUE",
+      rightButton: {
+        action: "completeChallenge"
+      },
+      showAward: false
+    });
   };
 }
 
@@ -695,7 +724,7 @@ export function keepOffspring(index, keptDrakesIndices, maxDrakes, shouldKeepSou
       // The size of the drakes array has changed since dispatching _keepOffspring
       const { drakes: updatedDrakes } = getState();
       if (updatedDrakes.length === maxDrakes) {
-        dispatch(completeChallenge());
+        dispatch(showInChallengeCompletionMessage());
       }
     } else {
       dispatch(showNotification({
@@ -726,7 +755,7 @@ export function winZoomChallenge() {
   return (dispatch) => {
     dispatch(_winZoomChallenge());
 
-    dispatch(completeChallenge());
+    dispatch(showInChallengeCompletionMessage());
   };
 }
 

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -565,11 +565,12 @@ export function showCompleteChallengeDialog() {
 }
 
 export function showNextTrialButton() {
-  const rightButton = rightButton || {
+  const rightButton = {
           action: "advanceTrial"
         };
   return {
     type: actionTypes.MODAL_DIALOG_SHOWN,
+    bigButtonText: "~BUTTON.NEXT_TRIAL",
     rightButton,
     showAward: false
   };

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -638,6 +638,11 @@ export function showInChallengeCompletionMessage() {
       arrowAsCloseButton: true,
       isRaised: true
     }));
+
+    dispatch({
+      type: actionTypes.MODAL_DIALOG_SHOWN,
+      mouseShieldOnly: true
+    });
   };
 }
 

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -576,19 +576,21 @@ export function showNextTrialButton() {
   };
 }
 
-export function showNotification({message, closeButton}) {
+export function showNotification({message, closeButton, isRaised}) {
   const messageObj = typeof message === "string" ? {text: message} : message;
   return showNotifications({
     messages: [messageObj],
-    closeButton
+    closeButton,
+    isRaised
   });
 }
 
-export function showNotifications({messages, closeButton}) {
+export function showNotifications({messages, closeButton, isRaised=false}) {
   return {
     type: actionTypes.NOTIFICATIONS_SHOWN,
     messages,
-    closeButton
+    closeButton,
+    isRaised
   };
 }
 
@@ -616,7 +618,7 @@ export function advanceTrial() {
 }
 
 export function showInChallengeCompletionMessage() {
-  return (dispatch, getState) => {
+  return (dispatch) => {
 
     dispatch({
       type: actionTypes.CHALLENGE_COMPLETED,
@@ -630,17 +632,9 @@ export function showInChallengeCompletionMessage() {
       },
       closeButton: {
         action: "completeChallenge"
-      }
-    }));
-
-    dispatch({
-      type: actionTypes.MODAL_DIALOG_SHOWN,
-      bigButtonText: "~BUTTON.CONTINUE",
-      rightButton: {
-        action: "completeChallenge"
       },
-      showAward: false
-    });
+      isRaised: true
+    }));
   };
 }
 

--- a/src/code/actions.js
+++ b/src/code/actions.js
@@ -649,10 +649,6 @@ export function showInChallengeCompletionMessage() {
 
 export function completeChallenge() {
   return (dispatch, getState) => {
-    dispatch({
-      type: actionTypes.CHALLENGE_COMPLETED,
-      meta: {sound: 'receiveCoin'}
-    });
     dispatch(showCompleteChallengeDialog());
 
     const { routeSpec, authoring, challengeErrors } = getState(),

--- a/src/code/components/modal-alert.js
+++ b/src/code/components/modal-alert.js
@@ -3,6 +3,7 @@
  */
 import EndLevelDialogView from '../fv-components/end-level-dialog';
 import NavigationDialogView from '../fv-components/navigation-dialog';
+import t from '../utilities/translate';
 import React, { PropTypes } from 'react';
 
 class ModalAlert extends React.Component {
@@ -17,6 +18,7 @@ class ModalAlert extends React.Component {
     }),
     onLeftButtonClick: PropTypes.func,        // optional click handlers if not defined
     onRightButtonClick: PropTypes.func,       // in button props. (Better for `mapDispatchToProps`)
+    bigButtonText: PropTypes.string,
     gems: PropTypes.array,
     routeSpec: PropTypes.object,
     challengeCount: PropTypes.number,
@@ -53,7 +55,7 @@ class ModalAlert extends React.Component {
                                      onHideMap={this.props.onHideMap}/>;
       } else {
         return <div className="next-trial-button" onClick={rightProps.onClick || this.props.onRightButtonClick}>
-                <div className="next-trial-text">Next Trial</div>
+                <div className="next-trial-text">{t(this.props.bigButtonText)}</div>
                </div>;
       }
     }

--- a/src/code/components/modal-alert.js
+++ b/src/code/components/modal-alert.js
@@ -19,6 +19,7 @@ class ModalAlert extends React.Component {
     onLeftButtonClick: PropTypes.func,        // optional click handlers if not defined
     onRightButtonClick: PropTypes.func,       // in button props. (Better for `mapDispatchToProps`)
     bigButtonText: PropTypes.string,
+    mouseShieldOnly: PropTypes.bool,
     gems: PropTypes.array,
     routeSpec: PropTypes.object,
     challengeCount: PropTypes.number,
@@ -53,6 +54,11 @@ class ModalAlert extends React.Component {
                                      gems={this.props.gems}
                                      onNavigateToChallenge={this.props.onNavigateToChallenge}
                                      onHideMap={this.props.onHideMap}/>;
+      } else if (this.props.mouseShieldOnly) {
+        return <div className="venture-pad-container">
+                <div className="venture-pad-backdrop light">
+                </div>
+              </div>;
       } else {
         return <div className="next-trial-button" onClick={rightProps.onClick || this.props.onRightButtonClick}>
                 <div className="next-trial-text">{t(this.props.bigButtonText)}</div>

--- a/src/code/components/notifications.js
+++ b/src/code/components/notifications.js
@@ -10,10 +10,11 @@ class Notifications extends React.Component {
     messages: PropTypes.array,
     defaultCharacter: PropTypes.string,
     closeButton: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
+    arrowAsCloseButton: PropTypes.bool,       // uses the arrow as a close button
     onCloseButton: PropTypes.func,
     onAdvanceNotifications: PropTypes.func.isRequired,
     onCloseNotifications: PropTypes.func.isRequired,
-    isRaised: PropTypes.boolean
+    isRaised: PropTypes.bool
   }
 
   static defaultProps = {
@@ -40,19 +41,20 @@ class Notifications extends React.Component {
           speaker = <div className={`fv-character ${character}`}></div>,
             // don't show close button if there's more narrative dialog
           isNarrative = message.type && message.type === "narrative",
-          showCloseButton = !!this.props.closeButton && (!isNarrative || !this.props.messages[1]),
-          showNextButton = !!this.props.messages[1],
+          showCloseButton = !!this.props.closeButton && (!isNarrative || !this.props.messages[1]) && !this.props.arrowAsCloseButton,
+          showNextButton = !!this.props.messages[1] || this.props.arrowAsCloseButton,
           isRaised = this.props.isRaised,
+          onClose = this.handleClose(this.props.onCloseButton, this.props.onCloseNotifications),
           className = `notification${isNarrative ? "" : " its-hint"}${isRaised ? " raised" : ""}`,
 
           messageView = <div className={ className }>
                       <div className="message-text"> { t(text) } </div>
                       <div className="message-buttons">
                         { showCloseButton
-                          ? <div className="close-button" onClick={ this.handleClose(this.props.onCloseButton, this.props.onCloseNotifications) }></div>
+                          ? <div className="close-button" onClick={ onClose }></div>
                           : null }
                         { showNextButton
-                          ? <div className="next-arrow" onClick={ this.props.onAdvanceNotifications }></div>
+                          ? <div className="next-arrow" onClick={ this.props.arrowAsCloseButton ? onClose : this.props.onAdvanceNotifications }></div>
                           : null }
                       </div>
                     </div>,

--- a/src/code/components/notifications.js
+++ b/src/code/components/notifications.js
@@ -12,7 +12,8 @@ class Notifications extends React.Component {
     closeButton: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
     onCloseButton: PropTypes.func,
     onAdvanceNotifications: PropTypes.func.isRequired,
-    onCloseNotifications: PropTypes.func.isRequired
+    onCloseNotifications: PropTypes.func.isRequired,
+    isRaised: PropTypes.boolean
   }
 
   static defaultProps = {
@@ -41,7 +42,8 @@ class Notifications extends React.Component {
           isNarrative = message.type && message.type === "narrative",
           showCloseButton = !!this.props.closeButton && (!isNarrative || !this.props.messages[1]),
           showNextButton = !!this.props.messages[1],
-          className = `notification${isNarrative ? "" : " its-hint"}`,
+          isRaised = this.props.isRaised,
+          className = `notification${isNarrative ? "" : " its-hint"}${isRaised ? " raised" : ""}`,
 
           messageView = <div className={ className }>
                       <div className="message-text"> { t(text) } </div>

--- a/src/code/containers/notification-container.js
+++ b/src/code/containers/notification-container.js
@@ -7,6 +7,7 @@ function mapStateToProps (state) {
   return {
     messages: state.notifications.messages,
     closeButton: state.notifications.closeButton,
+    arrowAsCloseButton: state.notifications.arrowAsCloseButton,
     isRaised: state.notifications.isRaised,
     defaultCharacter: state.location.defaultCharacter
   };

--- a/src/code/containers/notification-container.js
+++ b/src/code/containers/notification-container.js
@@ -7,6 +7,7 @@ function mapStateToProps (state) {
   return {
     messages: state.notifications.messages,
     closeButton: state.notifications.closeButton,
+    isRaised: state.notifications.isRaised,
     defaultCharacter: state.location.defaultCharacter
   };
 }

--- a/src/code/modules/notifications.js
+++ b/src/code/modules/notifications.js
@@ -59,7 +59,11 @@ export default function notifications(state = initialState, action) {
       const translatedMessages = action.messages.map(message => {
         return Object.assign({}, message, {text: t(message.text)});
       });
-      return {messages: state.messages.concat(translatedMessages), closeButton: action.closeButton};
+      return {
+        messages: state.messages.concat(translatedMessages),
+        closeButton: action.closeButton,
+        isRaised: action.isRaised
+      };
     }
     case ADVANCE_NOTIFICATIONS:
       return Object.assign({}, state, {messages: state.messages.length > 1 ? state.messages.slice(1, state.length) : initialState});

--- a/src/code/modules/notifications.js
+++ b/src/code/modules/notifications.js
@@ -62,6 +62,7 @@ export default function notifications(state = initialState, action) {
       return {
         messages: state.messages.concat(translatedMessages),
         closeButton: action.closeButton,
+        arrowAsCloseButton: action.arrowAsCloseButton,
         isRaised: action.isRaised
       };
     }

--- a/src/code/reducers/modal-dialog.js
+++ b/src/code/reducers/modal-dialog.js
@@ -5,7 +5,8 @@ import { GUIDE_ALERT_RECEIVED, GUIDE_MESSAGE_RECEIVED, ADVANCE_NOTIFICATIONS, CL
 const initialState = Immutable({
   show: false,
   leftButton: null,
-  rightButton: null
+  rightButton: null,
+  bigButtonText: null
 });
 
 const defaultRightButton = {
@@ -20,6 +21,7 @@ export default function modalDialog(state = initialState, action) {
         show: true,
         rightButton: action.rightButton || defaultRightButton,
         leftButton: action.leftButton,
+        bigButtonText: action.bigButtonText,
         showAward: action.showAward
       });
     case actionTypes.TOGGLE_MAP:

--- a/src/code/reducers/modal-dialog.js
+++ b/src/code/reducers/modal-dialog.js
@@ -6,7 +6,8 @@ const initialState = Immutable({
   show: false,
   leftButton: null,
   rightButton: null,
-  bigButtonText: null
+  bigButtonText: null,
+  mouseShieldOnly: false
 });
 
 const defaultRightButton = {
@@ -22,13 +23,15 @@ export default function modalDialog(state = initialState, action) {
         rightButton: action.rightButton || defaultRightButton,
         leftButton: action.leftButton,
         bigButtonText: action.bigButtonText,
-        showAward: action.showAward
+        showAward: !!action.showAward,
+        mouseShieldOnly: !!action.mouseShieldOnly
       });
     case actionTypes.TOGGLE_MAP:
       return state.merge({
         show: action.isVisible,
         showMap: action.isVisible,
-        showAward: false
+        showAward: false,
+        mouseShieldOnly: false
       });
     case actionTypes.MODAL_DIALOG_DISMISSED:
       return initialState;

--- a/src/code/utilities/lang/en-us.js
+++ b/src/code/utilities/lang/en-us.js
@@ -13,6 +13,7 @@ export default {
 
   // Challenge popup alerts
   "~ALERT.TITLE.GOOD_WORK": "Good work!",
+  "~ALERT.COMPLETED_CHALLENGE": "Challenge completed!",
   "~ALERT.TITLE.MISSION_ACCOMPLISHED": "Level Accomplished!",
   "~ALERT.TITLE.INCORRECT_DRAKE": "That's not the drake!",
   "~ALERT.TITLE.INCORRECT_PARENT": "Those parents won't work!",

--- a/src/stylus/fablevision/venture-pad.styl
+++ b/src/stylus/fablevision/venture-pad.styl
@@ -14,6 +14,9 @@
     background-color: black
     opacity: 0.8
 
+    &.light
+      opacity: 0.2
+
   .venture-pad-background
     position: absolute
     top: 7%
@@ -63,7 +66,7 @@
   .venture-pad-screen::-webkit-scrollbar
     width: 12px;
     background-color: #F5F5F5;
-    
+
   .venture-pad-overlay
     position: absolute
     top: 7%

--- a/src/stylus/notifications.styl
+++ b/src/stylus/notifications.styl
@@ -22,6 +22,10 @@
     background-image: url('../resources/fablevision/huds/scroll.png')
     background-repeat: no-repeat
 
+    &.raised
+      margin-bottom: 82px;
+      text-align: center
+
     .message-text
       margin-left: 140px
       margin-top: 23px

--- a/test/actions/egg-accepted.js
+++ b/test/actions/egg-accepted.js
@@ -26,16 +26,24 @@ describe('acceptEggInBasket action', () => {
                                       type: types.CHALLENGE_COMPLETED,
                                       meta: {sound: 'receiveCoin'}
                                     },
-          showCompleteChallengeAction = {
-                                          type: types.MODAL_DIALOG_SHOWN,
-                                          leftButton: {
-                                            action: "retryCurrentChallenge"
-                                          },
-                                          rightButton: {
-                                            action: "continueFromVictory"
-                                          },
-                                          showAward: true
-                                        };
+          showInChallengeCompletionMessage = {
+            type: types.NOTIFICATIONS_SHOWN,
+            messages: [
+              {
+                text: "~ALERT.COMPLETED_CHALLENGE",
+                type: "narrative"
+              }
+            ],
+            closeButton: {
+              action: "completeChallenge"
+            },
+            arrowAsCloseButton: true,
+            isRaised: true
+          },
+          showMouseShield = {
+            type: types.MODAL_DIALOG_SHOWN,
+            mouseShieldOnly: true
+          };
 
     const dispatch = expect.createSpy();
     const getState = () => ({routeSpec: {level: 0, mission: 0, challenge: 0}, trial: 0, trials: [{}], authoring: {
@@ -49,8 +57,9 @@ describe('acceptEggInBasket action', () => {
     dispatch.calls[1].arguments[0](dispatch, getState);
     // // thunk function dispatches the showCompleteChallengeAction
     expect(dispatch.calls[2].arguments).toEqual([completeChallengeAction]);
-    expect(dispatch.calls[3].arguments).toEqual([showCompleteChallengeAction]);
-    expect(dispatch.calls.length).toBe(4);
+    expect(dispatch.calls[3].arguments).toEqual([showInChallengeCompletionMessage]);
+    expect(dispatch.calls[4].arguments).toEqual([showMouseShield]);
+    expect(dispatch.calls.length).toBe(5);
   });
 
   describe('the reducer', () => {

--- a/test/actions/show-modal-dialog.js
+++ b/test/actions/show-modal-dialog.js
@@ -9,6 +9,7 @@ describe('showModalDialog action', () => {
   it('should create the correct action', () => {
     expect(actions.showNextTrialButton()).toEqual({
       type: types.MODAL_DIALOG_SHOWN,
+      bigButtonText: "~BUTTON.NEXT_TRIAL",
       rightButton: {action: "advanceTrial"},
       showAward: false
     });
@@ -21,17 +22,21 @@ describe('showModalDialog action', () => {
       let nextState = reducer(defaultState, {
         type: types.MODAL_DIALOG_SHOWN,
         showAward: false,
-        rightButton: {action: "advanceTrial"}
+        bigButtonText: "Next",
+        rightButton: {action: "advanceTrial"},
+        mouseShieldOnly: false
       });
 
       expect(nextState).toEqual(defaultState.merge({
         modalDialog: {
           show: true,
+          bigButtonText: "Next",
           rightButton: {
             "action": "advanceTrial"
           },
           leftButton: undefined,
-          showAward: false
+          showAward: false,
+          mouseShieldOnly: false
         },
         userDrakeHidden: false
       }));
@@ -50,12 +55,14 @@ describe('showModalDialog action', () => {
           "action": "action2",
           "label": "Left"
         },
-        showAward: true
+        showAward: true,
+        mouseShieldOnly: false
       });
 
       expect(nextState).toEqual(defaultState.merge({
         modalDialog: {
           show: true,
+          bigButtonText: undefined,
           rightButton: {
             "action": "action1",
             "label": "Right"
@@ -64,7 +71,8 @@ describe('showModalDialog action', () => {
             "action": "action2",
             "label": "Left"
           },
-          showAward: true
+          showAward: true,
+          mouseShieldOnly: false
         },
         userDrakeHidden: false
       }));
@@ -102,7 +110,8 @@ describe('showModalDialog action', () => {
                 "action": "action2",
                 "label": "Left"
               },
-              showAward: true
+              showAward: true,
+              mouseShieldOnly: false
             }
           });
 
@@ -114,7 +123,9 @@ describe('showModalDialog action', () => {
         modalDialog: {
           show: false,
           rightButton: null,
-          leftButton: null
+          leftButton: null,
+          bigButtonText: null,
+          mouseShieldOnly: false
         }
       }));
     });

--- a/test/actions/submit-drake.js
+++ b/test/actions/submit-drake.js
@@ -97,14 +97,18 @@ describe('submitDrake action', () => {
 
       // thunk function dispatches the MODAL_DIALOG_SHOWN action
       expect(dispatch).toHaveBeenCalledWith({
-        type: types.MODAL_DIALOG_SHOWN,
-        leftButton: {
-          action: "retryCurrentChallenge"
+        arrowAsCloseButton: true,
+        closeButton: {
+          action: "completeChallenge"
         },
-        rightButton: {
-          action: "continueFromVictory"
-        },
-        showAward: true
+        isRaised: true,
+        messages: [
+          {
+            text: "~ALERT.COMPLETED_CHALLENGE",
+            type: "narrative"
+          }
+        ],
+        type: "Notifications shown"
       });
     });
 
@@ -153,6 +157,8 @@ describe('submitDrake action', () => {
           label: "~BUTTON.TRY_AGAIN",
           action: "dismissModalDialog"
         },
+        arrowAsCloseButton: false,
+        isRaised: false
       });
     });
 
@@ -331,7 +337,9 @@ describe('submitDrake action', () => {
                   "text": "Good work!",
                   "type": "narrative"
                 }
-              ]
+              ],
+              arrowAsCloseButton: false,
+              isRaised: false
             },
             trialSuccess: true,
             userDrakeHidden: false
@@ -350,8 +358,10 @@ describe('submitDrake action', () => {
               rightButton: {
                 action: "advanceTrial"
               },
+              bigButtonText: "~BUTTON.NEXT_TRIAL",
               show: true,
-              showAward: false
+              showAward: false,
+              mouseShieldOnly: false
             }
           }));
         });
@@ -413,21 +423,24 @@ describe('submitDrake action', () => {
           expect(state2.gems[0][0][0]).toEqual([0]);
         });
 
-        it('should then trigger a modal_dialog_shown action with retry and continue buttons', () => {
+        it('should then trigger an in-challenge notification about victory', () => {
           let nextAction = nextDispatch.calls[1].arguments[0];
 
           state3 = reducer(state2, nextAction);
 
           expect(state3).toEqual(state2.merge({
-            modalDialog: {
-              leftButton: {
-                action: "retryCurrentChallenge"
+            notifications: {
+              messages: [
+                {
+                  "text": "Challenge completed!",
+                  "type": "narrative"
+                }
+              ],
+              closeButton: {
+                action: "completeChallenge"
               },
-              rightButton: {
-                action: "continueFromVictory"
-              },
-              show: true,
-              showAward: true
+              arrowAsCloseButton: true,
+              isRaised: true
             },
             userDrakeHidden: false
           }));

--- a/test/actions/submit-egg.js
+++ b/test/actions/submit-egg.js
@@ -137,8 +137,10 @@ describe('submitEggForBasket action', () => {
         type: types.NOTIFICATIONS_SHOWN,
         messages: [{text: "~ALERT.TITLE.EGG_MISMATCH"}],
         closeButton: {
-          action: "completeChallenge"
-        }
+          action: "showInChallengeCompletionMessage"
+        },
+        isRaised: false,
+        arrowAsCloseButton: false
       });
     });
   });


### PR DESCRIPTION
When the user has completed a challenge, show a Success message from a character while the new drake is still visible; let the new gem be visible; and block any mouse interaction except moving forward.

https://www.pivotaltracker.com/story/show/154811093 