### PR TITLE
Level 6 challenges 2.1 and 2.2 (egg sorting)

### DIFF
--- a/src/code/templates/fv-egg-sort-game.js
+++ b/src/code/templates/fv-egg-sort-game.js
@@ -342,16 +342,17 @@ export default class FVEggSortGame extends Component {
   }
 
   handleBasketClick = (basketIndex, basket) => {
-    const { correct, errors, onSubmitEggForBasket } = this.props,
-          { eggs } = this.state,
-          { index: selectedEggIndex, egg: selectedEgg } = this.selectedEgg(),
-          eggDrakeIndex = selectedEggIndex,
-          isChallengeComplete = correct + errors + 1 >= eggs.length;
+    const { onSubmitEggForBasket } = this.props,
+          { index: selectedEggIndex, egg: selectedEgg } = this.selectedEgg();
     isSubmittedEggCorrect = selectedEgg && isEggCompatibleWithBasket(selectedEgg, basket);
     if (selectedEgg) {
       animationEvents.moveEggToBasket.animate(selectedEgg, selectedEggIndex, basketIndex);
-      setTimeout(function() {
-        // Delay the submit until the egg is finished hatching
+      // Delay the submit until the egg is finished hatching
+      setTimeout(() => {
+        const { correct, errors } = this.props,
+        { eggs } = this.state,
+        eggDrakeIndex = selectedEggIndex,
+        isChallengeComplete = correct + errors + 1 >= eggs.length;
         onSubmitEggForBasket(eggDrakeIndex, basketIndex, isSubmittedEggCorrect, isChallengeComplete);
       }, 3000);
     }

--- a/src/code/templates/fv-egg-sort-game.js
+++ b/src/code/templates/fv-egg-sort-game.js
@@ -92,7 +92,7 @@ let animationEvents = {
       }},
       hatchDrakeInBasket: { id: 1, complete: false, animate: function() {
         const { scale } = _this.props,
-              leftOffset = -313,
+              leftOffset = -300,
               topOffset = -28;
         appendAnimation('hatchDrakeInBasket',
           <NewEggHatch
@@ -106,7 +106,7 @@ let animationEvents = {
         const { baskets, scale } = _this.props,
               targetBasket = targetBasketIndex >= 0 ? baskets[targetBasketIndex] : null,
               leftOffset = 100,
-              topOffset = 100;
+              topOffset = 97;
         _this.clearSelection();
         resetAnimationEvents(false);
 

--- a/src/code/templates/fv-egg-sort-game.js
+++ b/src/code/templates/fv-egg-sort-game.js
@@ -38,6 +38,13 @@ const EGG_IMAGE_WIDTH_MEDIUM = EGG_IMAGE_WIDTH,
       SMALL_EGG_ON_BASKET_X_OFFSET = 52,
       SMALL_EGG_ON_BASKET_Y_OFFSET = 10,
 
+      EGG_IN_CLUTCH = 0,
+      EGG_IS_ANIMATING = 1,
+      EGG_IN_BASKET = 2,
+      EGG_IS_HATCHED = 3,
+      EGG_IS_FADING = 4,
+      EGG_IS_COMPLETE = 5,
+
       modeCollectInBasket = urlParams.collectInBasket > 0;
 
 let _this,
@@ -45,6 +52,7 @@ let _this,
 
     isSubmittedEggCorrect,
     animatingEgg, animatingEggIndex,
+    eggStates = [],
     animatingDrake, targetBasketIndex;
 
 const FastEggHatch = compose(
@@ -73,6 +81,7 @@ let animationEvents = {
         if (eggIndex >= 0) {
           animatingEgg = egg;
           animatingEggIndex = eggIndex;
+          eggStates[animatingEggIndex] = EGG_IS_ANIMATING;
           animatingDrake = new BioLogica.Organism(BioLogica.Species.Drake, egg.alleles, egg.sex);
           targetBasketIndex = basketIndex;
 
@@ -117,6 +126,7 @@ let animationEvents = {
           evt.stopPropagation();
         }
 
+        eggStates[animatingEggIndex] = EGG_IS_FADING;
         appendAnimation('fadeDrakeAway',
           <EggFade
               org={animatingDrake} scale={scale}
@@ -171,26 +181,32 @@ function animationFinish(evt) {
   switch(evt) {
     case animationEvents.moveEggToBasket.id:
       animationEvents.moveEggToBasket.complete = true;
+      eggStates[animatingEggIndex] = EGG_IN_BASKET;
       resetAnimationEvents(false);
       animationEvents.hatchDrakeInBasket.animate(animatingEgg);
       break;
     case animationEvents.hatchDrakeInBasket.id:
       animationEvents.hatchDrakeInBasket.complete = true;
+      eggStates[animatingEggIndex] = EGG_IS_HATCHED;
       break;
     case animationEvents.fadeDrakeAway.id:
       animationEvents.fadeDrakeAway.complete = true;
+      eggStates[animatingEggIndex] = EGG_IS_COMPLETE;
       resetAnimationEvents(true);
       break;
     case animationEvents.settleEggInBasket.id:
       animationEvents.settleEggInBasket.complete = true;
+      eggStates[animatingEggIndex] = EGG_IN_BASKET;
       resetAnimationEvents(true);
       break;
     case animationEvents.returnEggFromBasket.id:
       animationEvents.returnEggFromBasket.complete = true;
+      eggStates[animatingEggIndex] = EGG_IN_CLUTCH;
       resetAnimationEvents(true);
       break;
     case animationEvents.hatchDrakeInEgg.id:
       animationEvents.hatchDrakeInEgg.complete = true;
+      eggStates[animatingEggIndex] = EGG_IS_HATCHED;
       break;
   }
   _this.setState({animation:"complete"});
@@ -252,15 +268,11 @@ export default class FVEggSortGame extends Component {
   }
 
   createEggsFromDrakes(props) {
+    eggStates = [];
     const { drakes } = props,
           eggs = drakes.map((child) => {
-                    let drake = new BioLogica.Organism(BioLogica.Species.Drake, child.alleleString, child.sex);
-                    if (drake.getCharacteristic('liveliness') === "Dead") {
-                      drake.species.makeAlive(drake);
-                      // regenerate the drake with the new "alive" alleles as makeAlive() doesn't update everything
-                      drake = new BioLogica.Organism(BioLogica.Species.Drake, drake.getAlleleString(), drake.sex);
-                    }
-                    return drake;
+                    eggStates.push(EGG_IN_CLUTCH);
+                    return new BioLogica.Organism(BioLogica.Species.Drake, child.alleleString, child.sex);
                   });
     this.setState({ eggs });
   }
@@ -355,7 +367,7 @@ export default class FVEggSortGame extends Component {
   }
 
   render() {
-    const { userChangeableGenes, visibleGenes, drakes, baskets, correct, errors } = this.props,
+    const { userChangeableGenes, visibleGenes, baskets, correct, errors } = this.props,
           { animation, animatedComponents, eggs } = this.state,
           selectedBaskets = this.selectedBaskets(),
           { index: selectedEggIndex, egg: selectedEgg } = this.selectedEgg(),
@@ -365,10 +377,7 @@ export default class FVEggSortGame extends Component {
           showSelectedEggIndex = isHatchingDrakeInEgg ? -1 : selectedEggIndex,
           basketEggs = modeCollectInBasket ? eggs : null,
           displayEggs = eggs.map((egg, index) => {
-            const isAnimatingEgg = (animatingEggIndex === index),
-                  drake = drakes[index],
-                  isEggInBasket = drake && (drake.basket != null);
-            return isAnimatingEgg || isEggInBasket ? null : egg;
+            return eggStates[index] === EGG_IN_CLUTCH ? egg : null;
           }),
           showInstructions = !selectedEgg && !correct && !errors,
           sectionTitle = showInstructions

--- a/src/code/templates/fv-egg-sort-game.js
+++ b/src/code/templates/fv-egg-sort-game.js
@@ -354,7 +354,7 @@ export default class FVEggSortGame extends Component {
         eggDrakeIndex = selectedEggIndex,
         isChallengeComplete = correct + errors + 1 >= eggs.length;
         onSubmitEggForBasket(eggDrakeIndex, basketIndex, isSubmittedEggCorrect, isChallengeComplete);
-      }, 3000);
+      }, 1000);
     }
     this.setBasketSelection([basketIndex]);
   }

--- a/src/resources/authoring/authoring.schema.json
+++ b/src/resources/authoring/authoring.schema.json
@@ -115,6 +115,7 @@
           "type": "object",
           "oneOf": [
             { "$ref": "#/definitions/challenge" },
+            { "$ref": "#/definitions/FVEggSortGame" },
             { "$ref": "#/definitions/FVGenomeChallenge" }
           ]
         }
@@ -146,9 +147,15 @@
   "required": ["application", "challenges", "rooms"],
   "additionalProperties": false,
   "definitions": {
-    "biologicaAlleleString": {
+    "biologicaAlleles": {
       "description": "A set of alleles that can be used to specify an organism in the 'a:b:' format used by BioLogica",
-      "type": "string"
+      "type": "string",
+      "pattern": "^(((a|b):(T|Tk|t|M|m|W|w|H|h|C|c|Fl|fl|Hl|hl|A1|A2|a|B|b|D|d|Rh|rh|Bog|bog))|,)*$"
+    },
+    "biologicaSex": {
+      "description": "Numeric value to indicate sex -- 0: male, 1: female",
+      "type": "number",
+      "enum": [0, 1]
     },
     "challenge": {
       "description": "Configuration of an individual challenge",
@@ -189,12 +196,8 @@
       "description": "Specification for a drake",
       "type": "object",
       "properties": {
-        "alleles": { "$ref": "#/definitions/biologicaAlleleString" },
-        "sex": {
-          "description": "Specifies the sex of the drake -- 0: male, 1: female",
-          "type": "number",
-          "enum": [0, 1]
-        }
+        "alleles": { "$ref": "#/definitions/biologicaAlleles" },
+        "sex": { "$ref": "#/definitions/biologicaSex" }
       },
       "required": ["alleles"],
       "additionalProperties": false
@@ -254,14 +257,11 @@
                 "type": "number"
               }
             },
-            "genes": {
-              "description": "String which specifies the genes to be linked",
-              "type": "string"
-            }
+            "genes": { "$ref": "#/definitions/genes" }
           }
         },
         "numTrials": {
-          "description": "DEPRECATED: The number of trials. Deprecated because trials have been deprecated",
+          "description": "The number of trials",
           "type": "number"
         },
         "randomizeTrials": {
@@ -285,17 +285,14 @@
           "description": "Specifies the randomization of the trials",
           "type": "object",
           "properties": {
-            "baseDrake": {
-              "description": "The alleles shared by all generated drakes",
-              "type": "string"
-            },
+            "baseDrake": { "$ref": "#/definitions/biologicaAlleles" },
             "initialDrakeCombos": {
               "description": "Specifies the combinations of alleles used to generated the initial drakes",
               "type": "array",
               "items": {
                 "description": "Specifies a set of alleles, one of which is to be randomly selected",
                 "type": "array",
-                "items": { "$ref": "#/definitions/biologicaAlleleString" }
+                "items": { "$ref": "#/definitions/biologicaAlleles" }
               }
             },
             "targetDrakeCombos": {
@@ -304,7 +301,7 @@
               "items": {
                 "description": "Specifies a set of alleles, one of which is to be randomly selected",
                 "type": "array",
-                "items": { "$ref": "#/definitions/biologicaAlleleString" }
+                "items": { "$ref": "#/definitions/biologicaAlleles" }
               }
             },
             "type": {
@@ -316,17 +313,71 @@
           "required": ["baseDrake", "initialDrakeCombos", "targetDrakeCombos", "type"],
           "additionalProperties": false
         },
-        "userChangeableGenes": {
-          "description": "List of genes that can be modified by the user",
+        "userChangeableGenes": { "$ref": "#/definitions/genes" },
+        "visibleGenes": { "$ref": "#/definitions/genes" }
+      },
+      "required": ["challengeType", "container", "showUserDrake", "template", "userChangeableGenes"],
+      "additionalProperties": false
+    },
+    "FVEggSortGame": {
+      "description": "A challenge that uses the FVEggSortGame template",
+      "type": "object",
+      "properties": {
+        "baskets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "alleles": {
+                "type": "array",
+                "items": { "$ref": "#/definitions/biologicaAlleles" }
+              },
+              "label": {
+                "type": "string"
+              },
+              "sex": { "$ref": "#/definitions/biologicaSex" }
+            },
+            "required": ["alleles", "label"],
+            "additionalProperties": false
+          }
+        },
+        "comment": {
           "type": "string"
         },
-        "visibleGenes": {
-          "description": "List of genes shown to the user",
-          "type": "string"
-        }
+        "container": {
+          "type": "string",
+          "enum": ["FVContainer"]
+        },
+        "template": {
+          "description": "The template identifies the React component that implements the challenge",
+          "type": "string",
+          "enum": ["FVEggSortGame"]
+        },
+        "trialGenerator": {
+          "type": "object",
+          "properties": {
+            "baseDrake": { "$ref": "#/definitions/biologicaAlleles" },
+            "drakes": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/drake" }
+            },
+            "type": {
+              "type": "string",
+              "enum": ["randomize-order"]
+            }
+          },
+          "required": ["baseDrake", "drakes", "type"],
+          "additionalProperties": false
+        },
+        "visibleGenes": { "$ref": "#/definitions/genes" }
       },
-      "required": ["template"],
+      "required": ["baskets", "container", "template", "trialGenerator"],
       "additionalProperties": false
+    },
+    "genes": {
+      "description": "A string containing comma-separated list of genes",
+      "type": "string",
+      "pattern": "^(tail|metallic|wings|horns|color|black|forelimbs|hindlimbs|armor|dilute|bogbreath|nose|(, ))*$"
     },
     "room": {
       "description": "The room/location of the challenge",
@@ -336,7 +387,7 @@
     "template": {
       "description": "The template identifies the React component that implements the challenge",
       "type": "string",
-      "enum": ["ClutchGame", "EggGame", "EggSortGame", "FVEggGame", "FVEggSortGame", "GenomeChallenge", "GenomePlayground", "ZoomChallenge"]
+      "enum": ["ClutchGame", "EggGame", "EggSortGame", "FVEggGame", "GenomeChallenge", "GenomePlayground", "ZoomChallenge"]
     }
   }
 }

--- a/src/resources/authoring/gv-1.json
+++ b/src/resources/authoring/gv-1.json
@@ -2076,6 +2076,73 @@
           }]
         },
         "name": "Mission 6.1"
