### PR TITLE
Clear remediation state on challenge navigation

### DIFF
--- a/src/code/modules/remediation.js
+++ b/src/code/modules/remediation.js
@@ -26,6 +26,7 @@ export function remediation(state = initialRemediationState, action) {
       else
         return initialRemediationState;
     case ENDED_REMEDIATION:
+    case actionTypes.NAVIGATED:
       return initialRemediationState;
     // otherwise keep the remediation challenge
     default:


### PR DESCRIPTION
Fixes [#166484061](https://www.pivotaltracker.com/story/show/166484061):

>Within a remediation challenge, navigating to another challenge (e.g. using VenturePad or directly modifying the URL) without completing the challenge leaves Geniventure in a confused state that prevents any subsequent remediation from occurring.