### PR TITLE
Remove handlers for receiving ITS alerts and hints

### DIFF
--- a/src/code/middleware/its-log.js
+++ b/src/code/middleware/its-log.js
@@ -30,14 +30,20 @@ export function initializeITSSocket(guideServer, socketPath, store) {
     console.info(`%c Received from ITS: ${event.action} ${event.target}`, 'color: #f99a00', event);
 
     if (event.isMatch("ITS", "HINT", "USER")) {
-      store.dispatch({type: GUIDE_HINT_RECEIVED, data: event});
+      // TODO: Re-enable dispatch once ITS is fixed
+      console.log("ITS provided hint to user:", event.context.dialog);
+      //store.dispatch({type: GUIDE_HINT_RECEIVED, data: event});
     } else if (event.isMatch("ITS", "REMEDIATE", "USER")) {
-      store.dispatch(requestRemediation(event));
+      // TODO: Re-enable dispatch once ITS is fixed
+      console.log("ITS spoke to user:", event.context.dialog);
+      // store.dispatch(requestRemediation(event));
     } else if (event.isMatch("ITS", "SPOKETO", "USER")) {
       // do nothing with this
       console.log("ITS spoke to user:", event.context.dialog);
     } else if (event.isMatch("ITS", "ISSUED", "ALERT")) {
-      store.dispatch({type: GUIDE_ALERT_RECEIVED, data: event});
+      // TODO: Re-enable dispatch once ITS is fixed
+      console.log("ITS alerted user:", event.context.dialog);
+      //store.dispatch({type: GUIDE_ALERT_RECEIVED, data: event});
     } else {
       console.log("%c Unhandled ITS message:", 'color: #f99a00', event.toString());
     }

--- a/src/code/middleware/its-log.js
+++ b/src/code/middleware/its-log.js
@@ -35,7 +35,7 @@ export function initializeITSSocket(guideServer, socketPath, store) {
       //store.dispatch({type: GUIDE_HINT_RECEIVED, data: event});
     } else if (event.isMatch("ITS", "REMEDIATE", "USER")) {
       // TODO: Re-enable dispatch once ITS is fixed
-      console.log("ITS spoke to user:", event.context.dialog);
+      console.log("ITS offered user remediation:", event.context.dialog);
       // store.dispatch(requestRemediation(event));
     } else if (event.isMatch("ITS", "SPOKETO", "USER")) {
       // do nothing with this


### PR DESCRIPTION
ITS v3 is currently not able to offer correct hints, so this PR is a quick adjustment to disable receiving ITS hints and alerts until the service can be fixed.