### PR TITLE
Adjust highlight for tutorial elements

### DIFF
--- a/src/code/components/tutorial-view.js
+++ b/src/code/components/tutorial-view.js
@@ -29,7 +29,8 @@ class TutorialView extends React.Component {
 
   componentWillUpdate(nextProps, nextState) {
     if (this.props.currentStep !== nextProps.currentStep ||
-        this.state.isShowing !== nextState.isShowing) {
+      this.state.isShowing !== nextState.isShowing ||
+      (this.props.visible !== nextProps.visible && nextProps.visible)) {
       let tutorialStep = this.props.steps[nextProps.currentStep];
       if (tutorialStep) {
         this.showTutorialHighlights(tutorialStep);

--- a/src/code/templates/clutch-game.js
+++ b/src/code/templates/clutch-game.js
@@ -272,7 +272,15 @@ export default class ClutchGame extends Component {
         </div>;
       return view;
     }
-
+    function parentColumnView(sex) {
+      let columnClass = 'column ' + (sex === BioLogica.FEMALE ? 'mother' : 'father');
+      return (
+        <div className={columnClass}>
+          {parentImageView(sex)}
+          {parentGenomeView(sex)}
+        </div>
+      );
+    }
     function parentImageView(sex) {
       const org = sex === BioLogica.FEMALE ? mother : father,
         parentName = sex === BioLogica.FEMALE ? "mother" : "father",
@@ -280,6 +288,7 @@ export default class ClutchGame extends Component {
         hiddenImage = isHiddenParent ? hiddenParent.hiddenImage : false;
       return <ParentDrakeView className={parentName} org={org} width={parentSize} hidden={hiddenImage} />;
     }
+
     const bottomButtons = isSubmitParents ?
       (
         <div id="bottom-buttons">
@@ -320,10 +329,7 @@ export default class ClutchGame extends Component {
     return (
       <div id="breeding-game">
         <div className="columns centered">
-          <div className='column'>
-            {parentImageView(BioLogica.FEMALE)}
-            {parentGenomeView(BioLogica.FEMALE)}
-          </div>
+          {parentColumnView(BioLogica.FEMALE)}
           <div className='column center-column'>
             {targetDrakeSection}
             {penView}
@@ -334,10 +340,7 @@ export default class ClutchGame extends Component {
                                   isHatchingComplete={false}
                                   onBreed={handleFertilize} />
           </div>
-          <div className='column'>
-            {parentImageView(BioLogica.MALE)}
-            {parentGenomeView(BioLogica.MALE)}
-          </div>
+          {parentColumnView(BioLogica.MALE)}
         </div>
 
         {bottomButtons}

--- a/src/resources/authoring/tutorial.json
+++ b/src/resources/authoring/tutorial.json
@@ -44,7 +44,8 @@
                 {
                   "element": "change-sex-toggle-group",
                   "text": "Male/Female button",
-                  "more": "The third chromosome pair determines whether a dragon is male or female. Change the position of the button to change this chromosome pair."
+                  "more": "The third chromosome pair determines whether a dragon is male or female. Change the position of the button to change this chromosome pair.",
+                  "location": "bottom-left"
                 }
               ]
             }
@@ -97,6 +98,23 @@
       "level": 3,
       "missions": [
         {
+          "mission": 0,
+          "challenges":[
+            {
+              "challenge": 0,
+              "steps":[
+                {
+                  "element": "genome parent",
+                  "text": "Select Chromosomes",
+                  "longText": "Selet one chromosome from each pair to make a gamete.",
+                  "location": "bottom-left",
+                  "pulseElement": "chromosome-allele-container"
+                }
+              ]
+            }
+          ]
+        },
+        {
           "mission": 1,
           "challenges":[
             {
@@ -105,7 +123,8 @@
                 {
                   "element": "mother",
                   "text": "Select Alleles",
-                  "longText": "Set the parent’s alleles so an offspring will match the Target Drake."
+                  "longText": "Set the parent’s alleles so an offspring will match the Target Drake.",
+                  "location": "bottom-left"
                 },
                 {
                   "element": "breed-button",

--- a/src/resources/authoring/tutorial.json
+++ b/src/resources/authoring/tutorial.json
@@ -10,14 +10,16 @@
               "challenge": 0,
               "steps": [
                 {
-                  "element": "fv-chromosome-image",
+                  "element": "geniblocks genome",
                   "text": "Chromosomes",
-                  "more": "Chromosomes are made of DNA and contain genes. For each pair of chromosomes, an individual gets one from its mother and one from its father."
+                  "more": "Chromosomes are made of DNA and contain genes. For each pair of chromosomes, an individual gets one from its mother and one from its father.",
+                  "pulseElement": "fv-chromosome-image"
                 },
                 {
-                  "element": "stripe",
+                  "element": "geniblocks genome",
                   "text": "Genes",
-                  "more": "These white lines show where certain genes are on the chromosomes. Each gene affects a particular trait."
+                  "more": "These white lines show where certain genes are on the chromosomes. Each gene affects a particular trait.",
+                  "pulseElement": "stripe"
                 },
                 {
                   "element": "labels",

--- a/src/resources/authoring/tutorial.json
+++ b/src/resources/authoring/tutorial.json
@@ -108,7 +108,7 @@
                 {
                   "element": "genome parent",
                   "text": "Select Chromosomes",
-                  "longText": "Selet one chromosome from each pair to make a gamete.",
+                  "longText": "Click or tap one chromosome from each pair to add them to an egg or sperm cell.",
                   "location": "bottom-left",
                   "pulseElement": "chromosome-allele-container"
                 }

--- a/src/resources/authoring/tutorial.json
+++ b/src/resources/authoring/tutorial.json
@@ -22,7 +22,7 @@
                   "pulseElement": "stripe"
                 },
                 {
-                  "element": "labels",
+                  "element": "geniblocks genome",
                   "text": "Alleles",
                   "more": "Genes have different versions called “alleles” (ah-leelz). Change the versions of each gene to make different drakes.",
                   "pulseElement": "simple-select"

--- a/src/resources/authoring/tutorial.json
+++ b/src/resources/authoring/tutorial.json
@@ -87,7 +87,7 @@
                 {
                   "element": "organism-color-text",
                   "text": "Drake Color",
-                  "more": "Each drake color is a combination of alleles from multiple genes. Breeders have named the colors for metals and other substances.",
+                  "more": "Each drake color is a combination of alleles from multiple genes.",
                   "location": "bottom-center"
                 }
               ]

--- a/src/stylus/fablevision/fv-chromosome.styl
+++ b/src/stylus/fablevision/fv-chromosome.styl
@@ -71,3 +71,8 @@
 .gamete-chromosomes
   .chromosome-label
     display:none
+
+.fv-layout-c
+  .parent
+    .chromosome-allele-container
+      cursor: pointer;


### PR DESCRIPTION
Recent layout tweaks have broken tutorial highlight functionality on genome challenges since flex layout elements are not affected by z-index changes. Attempted workaround for this PR is to elevate the closest parent element and then pulse the element being described in the tutorial. 