+      }, {
+        "challenges": [{
+          "about": {
+            "description" : "Students must sort eggs into appropriate baskets based on their tails.",
+            "tip" : "",
+            "type" : "Egg Drop"
+          },
+          "dialog": {
+            "end": {
+              "failure": [{
+                "character": "NETANYA",
+                "text": "Challenge 6.2.1 not completed successfully"
+              }],
+              "success": [{
+                "character": "NETANYA",
+                "text": "Challenge 6.2.1 completed successfully"
+              }]
+            },
+            "start": [{
+              "character": "YEUNG",
+              "text": "Welcome to Challenge 6.2.1!"
+            }]
+          },
+          "id": "eggDrop-tail",
+          "name": "Challenge 6.2.1",
+          "room": "hatchery"
+        }, {
+          "about": {
+            "description" : "Students must sort eggs into appropriate baskets based on their nose spikes.",
+            "tip" : "",
+            "type" : "Egg Drop"
+          },
+          "dialog": {
+            "end": {
+              "failure": [{
+                "character": "NETANYA",
+                "text": "Challenge 6.2.2 not completed successfully"
+              }],
+              "success": [{
+                "character": "NETANYA",
+                "text": "Challenge 6.2.2 completed successfully"
+              }]
+            },
+            "start": [{
+              "character": "YEUNG",
+              "text": "Welcome to Challenge 6.2.2!"
+            }]
+          },
+          "id": "eggDrop-noseSpike",
+          "name": "Challenge 6.2.2",
+          "room": "hatchery"
+        }],
+        "dialog": {
+          "end": [{
+            "character": "NETANYA",
+            "text": "End of mission 6.2"
+          }],
+          "middle": [{
+            "character": "WEAVER",
+            "text": "Middle of mission 6.2"
+          }],
+          "start": [{
+            "character": "YEUNG",
+            "text": "Start of mission 6.2"
+          }]
+        },
+        "name": "Mission 6.2"
       } ],
       "name": "Level 6"
     } ]
