### PR TITLE
Add `unused` script to identify unused templates and challenges

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "templates": "node ./script/templates.js",
     "test": "mocha --compilers js:babel-core/register --recursive --require ./test/setup.js --require mock-local-storage",
     "test:watch": "npm run test -- --watch",
+    "unused": "node ./script/unused.js",
     "validate": "ajv validate -s ./src/resources/authoring/authoring.schema.json -d ./src/resources/authoring/gv-1.json"
   }
 }

--- a/script/unused.js
+++ b/script/unused.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+
+/*
+ * Script to identify unused templates and challenges.
+ * The authoring document can be specified as the first argument.
+ * If no authoring document is specified, the default is used.
+ */  
+
+const fs = require("fs");
+const args = process.argv.slice(2);
+const path = args[0] || "src/resources/authoring/gv-1.json";
+const schemaPath = "src/resources/authoring/authoring.schema.json";
+const fileContents = fs.readFileSync(path);
+const schemaContents = fs.readFileSync(schemaPath);
+if (!fileContents) {
+  console.log(`Error reading authoring file: '${path}'`);
+  process.exit(1);
+}
+if (!schemaContents) {
+  console.log(`Error reading schema file: '${schemaPath}'`);
+  process.exit(1);
+}
+
+let authoring, schema;
+try {
+  authoring = JSON.parse(fileContents);
+}
+catch(e) {
+  console.log(`Error: '${path}' does not appear to be a valid JSON file`);
+  process.exit(1);
+}
+try {
+  schema = JSON.parse(schemaContents);
+}
+catch(e) {
+  console.log(`Error: '${schemaPath}' does not appear to be a valid JSON file`);
+  process.exit(1);
+}
+
+const { application: { levels }, challenges } = authoring;
+if (!levels || !challenges) {
+  console.log(`Error: '${path}' does not appear to be a valid authoring file`);
+  process.exit(1);
+}
+const { definitions } = schema;
+if (!definitions) {
+  console.log(`Error: '${schemaPath}' does not appear to be a valid schema file`);
+  process.exit(1);
+}
+const { template: { enum: templates } } = definitions,
+      templateMap = {};
+templates.forEach((template) => {
+  templateMap[template] = false;
+});
+
+const challengeMap = {};
+for (let challenge in challenges) {
+  challengeMap[challenge] = false;
+}
+
+const gitBranch = require('child_process')
+                    .execSync(`git branch | grep '* '`)
+                    .toString().trim().substr(2);
+const dateStr = new Date().toLocaleString()
+                    .replace(/-([0-9])(?=[- ])/g, '-0$1');
+console.log(`Authoring File: ${path}`);
+console.log(`Git Branch: ${gitBranch}`);
+console.log(`Export Date: ${dateStr}\n`);
+
+levels.forEach((level) => {
+  level.missions.forEach((mission) => {
+    mission.challenges.forEach((challenge) => {
+      const challengeSpec = challenges[challenge.id],
+            template = challengeSpec && challengeSpec.template;
+      challengeMap[challenge.id] = true;
+      templateMap[template] = true;
+    });
+  });
+});
+
+let unusedTemplateCount = 0;
+for (let t in templateMap) {
+  if (!templateMap[t]) {
+    ++ unusedTemplateCount;
+  }
+}
+if (unusedTemplateCount) {
+  console.log(`Unused templates:`);
+  for (let t in templateMap) {
+    if (!templateMap[t]) {
+      console.log(`  ${t}`);
+    }
+  }
+  console.log();
+}
+
+let unusedChallengeCount = 0;
+for (let c in challengeMap) {
+  if (!challengeMap[c]) {
+    ++ unusedChallengeCount;
+  }
+}
+if (unusedChallengeCount) {
+  console.log(`Unused challenges:`);
+  for (let c in challengeMap) {
+    if (!challengeMap[c]) {
+      console.log(`  ${c}`);
+    }
+  }  
+}


### PR DESCRIPTION
Add `unused` script to identify unused templates and challenges in the authoring file [#158160165]

Output:
```
Authoring File: src/resources/authoring/gv-1.json
Git Branch: 157981337-challenges-6.3.x
Export Date: 2018-06-06 17:44:40

Unused templates:
  EggGame
  EggSortGame
  GenomeChallenge
  GenomePlayground

Unused challenges:
  allele-5drakes-tutorial-original
  allele-targetMatch-hidden-armorHorns-original
  allele-targetMatch-hidden-simpleColors-original
  allele-targetMatch-hidden-simpleDom-original
  allele-targetMatch-visible-armorHorns-original
  allele-targetMatch-visible-simpleColors-original
  allele-targetMatch-visible-simpleDom-original
  cell-game-lava-steel-nucleus
  clutch-5drakes-intermediateTraits-original
  clutch-5drakes-starterTraits-original
  eggBreedingBasicChromosomesUnique
  eggBreedingBasicGametesTarget
  eggBreedingBasicGametesUnique
  eggBreedingProtoHidden
  eggBreedingProtoVisible
  eggDrop-armor-original
  eggDrop-horns-original
  eggDrop-hornsWingsArmor
  eggDrop-hornsWingsArmor-original
  eggDrop-limbs-original
  eggDrop-wings-original
  gamete-selectSpermEgg-starterTraits-bothParents-original
  gamete-selectSpermEgg-starterTraits-original
  gamete-targetMatch-starterTraits-original
  incompleteLevel
```
