### PR TITLE
Potential solution to null values in remediationHistory

### DIFF
--- a/src/code/middleware/state-save.js
+++ b/src/code/middleware/state-save.js
@@ -18,6 +18,7 @@ import actionTypes from '../action-types';
 import progressUtils from '../utilities/progress-utils';
 import { getFBClassId, getFBUserId } from "../utilities/firebase-auth";
 import { currentStateVersion } from '../migrations';
+import { makeMutable } from './its-log';
 
 export const authoringVersionNumber = 1;
 let userQueryString = getUserQueryString();
@@ -52,7 +53,7 @@ export default () => store => next => action => {
       } = nextState;
 
       // Stop nulls in remediationHistory from being sent to Firebase as this will throw an exception
-      let editedHistory = remediationHistory.asMutable({ deep: true });
+      let editedHistory = makeMutable(remediationHistory);
       for (let level in editedHistory) {
         if (editedHistory[level] === null) {
           editedHistory[level] = [];

--- a/src/code/middleware/state-save.js
+++ b/src/code/middleware/state-save.js
@@ -52,10 +52,22 @@ export default () => store => next => action => {
       } = nextState;
 
       // Stop nulls in remediationHistory from being sent to Firebase as this will throw an exception
-      let editedHistory = JSON.parse(JSON.stringify(remediationHistory));
-      for (let challenge in remediationHistory) {
-        if (remediationHistory[challenge] === null) {
-          editedHistory[challenge] = [];
+      let editedHistory = remediationHistory.asMutable();
+      for (let level in editedHistory) {
+        if (editedHistory[level] === null) {
+          editedHistory[level] = [];
+        } else if (Array.isArray(editedHistory[level])) {
+          for (let mission in editedHistory[level]) {
+            if (editedHistory[level][mission] === null) {
+              editedHistory[level][mission] = [];
+            } else if (Array.isArray(editedHistory[level][mission])) {
+              for (let challenge in editedHistory[level][mission]) {
+                if (editedHistory[level][mission][challenge] === null) {
+                  editedHistory[level][mission][challenge] = 0;
+                }
+              }
+            }
+          }
         }
       }
 

--- a/src/code/middleware/state-save.js
+++ b/src/code/middleware/state-save.js
@@ -77,6 +77,8 @@ export default () => store => next => action => {
         stateVersion: currentStateVersion
       };
     }
+
+    console.log(nextState.remediationHistory, userDataUpdate);
     firebase.database().ref(userQueryString).update(userDataUpdate, (error, userDataUpdate) => {
       if (error) {
         console.logError("Error updating user state!", userDataUpdate, error);

--- a/src/code/middleware/state-save.js
+++ b/src/code/middleware/state-save.js
@@ -52,7 +52,7 @@ export default () => store => next => action => {
       } = nextState;
 
       // Stop nulls in remediationHistory from being sent to Firebase as this will throw an exception
-      let editedHistory = remediationHistory.asMutable();
+      let editedHistory = remediationHistory.asMutable({ deep: true });
       for (let level in editedHistory) {
         if (editedHistory[level] === null) {
           editedHistory[level] = [];

--- a/src/code/middleware/state-save.js
+++ b/src/code/middleware/state-save.js
@@ -45,13 +45,23 @@ export default () => store => next => action => {
         ||
         nextState.remediationHistory && JSON.stringify(prevState.remediationHistory) !== JSON.stringify(nextState.remediationHistory)
       )) {
+
       let {
         gems
         , remediationHistory
       } = nextState;
+
+      // Stop nulls in remediationHistory from being sent to Firebase as this will throw an exception
+      let editedHistory = JSON.parse(JSON.stringify(remediationHistory));
+      for (let challenge in remediationHistory) {
+        if (remediationHistory[challenge] === null) {
+          editedHistory[challenge] = [];
+        }
+      }
+
       userDataUpdate.state = {
         gems,
-        remediationHistory,
+        remediationHistory: editedHistory,
         stateVersion: currentStateVersion
       };
     }

--- a/src/code/middleware/state-save.js
+++ b/src/code/middleware/state-save.js
@@ -78,7 +78,6 @@ export default () => store => next => action => {
       };
     }
 
-    console.log(nextState.remediationHistory, userDataUpdate);
     firebase.database().ref(userQueryString).update(userDataUpdate, (error, userDataUpdate) => {
       if (error) {
         console.logError("Error updating user state!", userDataUpdate, error);

--- a/src/code/middleware/state-save.js
+++ b/src/code/middleware/state-save.js
@@ -18,7 +18,6 @@ import actionTypes from '../action-types';
 import progressUtils from '../utilities/progress-utils';
 import { getFBClassId, getFBUserId } from "../utilities/firebase-auth";
 import { currentStateVersion } from '../migrations';
-import { makeMutable } from './its-log';
 
 export const authoringVersionNumber = 1;
 let userQueryString = getUserQueryString();
@@ -53,17 +52,17 @@ export default () => store => next => action => {
       } = nextState;
 
       // Stop nulls in remediationHistory from being sent to Firebase as this will throw an exception
-      let editedHistory = makeMutable(remediationHistory);
+      let editedHistory = remediationHistory.asMutable({ deep: true });
       for (let level in editedHistory) {
-        if (editedHistory[level] === null) {
+        if (!Array.isArray(editedHistory[level])) {
           editedHistory[level] = [];
-        } else if (Array.isArray(editedHistory[level])) {
+        } else {
           for (let mission in editedHistory[level]) {
-            if (editedHistory[level][mission] === null) {
+            if (!Array.isArray(editedHistory[level][mission])) {
               editedHistory[level][mission] = [];
-            } else if (Array.isArray(editedHistory[level][mission])) {
+            } else {
               for (let challenge in editedHistory[level][mission]) {
-                if (editedHistory[level][mission][challenge] === null) {
+                if (!editedHistory[level][mission][challenge]) {
                   editedHistory[level][mission][challenge] = 0;
                 }
               }


### PR DESCRIPTION
Replacing nulls with empty array when saving user's state to Firebase hopefully fixes the issue with failing updates - reloading the user at the same challenge will still show null for remediation for those challenges, so this doesn't seem to alter the original data.