### PR TITLE
Limit animation duration to half a second

### DIFF
--- a/src/code/hoc/animate-spring.js
+++ b/src/code/hoc/animate-spring.js
@@ -16,16 +16,24 @@ import {Motion, spring} from 'react-motion';
     in its target state without further animation. This allows animations at rest to
     respond immediately to window resize events, for instance.
  */
-export default function animateSpring(stiffness=120, damping=25) {
+export default function animateSpring(stiffness=115, damping=18) {
 
   return function(WrappedComponent) {
     return class extends React.Component {
-      
+      componentDidMount() {
+        this.fixedAnimationDuration = window.setInterval(() => {
+          if (!this.isComplete) {
+            this.handleRest();
+          }
+          window.clearInterval(this.fixedAnimationDuration);
+        }, 500);
+      }
+
       static propTypes = {
         key: PropTypes.string,
         initialStyle: PropTypes.object.isRequired,
         targetStyle: PropTypes.object.isRequired,
-        onRest: PropTypes.func
+        onRest: PropTypes.func,
       }
 
       handleRest = (...args) => {


### PR DESCRIPTION
I don't believe we use the spring motion anywhere else in the application - there's a tail to the spring that drags out the length of time until "onRest" is called which was delaying the hatch animation, so I've added a time limit. But I wanted to check if this approach was acceptable or whether there's a better way to achieve this result. 