### PR TITLE
Make end of challenge dialog clickable so users can move on to next challenge

### DIFF
--- a/src/stylus/notifications.styl
+++ b/src/stylus/notifications.styl
@@ -5,7 +5,7 @@
   display: flex
   flex-direction: row
   align-items: flex-end
-  z-index: 14
+  z-index: 25
   pointer-events: none
 
   .notification


### PR DESCRIPTION
Make end of challenge dialog clickable so users can move on to next challenge [#160618770]
- increase the z-index of the modal message so that it's on top of the VenturePad overlay

@sfentress It would be worth taking a look at the overall set of z-indices in use to make sure that there's an appropriate global ordering.