### PR TITLE
Remove linked genes in 6.5.x

### DIFF
--- a/src/resources/authoring/gv-1.json
+++ b/src/resources/authoring/gv-1.json
@@ -5492,7 +5492,7 @@
       },
       "linkedGenes" : {
         "drakes" : [ 0, 1, 2 ],
-        "genes" : "color, hindlimbs, black, horns, armor, tail, dilute, nose, bogbreath"
+        "genes" : "color, hindlimbs, black, horns, bogbreath"
       },
       "mother" : [ {
         "alleles" : "H-H, w-w, b-b, M-M, A1-A1, fl-fl, hl-Hl, t-t, C-C, d-d, rh-rh, Bog-Bog",
@@ -5525,7 +5525,7 @@
       },
       "linkedGenes" : {
         "drakes" : [ 0, 1, 2 ],
-        "genes" : "color, hindlimbs, black, horns, armor, tail, dilute, nose, bogbreath"
+        "genes" : "color, bogbreath"
       },
       "mother" : [ {
         "alleles" : "H-H, W-w, b-b, M-M, A1-A1, fl-fl, hl-Hl, T-T, C-C, D-, Rh-, Bog-Bog, T-Tk",
@@ -5597,7 +5597,7 @@
       },
       "linkedGenes" : {
         "drakes" : [ 0, 1, 2 ],
-        "genes" : "color, hindlimbs, black, horns, armor, tail, dilute, nose, bogbreath"
+        "genes" : "color, dilute, bogbreath"
       },
       "mother" : [ {
         "alleles" : "H-H, w-w, b-b, M-M, A1-a, fl-fl, hl-Hl, T-Tk, C-C, D-d, Rh-rh, Bog-Bog",


### PR DESCRIPTION
These were overriding the authored genes

This not only fixes [#158896149], but also two undiscovered bugs:

6.5.1 the target was always recessive.

6.5.3 the target was always whatever the other drake's initial
alleles were.