### PR TITLE
Fix bug which prevented egg game from working correctly when retrying a challenge

### DIFF
--- a/src/code/templates/fv-egg-game.js
+++ b/src/code/templates/fv-egg-game.js
@@ -394,7 +394,7 @@ var animationEvents = {
               totalDuration = slotMachineAnimationDuration;
         stage.chroms.forEach(function({ sex, name, sides }) {
           const halfBaseInterval = baseInterval / 2,
-                // initial interval is randomizes so timers aren't synchronized
+                // initial interval is randomized so timers aren't synchronized
                 initialInterval = Math.round(halfBaseInterval + halfBaseInterval * Math.random());
           timerSet.add(function(iteration, options) {
             if ((iteration < initialIterations) || (this.totalInterval < options.totalDuration)) {
@@ -452,7 +452,7 @@ var animationEvents = {
         animationEvents.randomizeChromosomes.animate();
       else
         _this.setState({ animation: 'complete' });
-    }
+      }
   },
   // Move tiny chromosomes into the gametes
   moveChromosomesToGamete: { id: 3, sexes: [], activeCount: 0, complete: false, ready: false,
@@ -1287,7 +1287,6 @@ export default class FVEggGame extends Component {
   }
 
   componentWillUnmount() {
-    this.props.onResetGametePools();
     _this = null;
     resetAnimationEvents();
   }
@@ -1312,7 +1311,6 @@ export default class FVEggGame extends Component {
     onFertilize: PropTypes.func.isRequired,
     onHatch: PropTypes.func,
     onResetGametes: PropTypes.func,
-    onResetGametePools: PropTypes.func,
     onKeepOffspring: PropTypes.func,
     onDrakeSubmission: PropTypes.func,
     moves: PropTypes.number

--- a/src/code/templates/fv-egg-game.js
+++ b/src/code/templates/fv-egg-game.js
@@ -834,7 +834,8 @@ export default class FVEggGame extends Component {
                         animation: "complete", isIntroComplete: false });
       }
       if (this.props.interactionType === "select-gametes") {
-        if (nextTrial === 0) {
+        // challengeDidChange controls whether button is displayed
+        if ((nextTrial === 0) && challengeDidChange) {
           // hide center chromosomes while "generate gametes" button is displayed on first trial
           chromosomeDisplayStyle = {display: "none"};
         } else {


### PR DESCRIPTION
Fix bug which prevented FVEggGame challenges from working correctly when retrying a challenge
- onResetGametePools() was being called after generation of the gamete pools but before the challenge

@sfentress fixed [#155271461](https://www.pivotaltracker.com/story/show/155271461) in 0b9583a7baa60d1ba58ad05d316272eb0b229916, which was reverted by @dstrawberrygirl in favor of d8a8f6473de220d85df6357d3e6df1b412e0be14 which was intended to fix [#157810891](https://www.pivotaltracker.com/story/show/157810891), but which also caused [#158224594](https://www.pivotaltracker.com/story/show/158224594).

This should fix all three without reintroducing any of the others.