@@ -2441,6 +2508,7 @@
       "container" : "FVContainer",
       "instructions" : "Match 2 drakes!",
       "numTrials" : 1,
+      "showUserDrake": false,
       "template" : "FVGenomeChallenge",
       "trialGenerator" : {
         "baseDrake" : "a:M,b:M,a:t,b:t,a:h,b:h,a:A1,b:A1,a:C,b:C,a:B,b:B,a:D,b:D,a:rh,b:rh,a:Bog,b:Bog",
@@ -2468,6 +2536,7 @@
       "container" : "FVContainer",
       "instructions" : "Match 2 drakes!",
       "numTrials" : 1,
+      "showUserDrake": false,
       "template" : "FVGenomeChallenge",
       "trialGenerator" : {
         "baseDrake" : "a:M,b:M,a:T,b:T,a:H,b:H,a:A1,b:A1,a:C,b:C,a:b,b:b,a:D,b:D,a:rh,b:rh,a:Bog,b:Bog",
@@ -3950,6 +4019,95 @@
         "type" : "randomize-order"
       },
       "visibleGenes" : "forelimbs, hindlimbs"
+    },
+    "eggDrop-noseSpike" : {
+      "baskets" : [ {
+        "alleles" : [ "a:Rh" ],
+        "label" : "Males with a nose spike",
+        "sex" : 0
+      }, {
+        "alleles" : [ "a:rh" ],
+        "label" : "Males without a nose spike",
+        "sex" : 0
+      }, {
+        "alleles" : [ "a:Rh", "b:Rh" ],
+        "label" : "Females with a nose spike",
+        "sex" : 1
+      }, {
+        "alleles" : [ "a:rh,b:rh" ],
+        "label" : "Females without a nose spike",
+        "sex" : 1
+      } ],
+      "comment" : "*** Egg Sorting Game Test ***",
+      "container" : "FVContainer",
+      "template" : "FVEggSortGame",
+      "trialGenerator" : {
+        "baseDrake" : "a:Bog,b:Bog",
+        "drakes" : [ {
+          "alleles" : "a:Rh",
+          "sex" : 0
+        }, {
+          "alleles" : "a:Rh",
+          "sex" : 0
+        }, {
+          "alleles" : "a:rh",
+          "sex" : 0
+        }, {
+          "alleles" : "a:rh",
+          "sex" : 0
+        }, {
+          "alleles" : "a:Rh,b:rh",
+          "sex" : 1
+        }, {
+          "alleles" : "a:rh,b:Rh",
+          "sex" : 1
+        }, {
+          "alleles" : "a:rh,b:rh",
+          "sex" : 1
+        }, {
+          "alleles" : "a:rh,b:rh",
+          "sex" : 1
+        } ],
+        "type" : "randomize-order"
+      },
+      "visibleGenes" : "tail, dilute, nose"
+    },
+    "eggDrop-tail" : {
+      "baskets" : [ {
+        "alleles" : [ "a:T", "b:T" ],
+        "label" : "Drakes with a long tail"
+      }, {
+        "alleles" : [ "a:Tk,b:Tk", "a:Tk,b:t", "a:t,b:Tk" ],
+        "label" : "Drakes with a kinked tail"
+      }, {
+        "alleles" : [ "a:t,b:t" ],
+        "label" : "Drakes with a short tail"
+      } ],
+      "comment" : "*** Egg Sorting Game Test ***",
+      "container" : "FVContainer",
+      "template" : "FVEggSortGame",
+      "trialGenerator" : {
+        "baseDrake" : "a:Bog,b:Bog",
+        "drakes" : [ {
+          "alleles" : "a:t,b:t"
+        }, {
+          "alleles" : "a:t,b:t"
+        }, {
+          "alleles" : "a:t,b:T"
+        }, {
+          "alleles" : "a:T,b:t"
+        }, {
+          "alleles" : "a:t,b:Tk"
+        }, {
+          "alleles" : "a:Tk,b:t"
+        }, {
+          "alleles" : "a:Tk,b:T"
+        }, {
+          "alleles" : "a:T,b:Tk"
+        } ],
+        "type" : "randomize-order"
+      },
+      "visibleGenes" : "tail, dilute, nose"
     },
     "eggDrop-wings" : {
       "baskets" : [ {


### PR DESCRIPTION
Note: This PR depends on PR #199. Once that is reviewed/merged this can be rebased to master to simplify review/merge of this PR.

Add detailed FVEggSortGame to schema
Additional schema improvements
- regex for gene list properties
- regex for allele string properties

Add level 6 egg sort challenges
- Challenge 6.2.1 (tail) [#157981278]
- Challenge 6.2.2 (nose spike) [#157981284]

Adjust egg hatch location to avoid jump when fade begins

Fix bug in which egg would sometimes appear briefly back in straw after animating to basket [#158034904]

Fix bug in which end-of-challenge dialog sometimes wouldn't appear [#158034904]
