### PR TITLE
Fix sex remediation in egg-sort game

### DIFF
--- a/src/code/templates/fv-egg-sort-game.js
+++ b/src/code/templates/fv-egg-sort-game.js
@@ -218,6 +218,10 @@ function isEggCompatibleWithBasket(egg, basket) {
     return false;
   // one of the basket's allele strings...
   return basket.alleles.some((basketAlleleString) => {
+    if (!basketAlleleString) {
+      // any alleles are correct (we only cared about sex)
+      return true;
+    }
     return GeneticsUtils.alleleStringContainsAlleles(egg.alleles, basketAlleleString);
   });
 }


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/158911599

Sex remediation contains no alleles on baskets. This was being automatically marked as incorrect.