### PR TITLE
Breeding and siblings remediation

### DIFF
--- a/src/code/components/clutch-view.js
+++ b/src/code/components/clutch-view.js
@@ -2,6 +2,8 @@ import React, {PropTypes} from 'react';
 import FVEggHatchView from '../fv-components/fv-egg-hatch';
 import classNames from 'classnames';
 
+let disabledTimer;
+
 const ClutchView = React.createClass({
 
   propTypes: {
@@ -45,6 +47,12 @@ const ClutchView = React.createClass({
     }
   },
 
+  componentWillUnmount() {
+    if (disabledTimer) {
+      clearTimeout(disabledTimer);
+    }
+  },
+
   render() {
     const handleClick = this.props.onClick ? (id, org) => {
       let _this = this;
@@ -57,7 +65,7 @@ const ClutchView = React.createClass({
 
         // Disable clicks for a bit to avoid mass submissions
         _this.setState({tempDisabled: true});
-        setTimeout(function() {
+        disabledTimer = setTimeout(function() {
           _this.setState({tempDisabled: false});
         }, 2000);
       }

--- a/src/code/components/notifications.js
+++ b/src/code/components/notifications.js
@@ -62,7 +62,10 @@ class Notifications extends React.Component {
                     </div>,
 
           traitHighlightView = message.trait ? (
-            <div className={`hint-arrow ${message.trait}`} />
+            [
+              <div className={`hint-arrow ${message.trait}`} />,
+              <div className={`hint-arrow-second-parent ${message.trait}`} />
+            ]
       ) : null;
 
     return (

--- a/src/code/modules/remediation.js
+++ b/src/code/modules/remediation.js
@@ -428,7 +428,7 @@ function getBreedingRemediation(trait, challengeType, practiceCriteria, previous
       previousState.userChangeableGenes[0].father.length > 0) {
     singleParent = false;
   }
-  let baseAlleles = "a:W,b:W,a:M,b:M,a:T,b:T,a:H,b:H,a:Hl,b:Hl,a:Fl,b:Fl,a:A1,b:A1,a:C,b:C,a:Bog,b:Bog,a:rh,b:rh";
+  let baseAlleles = "a:W,b:W,a:M,b:M,a:T,b:T,a:H,b:H,a:Hl,b:Hl,a:Fl,b:Fl,a:A1,b:A1,a:C,b:C,a:Bog,b:Bog,a:Rh,b:Rh";
   if (trait === "black") {
     baseAlleles = baseAlleles + ",a:B,b:B,a:D,b:D";
   } else {
@@ -442,6 +442,10 @@ function getBreedingRemediation(trait, challengeType, practiceCriteria, previous
       motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
       fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
       child1Alleles = GeneticsUtils.getAllelesForTrait(trait, "heterozygous");
+    } else if (practiceCriteria === "X Linked") {
+      motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
+      fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
+      child1Alleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
     } else {
       motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
       fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, singleParent ? "heterozygous" : "dominant");
@@ -453,6 +457,11 @@ function getBreedingRemediation(trait, challengeType, practiceCriteria, previous
       fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
       child1Alleles = GeneticsUtils.getAllelesForTrait(trait, "heterozygous");
       child2Alleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
+    } else if (practiceCriteria === "X Linked") {
+      motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
+      fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
+      child1Alleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
+      child2Alleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
     } else {
       motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
       fatherAlleles = motherAlleles;
@@ -465,7 +474,7 @@ function getBreedingRemediation(trait, challengeType, practiceCriteria, previous
 
   const targetDrakes = [[{
     "alleles" : `${child1Alleles},${baseAlleles}`,
-    "sex" : Math.round(Math.random())
+    "sex" : practiceCriteria === "X Linked" ? 0 : Math.round(Math.random())
   }]];
   if (isSiblings) {
     const sex = targetDrakes[0][0].sex === 0 ? 1 : 0;

--- a/src/code/modules/remediation.js
+++ b/src/code/modules/remediation.js
@@ -417,7 +417,7 @@ function getEggSortRemediation(trait, /* practiceCriteria */) {
   };
 }
 
-function getBreedingRemediation(trait, challengeType, previousState) {
+function getBreedingRemediation(trait, challengeType, practiceCriteria, previousState) {
   const templateName = "ClutchGame";
 
   const isSiblings = challengeType === "Siblings";
@@ -438,14 +438,27 @@ function getBreedingRemediation(trait, challengeType, previousState) {
 
   let motherAlleles, fatherAlleles, child1Alleles, child2Alleles;
   if (!isSiblings) {
-    motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
-    fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, singleParent ? "heterozygous" : "dominant");
-    child1Alleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
+    if (trait === "armor" && practiceCriteria === "Incomplete Dominance") {
+      motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
+      fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
+      child1Alleles = GeneticsUtils.getAllelesForTrait(trait, "heterozygous");
+    } else {
+      motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
+      fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, singleParent ? "heterozygous" : "dominant");
+      child1Alleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
+    }
   } else {
-    motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
-    fatherAlleles = motherAlleles;
-    child1Alleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
-    child2Alleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
+    if (trait === "armor" && practiceCriteria === "Incomplete Dominance") {
+      motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
+      fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
+      child1Alleles = GeneticsUtils.getAllelesForTrait(trait, "heterozygous");
+      child2Alleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
+    } else {
+      motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
+      fatherAlleles = motherAlleles;
+      child1Alleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
+      child2Alleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
+    }
   }
 
   let hiddenAlleles = ['Tk', 'A2'];
@@ -505,7 +518,7 @@ export function getRemediationChallengeProps(challengeType, trait, practiceCrite
   } else if (challengeType === "Hatchery") {
     challengeProps = getEggSortRemediation(trait, practiceCriteria);
   } else if (challengeType === "Breeding" || challengeType === "Siblings") {
-    challengeProps = getBreedingRemediation(trait, challengeType, previousState);
+    challengeProps = getBreedingRemediation(trait, challengeType, practiceCriteria, previousState);
   }
 
   if (!challengeProps) {

--- a/src/code/modules/remediation.js
+++ b/src/code/modules/remediation.js
@@ -417,12 +417,74 @@ function getEggSortRemediation(trait, /* practiceCriteria */) {
   };
 }
 
-export function getRemediationChallengeProps(challengeType, trait, practiceCriteria) {
+function getBreedingRemediation(trait, previousState) {
+  const templateName = "ClutchGame";
+
+  let singleParent = true;
+  if (previousState.userChangeableGenes[0] && previousState.userChangeableGenes[0].mother.length > 0 &&
+      previousState.userChangeableGenes[0].father.length > 0) {
+    singleParent = false;
+  }
+  let baseAlleles = "a:W,b:W,a:M,b:M,a:T,b:T,a:H,b:H,a:Hl,b:Hl,a:Fl,b:Fl,a:A1,b:A1,a:C,b:C,a:Bog,b:Bog,a:rh,b:rh";
+  if (trait === "black") {
+    baseAlleles = baseAlleles + ",a:B,b:B,a:D,b:D";
+  } else {
+    baseAlleles = baseAlleles + ",a:b,b:b,a:d,b:d";
+  }
+  baseAlleles = baseAlleles.replace(GeneticsUtils.getAllelesForTrait(trait, "dominant") + ",", "");
+
+  const motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
+  const fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, singleParent ? "heterozygous" : "dominant");
+  const childAlleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
+
+  let hiddenAlleles = ['Tk', 'A2'];
+
+  // Allele overwriting seems not to work correctly for X-linked alleles,
+  // so we have to be careful not to duplicate alleles.
+  const authoring = {
+    "challengeType" : "match-target",
+    "father" : [ {
+      "alleles" : `${fatherAlleles},${baseAlleles}`,
+      "sex" : 0
+    } ],
+    "mother" : [ {
+      "alleles" : `${motherAlleles},${baseAlleles}`,
+      "sex" : 1
+    } ],
+    "targetDrakes" : [ {
+      "alleles" : `${childAlleles},${baseAlleles}`,
+      "sex" : Math.round(Math.random())
+    } ]
+  };
+
+  return {
+    authoring,
+    templateName,
+    stateProps: {
+      // userChangeableGenes: [trait],
+      userChangeableGenes: [ {
+        "father" : singleParent ? [] : [trait],
+        "mother" : [trait]
+      } ],
+      visibleGenes: [trait],
+      hiddenAlleles: hiddenAlleles,
+      numTargets: 1,
+      numTrials: 1,
+      trial: 0,
+      goalMoves: -1,
+      room: "breedingbarn"
+    }
+  };
+}
+
+export function getRemediationChallengeProps(challengeType, trait, practiceCriteria, previousState) {
   let challengeProps;
   if (challengeType === "Sim") {
     challengeProps = getMatchDrakeRemediation(trait, practiceCriteria);
   } else if (challengeType === "Hatchery") {
     challengeProps = getEggSortRemediation(trait, practiceCriteria);
+  } else if (challengeType === "Breeding") {
+    challengeProps = getBreedingRemediation(trait, previousState);
   }
 
   if (!challengeProps) {

--- a/src/code/modules/remediation.js
+++ b/src/code/modules/remediation.js
@@ -446,6 +446,10 @@ function getBreedingRemediation(trait, challengeType, practiceCriteria, previous
       motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
       fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
       child1Alleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
+    } else if (trait === "tail") {
+      motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
+      fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
+      child1Alleles = "a:Tk,b:t";
     } else {
       motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
       fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, singleParent ? "heterozygous" : "dominant");
@@ -462,6 +466,11 @@ function getBreedingRemediation(trait, challengeType, practiceCriteria, previous
       fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
       child1Alleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
       child2Alleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
+    } else if (trait === "tail") {
+      motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
+      fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, "heterozygous");
+      child1Alleles = "a:Tk,b:t";
+      child2Alleles = "a:t,b:t";
     } else {
       motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
       fatherAlleles = motherAlleles;
@@ -470,7 +479,7 @@ function getBreedingRemediation(trait, challengeType, practiceCriteria, previous
     }
   }
 
-  let hiddenAlleles = ['Tk', 'A2'];
+  let hiddenAlleles = ['A2'];
 
   const targetDrakes = [[{
     "alleles" : `${child1Alleles},${baseAlleles}`,

--- a/src/code/modules/remediation.js
+++ b/src/code/modules/remediation.js
@@ -422,18 +422,16 @@ function getBreedingRemediation(trait, challengeType, practiceCriteria, previous
 
   const isSiblings = challengeType === "Siblings";
   let singleParent = true;
-  if (!isSiblings && previousState.userChangeableGenes[0] &&
+  if (!isSiblings && previousState.userChangeableGenes &&
+      previousState.userChangeableGenes[0] &&
       previousState.userChangeableGenes[0].mother &&
       previousState.userChangeableGenes[0].mother.length > 0 &&
       previousState.userChangeableGenes[0].father.length > 0) {
     singleParent = false;
   }
+
   let baseAlleles = "a:W,b:W,a:M,b:M,a:T,b:T,a:H,b:H,a:Hl,b:Hl,a:Fl,b:Fl,a:A1,b:A1,a:C,b:C,a:Bog,b:Bog,a:Rh,b:Rh";
-  if (trait === "black") {
-    baseAlleles = baseAlleles + ",a:B,b:B,a:D,b:D";
-  } else {
-    baseAlleles = baseAlleles + ",a:b,b:b,a:d,b:d";
-  }
+  baseAlleles += trait === "black" ? ",a:B,b:B,a:D,b:D" : ",a:b,b:b,a:d,b:d";
   baseAlleles = baseAlleles.replace(GeneticsUtils.getAllelesForTrait(trait, "dominant") + ",", "");
 
   let motherAlleles, fatherAlleles, child1Alleles, child2Alleles;

--- a/src/code/modules/remediation.js
+++ b/src/code/modules/remediation.js
@@ -439,16 +439,16 @@ function getBreedingRemediation(trait, challengeType, practiceCriteria, previous
   let motherAlleles, fatherAlleles, child1Alleles, child2Alleles;
   if (!isSiblings) {
     if (trait === "armor" && practiceCriteria === "Incomplete Dominance") {
-      motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
-      fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
-      child1Alleles = GeneticsUtils.getAllelesForTrait(trait, "heterozygous");
+      motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
+      fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
+      child1Alleles = GeneticsUtils.getAllelesForTrait(trait, singleParent ? "heterozygous" : "dominant");
     } else if (practiceCriteria === "X Linked") {
       motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
       fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
       child1Alleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
     } else if (trait === "tail") {
       motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
-      fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
+      fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, singleParent ? "dominant" : "recessive");
       child1Alleles = "a:Tk,b:t";
     } else {
       motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
@@ -457,10 +457,10 @@ function getBreedingRemediation(trait, challengeType, practiceCriteria, previous
     }
   } else {
     if (trait === "armor" && practiceCriteria === "Incomplete Dominance") {
-      motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
+      motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
       fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
       child1Alleles = GeneticsUtils.getAllelesForTrait(trait, "heterozygous");
-      child2Alleles = GeneticsUtils.getAllelesForTrait(trait, "recessive");
+      child2Alleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
     } else if (practiceCriteria === "X Linked") {
       motherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");
       fatherAlleles = GeneticsUtils.getAllelesForTrait(trait, "dominant");

--- a/src/code/reducers/helpers/load-state-from-authoring.js
+++ b/src/code/reducers/helpers/load-state-from-authoring.js
@@ -293,7 +293,7 @@ export function loadStateFromAuthoring(state, authoring) {
 export function loadStateFromRemediation(state, remediation, authoring) {
   // get authoring props specific to challengeType
   const {challengeType, attribute, practiceCriteria} = remediation;
-  const remediationChallengeProps = getRemediationChallengeProps(challengeType, attribute, practiceCriteria);
+  const remediationChallengeProps = getRemediationChallengeProps(challengeType, attribute, practiceCriteria, state);
 
   if (!remediationChallengeProps) {
     // bail

--- a/src/stylus/notifications.styl
+++ b/src/stylus/notifications.styl
@@ -144,13 +144,13 @@
       background-image: none;
       pointer-events: none;
 
-  .hint-arrow::before
+  .hint-arrow::before, .hint-arrow-second-parent::before
     content: url('../resources/images/hint-arrow.svg')
     position: absolute
     left: -152px
     top: 6px
 
-  .hint-arrow
+  .hint-arrow, .hint-arrow-second-parent
     position: absolute
     border: 3px solid #15e617
     border-radius: 10px;
@@ -189,18 +189,22 @@
 
 .fv-layout-h
   .hint-arrow
-    left: -1000px;
+    left: 165px;
+    width: 435px;
+    height: 51px;
+  .hint-arrow-second-parent
+    left: 1314px;
     width: 435px;
     height: 51px;
 
   &.fixed-father
-    .hint-arrow
-      left: 165px;
+    .hint-arrow-second-parent
+      left: -1000px;
   &.fixed-mother
     .hint-arrow
-      left: 1314px;
+      left: -1000px;
 
-  .hint-arrow
+  .hint-arrow, .hint-arrow-second-parent
     &.tail
       top: -418px;
     &.metallic
@@ -225,7 +229,9 @@
       top: -39px;
 
 .fv-layout-h.submit-parents
-  .hint-arrow
+  .hint-arrow, .hint-arrow-second-parent
+    &.tail
+      top: -358px;
     &.metallic
       top: -324px;
     &.wings


### PR DESCRIPTION
This adds breeding and sibling remediation.

As usual, the remediation generator is fairly special-cased and wordy. It attempts to generalize as much as possible, but has to account for the following situations:

1. Straight breeding or sibling (submit parents) challenge
2. One changeable parent or two (straight breeding only)
3. Traits or ITS concepts that are not plain dominance/recessive (sometimes special-cased by concept, sometimes by trait)