### PR TITLE
Export narrative text

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "lint": "eslint examples gv2 src test",
     "examples": "live-server public --open=examples",
     "gv2": "live-server public --open=gv2",
+    "narrative": "node ./script/narrative.js",
     "pretest": "npm run lint",
     "start": "gulp",
     "test": "mocha --compilers js:babel-core/register --recursive --require ./test/setup.js --require mock-local-storage",

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,32 @@ Visual Studio Code can be configured to [show schema validation errors](https://
   }],
 ```
 
+### Narrative
+
+The narrative dialog alone can be exported from the authoring document using
+
+    npm run narrative > narrative.txt
+
+which generates output like the following:
+```
+Authoring File: src/resources/authoring/gv-1.json
+Git Branch: 157825652-export-dialog-text
+Export Date: 2018-06-04 14:56:36
+
+*
+* Level 1 - "Level 1"
+*
+
+*
+* Mission 1.1 - "Mission 1.1"
+*
+  HATCH: "Welcome, Cadet, to our underground hideout! I'm Professor Hatch, director of the Drake Breeder's Guild."
+  WEAVER: "And I'm Dr. Weaver, head of Mission Control here in the heart of our subterranean base."
+  HATCH: "Here in the Wyvern Republic, our dragons are under attack from the evil Kingdom of Darkwell, and in danger of going extinct! "
+  WEAVER: "You are training to be part of an elite team of scientists who will help us bring dragons back from the brink!"
+  HATCH: "Time is running out and we need to train you fast! Come with me to the Sim Room. Click your VenturePad to navigate around the base."
+```
+
 ## Structure
 
 The code is written in ES2015+ and JSX, which is transformed using Babel. We use

--- a/script/narrative.js
+++ b/script/narrative.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+/*
+ * Script to export the narrative text from an authoring document.
+ * The authoring document can be specified as the first argument.
+ * If no authoring document is specified, the default is used.
+ */  
+
+const fs = require("fs");
+const args = process.argv.slice(2);
+const path = args[0] || "src/resources/authoring/gv-1.json";
+const fileContents = fs.readFileSync(path);
+if (!fileContents) {
+  console.log(`Error reading authoring file: '${path}'`);
+  process.exit(1);
+}
+
+let authoring;
+try {
+  authoring = JSON.parse(fileContents);
+}
+catch(e) {
+  console.log(`Error: '${path}' does not appear to be a valid JSON file`);
+  process.exit(1);
+}
+
+const { application: { levels } } = authoring;
+if (!levels) {
+  console.log(`Error: '${path}' does not appear to be a valid authoring file`);
+  process.exit(1);
+}
+
+const gitBranch = require('child_process')
+                    .execSync(`git branch | grep '* '`)
+                    .toString().trim().substr(2);
+const dateStr = new Date().toLocaleString()
+                    .replace(/-([0-9])(?=[- ])/g, '-0$1');
+console.log(`Authoring File: ${path}`);
+console.log(`Git Branch: ${gitBranch}`);
+console.log(`Export Date: ${dateStr}\n`);
+
+levels.forEach((level, levelIndex) => {
+  console.log(`*`);
+  console.log(`* Level ${levelIndex+1} - "${level.name}"`);
+  console.log(`*\n`);
+
+  level.missions.forEach((mission, missionIndex) => {
+    console.log(`*`);
+    console.log(`* Mission ${levelIndex+1}.${missionIndex+1} - "${mission.name}"`);
+    console.log(`*`);  
+
+    (mission.dialog.start || []).forEach(d => {
+      console.log(`  ${d.character}: "${d.text}"`);
+    });
+    console.log(``);
+    mission.challenges.forEach((challenge, challengeIndex) => {
+      console.log(`  *`);
+      console.log(`  * Challenge ${levelIndex+1}.${missionIndex+1}.${challengeIndex+1} - "${challenge.name}"`);
+      console.log(`  *`);  
+
+      (challenge.dialog.start || []).forEach(d => {
+        console.log(`    ${d.character}: "${d.text}"`);
+      });
+      console.log(``);
+      for (let ending in challenge.dialog.end || {}) {
+        console.log(`    ${ending}:`);
+        (challenge.dialog.end[ending] || []).forEach(d => {
+          console.log(`    ${d.character}: "${d.text}"`);
+        });
+        console.log(``);
+      }
+    });
+    if (mission.dialog.middle) {
+      console.log(`  middle/home:`);
+      (mission.dialog.middle || []).forEach(d => {
+        console.log(`  ${d.character}: "${d.text}"`);
+      });
+    }
+    console.log(``);
+    if (mission.dialog.end) {
+      console.log(`  end:`);
+      (mission.dialog.end || []).forEach(d => {
+        console.log(`  ${d.character}: "${d.text}"`);
+      });
+    }
+    console.log(``);
+  });
+});

--- a/src/resources/authoring/authoring.schema.json
+++ b/src/resources/authoring/authoring.schema.json
@@ -54,7 +54,6 @@
                             "type": "object",
                             "properties": {
                               "end": { "$ref": "#/definitions/endDialogSequence" },
-                              "middle": { "$ref": "#/definitions/dialogSequence" },
                               "start": { "$ref": "#/definitions/dialogSequence" }
                             },
                             "required": ["end", "start"],

--- a/src/resources/authoring/gv-1.json
+++ b/src/resources/authoring/gv-1.json
@@ -1831,10 +1831,6 @@
                 "text" : "Focus on doing your best work, Cadet."
               } ]
             },
-            "middle" : [ {
-              "character" : "RAJPUT",
-              "text" : "Open your VentureMap and head on over to the Breeding Barn. Quickly! We don’t have much time!"
-            } ],
             "start" : [ {
               "character" : "RAJPUT",
               "text" : "These drakes had to be smuggled out quickly and secretly, so  we have no information on them."
@@ -1850,7 +1846,7 @@
             } ]
           },
           "id" : "test-cross-1",
-          "name" : "Challenge 5.1",
+          "name" : "Challenge 5.1.1",
           "room" : "breedingbarn"
         }, {
           "about" : {
@@ -1869,10 +1865,6 @@
                 "text" : "Did you show us your best effort here Cadet? If so, move on to the next mystery drake."
               } ]
             },
-            "middle" : [ {
-              "character" : "RAJPUT",
-              "text" : "Open your VentureMap and head on over to the Breeding Barn. Quickly! We don’t have much time!"
-            } ],
             "start" : [ {
               "character" : "RAJPUT",
               "text" : "Colonel Herrera, I have a feeling our Cadet needs a tougher challenge."
@@ -1885,7 +1877,7 @@
             } ]
           },
           "id" : "test-cross-2",
-          "name" : "Challenge 5.2",
+          "name" : "Challenge 5.1.2",
           "room" : "breedingbarn"
         }, {
           "about" : {
@@ -1916,10 +1908,6 @@
                 "text" : "Seriously, Cadet, It's been great having you. We have to bid you farewell for now. Just remember, when you come across genetics, think of Geniventure! "
               } ]
             },
-            "middle" : [ {
-              "character" : "RAJPUT",
-              "text" : "Open your VentureMap and head on over to the Breeding Barn. Quickly! We don’t have much time!"
-            } ],
             "start" : [ {
               "character" : "RAJPUT",
               "text" : "Now we are going to see if you've really got what it takes, Cadet."
@@ -1929,7 +1917,7 @@
             } ]
           },
           "id" : "test-cross-3",
-          "name" : "Challenge 5.3",
+          "name" : "Challenge 5.1.3",
           "room" : "breedingbarn"
         } ],
         "dialog" : {


### PR DESCRIPTION
Not seeing a script for exporting the narrative text in the repository, I decided to whip one up. Apparently, another script already exists. @dstrawberrygirl I'm not sure how best to handle this. If you want to add the other script to this PR we can make both available. Or we can decide to merge the two somehow.

In writing and testing the script I encountered and fixed a couple of issues with the authoring document itself, e.g. unused properties and inconsistent challenge naming.

Note: To get the Travis build to complete I had to fix an unrelated bower installation issue that seems to have resulted from some change in the way the React-DnD library is made available through bower. For Geniventure itself, we use npm to install the appropriate version of React-DnD. For some of the older static examples we were relying on bower to install from the unpkg CDN. The bower installation of React-DnD was failing this morning, so I updated bower.json to specify a standard dependency rather than a CDN dependency, which allowed the Travis build to succeed. The drag/drop example doesn't actually work, but that may have been true for some time. In any case, it seems like a separate issue.