### PR TITLE
Add schema for authoring validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "uuid": "^2.0.2"
   },
   "devDependencies": {
+    "ajv-cli": "^3.0.0",
     "babel-eslint": "^7.1.1",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
@@ -101,6 +102,7 @@
     "pretest": "npm run lint",
     "start": "gulp",
     "test": "mocha --compilers js:babel-core/register --recursive --require ./test/setup.js --require mock-local-storage",
-    "test:watch": "npm run test -- --watch"
+    "test:watch": "npm run test -- --watch",
+    "validate": "ajv validate -s ./src/resources/authoring/authoring.schema.json -d ./src/resources/authoring/gv-1.json"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,19 @@ You can add the url parameter `localAuthoring=x` to the url to load a JSON file 
 
 The authored activities in the authoring folder should be named `gv-x` for reasonably-up-to-date copies of the official authoring, where x is the version at the root of the Firebase document. Experimental activities can be given other names.
 
+The authoring document can be validated against the schema specified in the [authoring.schema.json](src/resources/authoring/authoring.schema.json) file. Validation can be triggered from the command line with the command
+
+    npm run validate
+
+Visual Studio Code can be configured to [show schema validation errors](https://code.visualstudio.com/docs/languages/json#_mapping-to-a-schema-in-the-workspace) in the editor by configuring a user setting for the project:
+```
+  // Associate schemas to JSON files in the current project
+  "json.schemas": [{
+      "fileMatch": ["gv-1.json"],
+      "url": "./src/resources/authoring/authoring.schema.json"
+  }],
+```
+
 ## Structure
 
 The code is written in ES2015+ and JSX, which is transformed using Babel. We use

--- a/src/resources/authoring/authoring.schema.json
+++ b/src/resources/authoring/authoring.schema.json
@@ -1,0 +1,342 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Geniventure Authoring",
+  "description": "Geniventure's authoring document",
+  "type": "object",
+  "properties": {
+    "application": {
+      "description": "Configuration for the levels and missions that comprise the application",
+      "type": "object",
+      "properties": {
+        "levels": {
+          "description": "Configuration for the levels that comprise the application",
+          "type": "array",
+          "items": {
+            "description": "Each entry corresponds to a level",
+            "type": "object",
+            "properties": {
+              "missions": {
+                "description": "Configuration for the missions that comprise the level",
+                "type": "array",
+                "items": {
+                  "description": "Each entry corresponds to a mission",
+                  "type": "object",
+                  "properties": {
+                    "challenges": {
+                      "description": "The list of challenges provided by this mission",
+                      "type": "array",
+                      "items": {
+                        "description": "Each entry corresponds to a challenge",
+                        "type": "object",
+                        "properties": {
+                          "about": {
+                            "description": "Information about the challenge",
+                            "type": "object",
+                            "properties": {
+                              "description": {
+                                "description": "A description of the challenge",
+                                "type": "string"
+                              },
+                              "tip": {
+                                "description": "A hint provided to the user",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "The type of the challenge",
+                                "type": "string"
+                              }
+                            },
+                            "required": ["description", "type"],
+                            "additionalProperties": false
+                          },
+                          "dialog": {
+                            "description": "The dialog spoken by the characters during the challenge",
+                            "type": "object",
+                            "properties": {
+                              "end": { "$ref": "#/definitions/endDialogSequence" },
+                              "middle": { "$ref": "#/definitions/dialogSequence" },
+                              "start": { "$ref": "#/definitions/dialogSequence" }
+                            },
+                            "required": ["end", "start"],
+                            "additionalProperties": false
+                          },
+                          "id": {
+                            "description": "The ID of the challenge, which should correspond to an ID in the challenges map",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "The name of the challenge",
+                            "type": "string"
+                          },
+                          "room": { "$ref": "#/definitions/room" }
+                        },
+                        "required": ["about", "dialog", "id", "name", "room"],
+                        "additionalProperties": false
+                      }
+                    },
+                    "dialog": {
+                      "description": "The dialog text spoken by the characters in the mission",
+                      "type": "object",
+                      "properties": {
+                        "end": { "$ref": "#/definitions/dialogSequence" },
+                        "middle": { "$ref": "#/definitions/dialogSequence" },
+                        "start": { "$ref": "#/definitions/dialogSequence" }
+                      },
+                      "required": ["end", "middle", "start"],
+                      "additionalProperties": false
+                    },
+                    "name": {
+                      "description": "The name of the mission",
+                      "type": "string"
+                    }
+                  },
+                  "required": ["challenges", "dialog", "name"]
+                }
+              },
+              "name": {
+                "description": "The name of the mission",
+                "type": "string"
+              }
+            },
+            "required": ["missions", "name"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": ["levels"],
+      "additionalProperties": false
+    },
+    "challenges": {
+      "description": "Configuration of the challenges provided by the application",
+      "type": "object",
+      "patternProperties": {
+        "^.+$": {
+          "description": "Each entry represents a challenge",
+          "type": "object",
+          "oneOf": [
+            { "$ref": "#/definitions/challenge" },
+            { "$ref": "#/definitions/FVGenomeChallenge" }
+          ]
+        }
+      }
+    },
+    "rooms": {
+      "description": "Configuration of the locations available within the application",
+      "type": "object",
+      "patternProperties": {
+        "^.+$": {
+          "description": "Each entry represents a room",
+          "type": "object",
+          "properties": {
+            "defaultCharacter": {
+              "description": "The narrative character present by default in the room",
+              "type": "string"
+            },
+            "name": {
+              "description": "The name of the room",
+              "type": "string"
+            }
+          },
+          "required": ["name"]
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "required": ["application", "challenges", "rooms"],
+  "additionalProperties": false,
+  "definitions": {
+    "biologicaAlleleString": {
+      "description": "A set of alleles that can be used to specify an organism in the 'a:b:' format used by BioLogica",
+      "type": "string"
+    },
+    "challenge": {
+      "description": "Configuration of an individual challenge",
+      "type": "object",
+      "properties": {
+        "template": { "$ref": "#/definitions/template" },
+        "patternProperties": {
+          "^.+$": {
+            "description": "Challenge properties are defined by the template and vary among challenges."
+          }
+        }
+      },
+      "required": ["template"]
+    },
+    "character": {
+      "description": "The name of the character",
+      "type": "string",
+      "enum": ["ELLIS", "HATCH", "HERRERA", "NETANYA", "RAJPUT", "WEAVER", "YEUNG"]
+    },
+    "dialogSequence": {
+      "description": "A sequence of spoken dialog items",
+      "type": "array",
+      "items": {
+        "description": "Each item corresponds to a piece of dialog from one of the characters",
+        "type": "object",
+        "properties": {
+          "character": { "$ref": "#/definitions/character" },
+          "text": {
+            "description": "The text spoken by the character",
+            "type": "string"
+          }
+        },
+        "required": ["character", "text"],
+        "additionalProperties": false
+      }
+    },
+    "drake": {
+      "description": "Specification for a drake",
+      "type": "object",
+      "properties": {
+        "alleles": { "$ref": "#/definitions/biologicaAlleleString" },
+        "sex": {
+          "description": "Specifies the sex of the drake -- 0: male, 1: female",
+          "type": "number",
+          "enum": [0, 1]
+        }
+      },
+      "required": ["alleles"],
+      "additionalProperties": false
+    },
+    "endDialogSequence": {
+      "description": "Alternative dialog sequences spoken at the end of a challenge or mission",
+      "type": "object",
+      "properties": {
+        "failure": { "$ref": "#/definitions/dialogSequence" },
+        "success": { "$ref": "#/definitions/dialogSequence" }
+      },
+      "required": ["failure", "success"],
+      "additionalProperties": false
+    },
+    "FVGenomeChallenge": {
+      "description": "A challenge that uses the FVGenomeChallenge template",
+      "type": "object",
+      "properties": {
+        "challengeType": {
+          "type": "string",
+          "enum": ["create-unique", "match-target"]
+        },
+        "comment": {
+          "type": "string"
+        },
+        "container": {
+          "type": "string",
+          "enum": ["FVContainer"]
+        },
+        "hiddenAlleles": {
+          "description": "The alleles that should not be selectable by the user",
+          "type": "string"
+        },
+        "initialDrake": {
+          "description": "Specifies a single drake or an array of drakes",
+          "oneOf": [
+            { "$ref": "#/definitions/drake" },
+            {
+              "type": "array",
+              "items": { "$ref": "#/definitions/drake" }
+            }
+          ]
+        },
+        "instructions": {
+          "description": "Instructions displayed to the user",
+          "type": "string"
+        },
+        "linkedGenes": {
+          "description": "Specifies genes that should be synchronized between multiple drakes",
+          "type": "object",
+          "properties": {
+            "drakes": {
+              "description": "Specifies the drakes that should be linked by their indices",
+              "type": "array",
+              "items": {
+                "description": "Indices of the drakes to be linked",
+                "type": "number"
+              }
+            },
+            "genes": {
+              "description": "String which specifies the genes to be linked",
+              "type": "string"
+            }
+          }
+        },
+        "numTrials": {
+          "description": "DEPRECATED: The number of trials. Deprecated because trials have been deprecated",
+          "type": "number"
+        },
+        "randomizeTrials": {
+          "description": "Whether the order of the trials should be randomized",
+          "type": "boolean"
+        },
+        "showUserDrake": {
+          "description": "Whether the user's drake should be visible",
+          "type": "boolean"
+        },
+        "targetDrakes": {
+          "description": "Specifies the target drakes to be matched",
+          "type": "array",
+          "items": { "$ref": "#/definitions/drake" }
+        },
+        "template": {
+          "type": "string",
+          "enum": ["FVGenomeChallenge"]
+        },
+        "trialGenerator": {
+          "description": "Specifies the randomization of the trials",
+          "type": "object",
+          "properties": {
+            "baseDrake": {
+              "description": "The alleles shared by all generated drakes",
+              "type": "string"
+            },
+            "initialDrakeCombos": {
+              "description": "Specifies the combinations of alleles used to generated the initial drakes",
+              "type": "array",
+              "items": {
+                "description": "Specifies a set of alleles, one of which is to be randomly selected",
+                "type": "array",
+                "items": { "$ref": "#/definitions/biologicaAlleleString" }
+              }
+            },
+            "targetDrakeCombos": {
+              "description": "Specifies the combinations of alleles used to generated the target drakes",
+              "type": "array",
+              "items": {
+                "description": "Specifies a set of alleles, one of which is to be randomly selected",
+                "type": "array",
+                "items": { "$ref": "#/definitions/biologicaAlleleString" }
+              }
+            },
+            "type": {
+              "description": "The type of randomization used to generate the trials",
+              "type": "string",
+              "enum": ["all-combinations"]
+            }
+          },
+          "required": ["baseDrake", "initialDrakeCombos", "targetDrakeCombos", "type"],
+          "additionalProperties": false
+        },
+        "userChangeableGenes": {
+          "description": "List of genes that can be modified by the user",
+          "type": "string"
+        },
+        "visibleGenes": {
+          "description": "List of genes shown to the user",
+          "type": "string"
+        }
+      },
+      "required": ["template"],
+      "additionalProperties": false
+    },
+    "room": {
+      "description": "The room/location of the challenge",
+      "type": "string",
+      "enum": ["breedingbarn", "hatchery", "home", "simroom", "zoomroom"]
+    },
+    "template": {
+      "description": "The template identifies the React component that implements the challenge",
+      "type": "string",
+      "enum": ["ClutchGame", "EggGame", "EggSortGame", "FVEggGame", "FVEggSortGame", "GenomeChallenge", "GenomePlayground", "ZoomChallenge"]
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13,6 +13,10 @@ abab@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
 
+abbrev@1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+
 accessory@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/accessory/-/accessory-1.1.0.tgz#7833e9839a32ded76d26021f36a41707a520f593"
@@ -72,9 +76,27 @@ after@0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
 
+ajv-cli@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ajv-cli/-/ajv-cli-3.0.0.tgz#5823231f64e2833054130690b18099609e980f29"
+  dependencies:
+    ajv "^6.0.0"
+    ajv-pack "^0.3.0"
+    fast-json-patch "^0.5.6"
+    glob "^7.0.3"
+    json-schema-migrate "^0.2.0"
+    minimist "^1.2.0"
+
 ajv-keywords@^1.0.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.0.tgz#c11e6859eafff83e0dafc416929472eca946aa2c"
+
+ajv-pack@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/ajv-pack/-/ajv-pack-0.3.1.tgz#b72c4d4219e3928e62842d742ded93bf50796560"
+  dependencies:
+    js-beautify "^1.6.4"
+    require-from-string "^1.2.0"
 
 ajv@^4.7.0:
   version "4.10.3"
@@ -82,6 +104,24 @@ ajv@^4.7.0:
   dependencies:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
+
+ajv@^5.0.0:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+
+ajv@^6.0.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.0.tgz#4c8affdf80887d8f132c9c52ab8a2dc4d0b7b24c"
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+    uri-js "^4.2.1"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -942,6 +982,10 @@ blob@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.4.tgz#bcf13052ca54463f30f9fc7e95b9a47630a94921"
 
+bluebird@^3.0.5:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"
@@ -1097,6 +1141,10 @@ browserify@^13.1.1:
     util "~0.10.1"
     vm-browserify "~0.0.1"
     xtend "^4.0.0"
+
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
 
 buffer-shims@^1.0.0:
   version "1.0.0"
@@ -1332,6 +1380,13 @@ concat-with-sourcemaps@^1.0.0:
   dependencies:
     source-map "^0.5.1"
 
+config-chain@~1.1.5:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.11.tgz#aba09747dfbe4c3e70e766a6e41586e1859fc6f2"
+  dependencies:
+    ini "^1.3.4"
+    proto-list "~1.2.1"
+
 console-browserify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"
@@ -1353,6 +1408,10 @@ convert-source-map@^1.1.0, convert-source-map@^1.1.1, convert-source-map@^1.2.0:
 convert-source-map@~1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.1.3.tgz#4829c877e9fe49b3161f3bf3673888e204699860"
+
+core-js@^0.8.3:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-0.8.4.tgz#c22665f1e0d1b9c3c5e1b08dabd1f108695e4fcf"
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -1603,6 +1662,10 @@ dom-serializer@0, dom-serializer@~0.1.0:
     domelementtype "~1.1.1"
     entities "~1.1.1"
 
+dom-walk@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
+
 domain-browser@~1.1.0:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
@@ -1663,9 +1726,25 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
+ecdsa-sig-formatter@1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz#1c595000f04a8897dfb85000892a0f4c33af86c3"
+  dependencies:
+    safe-buffer "^5.0.1"
+
 editions@^1.1.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/editions/-/editions-1.3.3.tgz#0907101bdda20fac3cbe334c27cbd0688dc99a5b"
+
+editorconfig@^0.13.2:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.13.3.tgz#e5219e587951d60958fd94ea9a9a008cdeff1b34"
+  dependencies:
+    bluebird "^3.0.5"
+    commander "^2.9.0"
+    lru-cache "^3.2.0"
+    semver "^5.1.0"
+    sigmund "^1.0.1"
 
 element-resize-event@^2.0.4:
   version "2.0.7"
@@ -2021,6 +2100,22 @@ fancy-log@^1.1.0:
     chalk "^1.1.1"
     time-stamp "^1.0.0"
 
+fast-deep-equal@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
+
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+
+fast-json-patch@^0.5.6:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/fast-json-patch/-/fast-json-patch-0.5.7.tgz#b5a8f49d259624596ef98b872f3fda895b4d8665"
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
@@ -2315,6 +2410,13 @@ global-prefix@^0.1.4:
     ini "^1.3.4"
     is-windows "^0.2.0"
     which "^1.2.12"
+
+global@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
+  dependencies:
+    min-document "^2.19.0"
+    process "~0.5.1"
 
 globals@^9.0.0, globals@^9.14.0:
   version "9.14.0"
@@ -2999,6 +3101,15 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
+js-beautify@^1.6.4:
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.7.5.tgz#69d9651ef60dbb649f65527b53674950138a7919"
+  dependencies:
+    config-chain "~1.1.5"
+    editorconfig "^0.13.2"
+    mkdirp "~0.5.0"
+    nopt "~3.0.1"
+
 js-tokens@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-2.0.0.tgz#79903f5563ee778cc1162e6dcf1a0027c97f9cb5"
@@ -3047,6 +3158,16 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
+json-schema-migrate@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/json-schema-migrate/-/json-schema-migrate-0.2.0.tgz#ba47a5b0072fc72396460e1bd60b44d52178bbc6"
+  dependencies:
+    ajv "^5.0.0"
+
+json-schema-traverse@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
@@ -3087,6 +3208,21 @@ jsonpointer@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
 
+jsonwebtoken@^8.1.0:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.2.2.tgz#76d7993fda79660d71bd0f933109e1f133734b20"
+  dependencies:
+    jws "^3.1.5"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    xtend "^4.0.1"
+
 jsprim@^1.2.2:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.3.1.tgz#2a7256f70412a29ee3670aaca625994c4dcff252"
@@ -3101,6 +3237,21 @@ jsx-ast-utils@^1.3.4:
   dependencies:
     acorn-jsx "^3.0.1"
     object-assign "^4.1.0"
+
+jwa@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.1.6.tgz#87240e76c9808dbde18783cf2264ef4929ee50e6"
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.10"
+    safe-buffer "^5.0.1"
+
+jws@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.1.5.tgz#80d12d05b293d1e841e7cb8b4e69e561adcf834f"
+  dependencies:
+    jwa "^1.1.5"
+    safe-buffer "^5.0.1"
 
 kind-of@^3.0.2:
   version "3.1.0"
@@ -3270,6 +3421,10 @@ lodash.foreach@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -3277,6 +3432,10 @@ lodash.isarguments@^3.0.0:
 lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
 
 lodash.isempty@^4.2.1:
   version "4.4.0"
@@ -3286,7 +3445,15 @@ lodash.isequal@^4.0.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.4.0.tgz#6295768e98e14dc15ce8d362ef6340db82852031"
 
-lodash.isplainobject@^4.0.4:
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+
+lodash.isplainobject@^4.0.4, lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
 
@@ -3317,6 +3484,10 @@ lodash.memoize@~3.0.3:
 lodash.merge@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
 
 lodash.partialright@^4.1.4:
   version "4.2.1"
@@ -3393,6 +3564,12 @@ lru-cache@2:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
 
+lru-cache@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-3.2.0.tgz#71789b3b7f5399bec8565dda38aa30d2a097efee"
+  dependencies:
+    pseudomap "^1.0.1"
+
 make-error-cause@^1.1.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/make-error-cause/-/make-error-cause-1.2.2.tgz#df0388fcd0b37816dff0a5fb8108939777dcbc9d"
@@ -3462,6 +3639,12 @@ mime-types@^2.1.12, mime-types@~2.1.7:
   dependencies:
     mime-db "~1.25.0"
 
+min-document@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
+  dependencies:
+    dom-walk "^0.1.0"
+
 minimalistic-assert@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz#702be2dda6b37f4836bcb3f5db56641b64a1d3d3"
@@ -3489,11 +3672,11 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.0:
+minimist@^1.1.0, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -3514,6 +3697,13 @@ mocha@^3.2.0:
     lodash.create "3.1.1"
     mkdirp "0.5.1"
     supports-color "3.1.2"
+
+mock-local-storage@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/mock-local-storage/-/mock-local-storage-1.0.5.tgz#899ff300027cefed47816e6dc539bb059fcce489"
+  dependencies:
+    core-js "^0.8.3"
+    global "^4.3.2"
 
 module-deps@^4.0.8:
   version "4.0.8"
@@ -3543,6 +3733,10 @@ ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+
 multipipe@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/multipipe/-/multipipe-0.1.2.tgz#2a8f2ddf70eed564dff2d57f1e1a137d9f05078b"
@@ -3571,6 +3765,12 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+nopt@~3.0.1:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
+  dependencies:
+    abbrev "1"
 
 normalize-path@^2.0.1:
   version "2.0.1"
@@ -3885,6 +4085,10 @@ process@~0.11.0:
   version "0.11.9"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.9.tgz#7bd5ad21aa6253e7da8682264f1e11d11c0318c1"
 
+process@~0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
+
 progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
@@ -3894,6 +4098,14 @@ promise@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
     asap "~2.0.3"
+
+proto-list@~1.2.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
+
+pseudomap@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 public-encrypt@^4.0.0:
   version "4.0.0"
@@ -3912,6 +4124,10 @@ punycode@1.3.2:
 punycode@^1.3.2, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
 qs@~6.3.0:
   version "6.3.0"
@@ -4301,6 +4517,10 @@ require-dir@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/require-dir/-/require-dir-0.3.2.tgz#c1d5c75e9fbffde9f2e6b33e383db4f594b5a6a9"
 
+require-from-string@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
+
 require-uncached@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
@@ -4371,6 +4591,10 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
+safe-buffer@^5.0.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+
 sax@0.5.x:
   version "0.5.8"
   resolved "https://registry.yarnpkg.com/sax/-/sax-0.5.8.tgz#d472db228eb331c2506b0e8c15524adb939d12c1"
@@ -4386,6 +4610,10 @@ seamless-immutable@^7.0.1:
 semver@^4.1.0:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
+
+semver@^5.1.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
 semver@^5.3.0:
   version "5.3.0"
@@ -4429,7 +4657,7 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-sigmund@~1.0.0:
+sigmund@^1.0.1, sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
 
@@ -4895,6 +5123,12 @@ unique-stream@^2.0.2:
     json-stable-stringify "^1.0.0"
     through2-filter "^2.0.0"
 
+uri-js@^4.2.1:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  dependencies:
+    punycode "^2.1.0"
+
 url@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -5125,7 +5359,7 @@ xmlhttprequest-ssl@1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz#185a888c04eca46c3e4070d99f7b49de3528992d"
 
-"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.0, xtend@~4.0.1:
+"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
Add schema for authoring validation [#157981472]
- add `validate` script to perform authoring validation against schema

There's a lot more that could be done here, but this should be a reasonable starting point. I've fleshed out the schema for the `FVGenomeChallenge`, but the other challenges are currently handled generically. Allele strings and gene lists could be validated with regular expressions, etc.

@dstrawberrygirl pointed out that Visual Studio Code can be configured to [show schema validation errors](https://code.visualstudio.com/docs/languages/json#_mapping-to-a-schema-in-the-workspace) in the editor. My configuration looks like
```
    // Associate schemas to JSON files in the current project
    "json.schemas": [{
        "fileMatch": ["gv-1.json"],
        "url": "./src/resources/authoring/authoring.schema.json"
    }],
```
If we adopted a naming convention like `.authoring.json` for all authoring files, then that could be coded into the `fileMatch`.