### PR TITLE
Enforce minimum number of moves in target-matching challenges

### DIFF
--- a/src/resources/authoring/authoring.schema.json
+++ b/src/resources/authoring/authoring.schema.json
@@ -256,8 +256,14 @@
                 "type": "number"
               }
             },
-            "genes": { "$ref": "#/definitions/genes" }
-          }
+            "genes": { "$ref": "#/definitions/genes" },
+            "minChanges": {
+              "description": "The minimum number of allele changes required to match the drakes after linking genes",
+              "type": "number"
+            }
+          },
+          "required": ["drakes", "genes"],
+          "additionalProperties": false
         },
         "numTrials": {
           "description": "The number of trials",

--- a/src/resources/authoring/authoring.schema.json
+++ b/src/resources/authoring/authoring.schema.json
@@ -259,7 +259,8 @@
             "genes": { "$ref": "#/definitions/genes" },
             "minChanges": {
               "description": "The minimum number of allele changes required to match the drakes after linking genes",
-              "type": "number"
+              "type": "integer",
+              "minimum": 0
             }
           },
           "required": ["drakes", "genes"],

--- a/src/resources/authoring/gv-1.json
+++ b/src/resources/authoring/gv-1.json
@@ -2270,7 +2270,8 @@
       "instructions" : "Match the target drake!",
       "linkedGenes" : {
         "drakes" : [ 0, 1 ],
-        "genes" : "wings, forelimbs, armor, horns, hindlimbs, metallic, color, black, bogbreath"
+        "genes" : "wings, forelimbs, armor, horns, hindlimbs, metallic, color, black, bogbreath",
+        "minChanges": 2
       },
       "randomizeTrials" : true,
       "showUserDrake" : false,
@@ -2291,7 +2292,8 @@
       "instructions" : "Match the target drake!",
       "linkedGenes" : {
         "drakes" : [ 0, 1 ],
-        "genes" : "wings, forelimbs, armor, horns, hindlimbs, metallic, color, black, bogbreath"
+        "genes" : "wings, forelimbs, armor, horns, hindlimbs, metallic, color, black, bogbreath",
+        "minChanges": 2
       },
       "randomizeTrials" : true,
       "showUserDrake" : false,
@@ -2650,7 +2652,8 @@
       "instructions" : "Match the target drake!",
       "linkedGenes" : {
         "drakes" : [ 0, 1 ],
-        "genes" : "wings, forelimbs, armor, horns, hindlimbs, metallic, color, black, bogbreath"
+        "genes" : "wings, forelimbs, armor, horns, hindlimbs, metallic, color, black, bogbreath",
+        "minChanges": 2
       },
       "randomizeTrials" : true,
       "showUserDrake" : true,
@@ -2671,7 +2674,8 @@
       "instructions" : "Match the target drake!",
       "linkedGenes" : {
         "drakes" : [ 0, 1 ],
-        "genes" : "wings, forelimbs, armor, horns, hindlimbs, metallic, color, black, bogbreath"
+        "genes" : "wings, forelimbs, armor, horns, hindlimbs, metallic, color, black, bogbreath",
+        "minChanges": 2
       },
       "randomizeTrials" : true,
       "showUserDrake" : true,


### PR DESCRIPTION
Target-matching challenges now provide a means of specifying a minimum number of moves when generating drakes [#158095906].
