### PR TITLE
Fix target drake gizmo

### DIFF
--- a/src/stylus/fablevision/target-drake.styl
+++ b/src/stylus/fablevision/target-drake.styl
@@ -8,8 +8,6 @@
   background-size: cover
   justify-content: center
   align-self: center
-  margin-bottom: -420px
-  margin-top: -30px
   z-index: 3
 
   .target-drake-text

--- a/src/stylus/fablevision/target-drake.styl
+++ b/src/stylus/fablevision/target-drake.styl
@@ -10,7 +10,7 @@
   align-self: center
   z-index: 3
   position:absolute
-  bottom:0px
+  bottom: 2px
 
   .target-drake-text
     font-family: 'Yanone Kaffeesatz'

--- a/src/stylus/fablevision/target-drake.styl
+++ b/src/stylus/fablevision/target-drake.styl
@@ -1,14 +1,16 @@
 .geniblocks.target-drake-container
   display: flex
   flex-direction: row
-  height: 204px
-  width: 520px
+  height: 195px
+  width: 500px
   background: url('../resources/fablevision/layout-c/target_drake_gizmo.png')
   background-repeat: no-repeat
   background-size: cover
   justify-content: center
   align-self: center
   z-index: 3
+  position:absolute
+  bottom:0px
 
   .target-drake-text
     font-family: 'Yanone Kaffeesatz'


### PR DESCRIPTION
This should get the target gizmo in the correct place for all 4.1.x challenges - Firefox still has other issues with layout that are known and tracked, but at least this tackles one of them.