### PR TITLE
Fix gene-linking of sex-linked traits

### DIFF
--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -114,7 +114,8 @@ function processAuthoredDrakes(authoredChallenge, authoredTrialNumber, template,
         linkedGenesDef = linkedGenes[authoredTrialNumber];
       }
       if (i === linkedGenesDef.drakes[0]) {
-        linkedGeneDrake = new BioLogica.Organism(BioLogica.Species.Drake, femaleDrake.getAlleleString(), actualDrakeSex);
+        // the source of the linkedGenes should have all alleles, including sex-linked ones
+        linkedGeneDrake = femaleDrake;
       } else if (linkedGenesDef.drakes.indexOf(i)) {
         let genes = split(linkedGenesDef.genes);
         for (let gene of genes) {

--- a/src/resources/authoring/gv-1.json
+++ b/src/resources/authoring/gv-1.json
@@ -2391,25 +2391,25 @@
       "instructions" : "Match the target drake!",
       "linkedGenes" : {
         "drakes" : [ 0, 1 ],
-        "genes" : "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, bogbreath"
+        "genes" : "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, bogbreath, nose"
       },
       "numTrials" : 1,
       "randomizeTrials" : true,
       "showUserDrake" : false,
       "targetDrakes" : [ {
-        "alleles" : "a:m,b:m,a:C,b:C,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:m,b:m,a:C,b:C,a:B,b:B",
         "sex" : 0
       }, {
-        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B",
         "sex" : 1
       }, {
-        "alleles" : "a:m,b:m,a:C,b:C,a:b,b:b,a:rh,b:rh",
+        "alleles" : "a:m,b:m,a:C,b:C,a:b,b:b",
         "sex" : 0
       }, {
-        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B",
         "sex" : 1
       }, {
-        "alleles" : "a:m,b:m,a:c,b:c,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:m,b:m,a:c,b:c,a:B,b:B",
         "sex" : 0
       } ],
       "template" : "FVGenomeChallenge",
@@ -2438,25 +2438,25 @@
       "instructions" : "Match the target drake!",
       "linkedGenes" : {
         "drakes" : [ 0, 1 ],
-        "genes" : "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, bogbreath"
+        "genes" : "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, bogbreath, nose"
       },
       "numTrials" : 3,
       "randomizeTrials" : true,
       "showUserDrake" : false,
       "targetDrakes" : [ {
-        "alleles" : "a:m,b:m,a:C,b:C,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:m,b:m,a:C,b:C,a:B,b:B",
         "sex" : 0
       }, {
-        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B",
         "sex" : 1
       }, {
-        "alleles" : "a:m,b:m,a:C,b:C,a:b,b:b,a:rh,b:rh",
+        "alleles" : "a:m,b:m,a:C,b:C,a:b,b:b",
         "sex" : 0
       }, {
-        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B",
         "sex" : 1
       }, {
-        "alleles" : "a:m,b:m,a:c,b:c,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:m,b:m,a:c,b:c,a:B,b:B",
         "sex" : 0
       } ],
       "template" : "FVGenomeChallenge",
@@ -2485,25 +2485,25 @@
       "instructions" : "Match the target drake!",
       "linkedGenes" : {
         "drakes" : [ 0, 1 ],
-        "genes" : "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, bogbreath"
+        "genes" : "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, bogbreath, nose"
       },
       "numTrials" : 1,
       "randomizeTrials" : true,
       "showUserDrake" : false,
       "targetDrakes" : [ {
-        "alleles" : "a:m,b:m,a:C,b:C,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:m,b:m,a:C,b:C,a:B,b:B",
         "sex" : 0
       }, {
-        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B",
         "sex" : 1
       }, {
-        "alleles" : "a:m,b:m,a:C,b:C,a:b,b:b,a:rh,b:rh",
+        "alleles" : "a:m,b:m,a:C,b:C,a:b,b:b",
         "sex" : 0
       }, {
-        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B",
         "sex" : 1
       }, {
-        "alleles" : "a:m,b:m,a:c,b:c,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:m,b:m,a:c,b:c,a:B,b:B",
         "sex" : 0
       } ],
       "template" : "FVGenomeChallenge",
@@ -2532,25 +2532,25 @@
       "instructions" : "Match the target drake!",
       "linkedGenes" : {
         "drakes" : [ 0, 1 ],
-        "genes" : "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, bogbreath"
+        "genes" : "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, bogbreath, nose"
       },
       "numTrials" : 1,
       "randomizeTrials" : true,
       "showUserDrake" : false,
       "targetDrakes" : [ {
-        "alleles" : "a:m,b:m,a:C,b:C,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:m,b:m,a:C,b:C,a:B,b:B",
         "sex" : 0
       }, {
-        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B",
         "sex" : 1
       }, {
-        "alleles" : "a:m,b:m,a:C,b:C,a:b,b:b,a:rh,b:rh",
+        "alleles" : "a:m,b:m,a:C,b:C,a:b,b:b",
         "sex" : 0
       }, {
-        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B",
         "sex" : 1
       }, {
-        "alleles" : "a:m,b:m,a:c,b:c,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:m,b:m,a:c,b:c,a:B,b:B",
         "sex" : 0
       } ],
       "template" : "FVGenomeChallenge",
@@ -2761,13 +2761,13 @@
       "instructions" : "Match the target drake!",
       "linkedGenes" : {
         "drakes" : [ 0, 1 ],
-        "genes" : "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, bogbreath"
+        "genes" : "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, bogbreath, nose"
       },
       "randomizeTrials" : true,
       "showDrakeColorHint": true,
       "showUserDrake" : true,
       "targetDrakes" : [ {
-        "alleles" : "a:m,b:m,a:C,b:C,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:m,b:m,a:C,b:C,a:B,b:B",
         "sex" : 0
       } ],
       "template" : "FVGenomeChallenge",
@@ -2795,24 +2795,24 @@
       "instructions" : "Match the target drake!",
       "linkedGenes" : {
         "drakes" : [ 0, 1 ],
-        "genes" : "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, bogbreath"
+        "genes" : "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, bogbreath, nose"
       },
       "randomizeTrials" : true,
       "showUserDrake" : true,
       "targetDrakes" : [ {
-        "alleles" : "a:m,b:m,a:C,b:C,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:m,b:m,a:C,b:C,a:B,b:B",
         "sex" : 0
       }, {
-        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B",
         "sex" : 0
       }, {
-        "alleles" : "a:m,b:m,a:C,b:C,a:b,b:b,a:rh,b:rh",
+        "alleles" : "a:m,b:m,a:C,b:C,a:b,b:b",
         "sex" : 1
       }, {
-        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B",
         "sex" : 0
       }, {
-        "alleles" : "a:m,b:m,a:c,b:c,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:m,b:m,a:c,b:c,a:B,b:B",
         "sex" : 0
       } ],
       "template" : "FVGenomeChallenge",
@@ -2828,13 +2828,13 @@
       "instructions" : "Match the target drake!",
       "linkedGenes" : {
         "drakes" : [ 0, 1 ],
-        "genes" : "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, bogbreath"
+        "genes" : "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, bogbreath, nose"
       },
       "randomizeTrials" : true,
       "showDrakeColorHint": true,
       "showUserDrake" : true,
       "targetDrakes" : [ {
-        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B",
         "sex" : 0
       } ],
       "template" : "FVGenomeChallenge",
@@ -2850,13 +2850,13 @@
       "instructions" : "Match the target drake!",
       "linkedGenes" : {
         "drakes" : [ 0, 1 ],
-        "genes" : "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, bogbreath"
+        "genes" : "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, bogbreath, nose"
       },
       "randomizeTrials" : true,
       "showDrakeColorHint": true,
       "showUserDrake" : true,
       "targetDrakes" : [ {
-        "alleles" : "a:m,b:m,a:C,b:C,a:b,b:b,a:rh,b:rh",
+        "alleles" : "a:m,b:m,a:C,b:C,a:b,b:b",
         "sex" : 1
       } ],
       "template" : "FVGenomeChallenge",
@@ -2872,13 +2872,13 @@
       "instructions" : "Match the target drake!",
       "linkedGenes" : {
         "drakes" : [ 0, 1 ],
-        "genes" : "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, bogbreath"
+        "genes" : "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, bogbreath, nose"
       },
       "randomizeTrials" : true,
       "showDrakeColorHint": true,
       "showUserDrake" : true,
       "targetDrakes" : [ {
-        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:M,b:m,a:C,b:C,a:B,b:B",
         "sex" : 0
       } ],
       "template" : "FVGenomeChallenge",
@@ -2894,13 +2894,13 @@
       "instructions" : "Match the target drake!",
       "linkedGenes" : {
         "drakes" : [ 0, 1 ],
-        "genes" : "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, bogbreath"
+        "genes" : "wings, forelimbs, armor, horns, hindlimbs, tail, dilute, bogbreath, nose"
       },
       "randomizeTrials" : true,
       "showDrakeColorHint": true,
       "showUserDrake" : true,
       "targetDrakes" : [ {
-        "alleles" : "a:m,b:m,a:c,b:c,a:B,b:B,a:rh,b:rh",
+        "alleles" : "a:m,b:m,a:c,b:c,a:B,b:B",
         "sex" : 0
       } ],
       "template" : "FVGenomeChallenge",


### PR DESCRIPTION
Fix bug in which linked sex-linked genes could result in gratuitous nose spikes [#158535268]
This bug was introduced on 2018-06-06 in commit cba46a4e143086cf8b440d8b17d93d07847d04aa.

Authoring changes resulting from fix of linkedGenes bug
- restore `nose` to list of `linkedGenes` in challenges from which it was recently removed (to avoid the bug)
- removed redundant specification of nose spike gene in challenges in which it is linked
