### PR TITLE
Use default AWS environment variable names

### DIFF
--- a/deploy/s3_deploy.sh
+++ b/deploy/s3_deploy.sh
@@ -4,10 +4,6 @@ DISTRIBUTION_ID='E2X2BQ2N6BGETV'
 # name of branch to deploy to root of site
 PRODUCTION_BRANCH='production'
 
-# Travis settings define S3_ACCESS_KEY_ID and S3_SECRET_KEY
-export AWS_ACCESS_KEY_ID=$S3_ACCESS_KEY_ID
-export AWS_SECRET_ACCESS_KEY=$S3_SECRET_KEY
-
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
 	echo "skipping deploy to S3: this is a pull request"
 	exit 0


### PR DESCRIPTION
Used technique from https://www.topcoder.com/blog/recover-lost-travisci-variables-two-ways/ to recover the contents of the S3_SECRET_KEY environment variable. Then use it to eliminate redundant environment variable definitions.

Note: I'm leaving the definition of S3_SECRET_KEY in place in the Travis settings until we're certain that the replacement is working. It should be removed once that's been verified.