### PR TITLE
Fix bug which could prevent exiting remediation

### DIFF
--- a/src/code/modules/notifications.js
+++ b/src/code/modules/notifications.js
@@ -61,7 +61,9 @@ export default function notifications(state = initialState, action) {
       return notificationResponse;
     }
     case ADVANCE_NOTIFICATIONS:
-      return Object.assign({}, state, { messages: state.messages.length > 1 ? state.messages.slice(1, state.length) : initialState });
+      return Object.assign({}, state, { messages: state.messages.length > 1
+                                                    ? state.messages.slice(1, state.length)
+                                                    : initialState.messages });
 
     case CLOSE_NOTIFICATIONS:
       return initialState;

--- a/src/stylus/notifications.styl
+++ b/src/stylus/notifications.styl
@@ -119,6 +119,7 @@
     height: 359px
     background-repeat: no-repeat
     background-size: contain
+    pointer-events: auto
 
     &.ELLIS
       background-image: url('../resources/fablevision/huds/characters/Ellis_active.png')
@@ -141,6 +142,7 @@
 
     &.SYSTEM
       background-image: none;
+      pointer-events: none;
 
   .hint-arrow::before
     content: url('../resources/images/hint-arrow.svg')


### PR DESCRIPTION
[#167663884] Fix bug in which a user-requested connection status message would dismiss the end-of-challenge dialog in remediation, thus preventing the user from being able to exit remediation. The fix here is to add `pointer-events: auto` to the `fv-character` class so that the avatar button (which brings up the connection status message) cannot be clicked while a character is present, i.e. when any dialog message is present.

Also fixed a latent bug found while investigating possible fixes to the previous bug. In the handler for `ADVANCE_NOTIFICATIONS` in the notifications reducer, an ill-formed state object could be returned.

@dstrawberrygirl I originally assigned this to you for review, but since you were out I reviewed it synchronously with Matt.